### PR TITLE
ENH: Add helper scripts for hutch-python development environments

### DIFF
--- a/scripts/pydev_env
+++ b/scripts/pydev_env
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Source this file to activate a development environment based on the latest
+# shared environment and on past calls to pydev_register
 source /reg/g/pcds/pyps/conda/py36env.sh
 PYDEV="${HOME}/pydev"
 export PATH="${PYDEV}/bin:${PATH}"

--- a/scripts/pydev_env
+++ b/scripts/pydev_env
@@ -1,0 +1,5 @@
+#!/bin/bash
+source /reg/g/pcds/pyps/conda/py36env.sh
+PYDEV="${HOME}/pydev"
+export PATH="${PYDEV}/bin:${PATH}"
+export PYTHONPATH="${PYDEV}:${PYTHONPATH}"

--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Use this script to register development packages so that they will be
+# available when you source pydev_env
 usage="pydev_register <path> <module or bin>"
 if [ -z "${1}" ]; then
   echo "${usage}"

--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -1,0 +1,19 @@
+#!/bin/bash
+usage="pydev_register <path> <module or bin>"
+if [ -z "${1}" ]; then
+  echo "${usage}"
+  return
+fi
+PYDEV_DIR=~/pydev
+full_path="$(readlink -f $1)"
+if [ "${2}" == "module" ]; then
+  link="${PYDEV_DIR}"
+elif [ "${2}" == "bin" ]; then
+  link="${PYDEV_DIR}/bin"
+else
+  echo "Invalid input."
+  echo "${usage}"
+  return
+fi
+mkdir -p "${PYDEV_DIR}/bin"
+ln -s "${full_path}" "${link}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- `pydev_env` can be sourced to activate the most recent conda release, with your checked-out packages masking the release packages using `$PYTHONPATH`
- `pydev_register` can be used to add modules and scripts to this path via creating softlinks in your home area

These are also reasonable starting points for making your own scripts to point to your own conda environments instead of the shared environment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helpful for rapidly setting up dev environments separate from the main environments. The workflow is something like:
- check out modules
- `pydev_register path_to_module module`
- `pydev_register path_to_script bin`
- `source pydev_env`
- `python run_tests.py`

Later, you decide that you want to remove packages from this dev path:
- `rm ~/pydev/packagename`

I've found that this workflow is better for me than `python setup.py develop` or `conda develop`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've been using these for months

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'm doing a writeup in pcdshub.github.io

<!--
## Screenshots (if appropriate):
-->
