### PR TITLE
FIX: use command instead of /bin

### DIFF
--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Source this to activate a pcds conda environment.
 # By default, this activates the latest environment.
 # Use export PCDS_CONDA_VER=<version> before running to pick a different env.
@@ -10,7 +10,7 @@ source "${CONDA_ROOT}/etc/profile.d/conda.sh"
 conda activate
 if [ -z "${PCDS_CONDA_VER}" ]; then
   # Default to latest pcds release
-  conda activate "$(/bin/ls ${CONDA_ROOT}/envs | /bin/grep pcds- | /bin/tail -1)"
+  conda activate "$(command ls ${CONDA_ROOT}/envs | command grep pcds- | command tail -1)"
 elif [ -z "${PCDS_CONDA_VER##*-*}" ]; then
   # If you had a dash, assume this is a full environment name
   conda activate "${PCDS_CONDA_VER}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Use command instead of bin
- Use /usr/bin/env bash instead of /bin/bash

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removing corner cases where commands may be installed in different places on different machines. The `command` built-in ignores the user's alias, which is important for consistent script behavior between users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested most of the previous fail cases
- Works on `cxi-control`
- Works with Bruce's `ls -F` alias