### PR TITLE
FIX: typo and syntax error

### DIFF
--- a/rc/pcds_shortcuts.sh
+++ b/rc/pcds_shortcuts.sh
@@ -376,7 +376,7 @@ function mec()
 }
 export mec
 
-afunction mfx()
+function mfx()
 {
 	if [[ ${MFX_SUBNET[*]} =~ $SUBNET ]]; then
 		echo "Warning: Launching live MFX screen ..."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`afunction` -> `function`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bruce came to my cube to ask about this typo in the shortcuts script and ask about why it moved. Apparently the script was previously version controlled in an svn repo. We need to figure out what to do about the `/reg/g/pcds/setup` area.

In the mean time, I'm doing a quick fix and release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I sourced the file, it didn't explode, and the function is callable.
