### PR TITLE
FIX: Redirect pydev_env to the new pcds_conda setup script

### DIFF
--- a/scripts/pydev_env
+++ b/scripts/pydev_env
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Source this file to activate a development environment based on the latest
 # shared environment and on past calls to pydev_register
-source /reg/g/pcds/pyps/conda/py36env.sh
+source pcds_conda
 PYDEV="${HOME}/pydev"
 export PATH="${PYDEV}/bin:${PATH}"
 export PYTHONPATH="${PYDEV}:${PYTHONPATH}"


### PR DESCRIPTION
I noticed this was hardlinked to the old script