### PR TITLE
Changed get_info to first try finding hutch by IP address subnet

### DIFF
--- a/scripts/get_info
+++ b/scripts/get_info
@@ -26,6 +26,10 @@ args = parser.parse_args()
 hutches=['amo','sxr','xpp','xcs','mfx','cxi','mec', 'det', 'fee']
 foundHutch=False
 hutch=''
+
+#populate hutch-specific subnets here:
+hutch_subnets={'amo': ['37'],'sxr': ['39'],'xpp': ['38','46'],'xcs': ['36', '43'],'mfx': ['62','24'],'cxi': ['68','26'] ,'mec': ['45'],'det': [],'fee': ['36']}
+
 if args.hutch:
     hutch=args.hutch
     if hutch in hutches:
@@ -41,11 +45,19 @@ if args.hutch:
             sys.exit()
 else:
     hostname=socket.gethostname()
-    for ihutch in hutches:
-        if hostname.find(ihutch)>=0:
+    ip=socket.gethostbyname(hostname)
+    subnet=ip.split('.')[2]
+    for ihutch in hutches: #use the IP address to match the host to a hutch by subnet
+        if subnet in hutch_subnets.get(ihutch):
             hutch=ihutch.upper()
             foundHutch=True
             break
+    if not foundHutch:
+        for ihutch in hutches:
+            if hostname.find(ihutch)>=0:
+                hutch=ihutch.upper()
+                foundHutch=True
+                break
     if not foundHutch and hostname.find('psusr')>=0:
         if hostname.find('psusr11')>=0:
             hutch='AMO'
@@ -71,8 +83,8 @@ else:
                 hutch=ihutch.upper()
                 foundHutch=True
                 break
-        if not foundHutch and path.find('xrt')+hostname.find('xtod')>=-1:
-            hutch='FEE'
+        if not foundHutch and path.find('xrt')+hostname.find('xrt')>=-1 or path.find('xtod')+hostname.find('xtod')>=-1:
+            hutch='FEE' #because we have so many names for the same subnet.
             foundHutch=True
         if not foundHutch:
             #then ask.....outside of python

--- a/scripts/get_info
+++ b/scripts/get_info
@@ -28,7 +28,7 @@ foundHutch=False
 hutch=''
 
 #populate hutch-specific subnets here:
-hutch_subnets={'amo': ['37'],'sxr': ['39'],'xpp': ['38','46'],'xcs': ['25', '43'],'mfx': ['62','24'],'cxi': ['68','26'] ,'mec': ['45'],'det': [],'fee': ['36']}
+hutch_subnets={'amo': ['37','20'],'sxr': ['39','21'],'xpp': ['38','46'],'xcs': ['25', '43'],'mfx': ['62','24'],'cxi': ['68','26'] ,'mec': ['45','27'],'det': ['58'],'fee': ['36']}
 
 if args.hutch:
     hutch=args.hutch

--- a/scripts/get_info
+++ b/scripts/get_info
@@ -28,7 +28,7 @@ foundHutch=False
 hutch=''
 
 #populate hutch-specific subnets here:
-hutch_subnets={'amo': ['37'],'sxr': ['39'],'xpp': ['38','46'],'xcs': ['36', '43'],'mfx': ['62','24'],'cxi': ['68','26'] ,'mec': ['45'],'det': [],'fee': ['36']}
+hutch_subnets={'amo': ['37'],'sxr': ['39'],'xpp': ['38','46'],'xcs': ['25', '43'],'mfx': ['62','24'],'cxi': ['68','26'] ,'mec': ['45'],'det': [],'fee': ['36']}
 
 if args.hutch:
     hutch=args.hutch


### PR DESCRIPTION
Hi, I changed the first method for --gethutch/getHutch to use the IP address subnet.  I made this a PR because I first wanted to check with the hutch/daq POCs that this is acceptable and because I'd like representatives to help me populate the dictionary `hutch_subnets` with whatever IP subnets they'd want to associate with their hutches!

## Motivation and Context
Using the hostname or working directory doesn't always work so using the IP address seemed more reliable.  

## How Has This Been Tested?
Tested on XCS/CXI control room machines by calling ./get_info --getHutch

