### PR TITLE
Fixed and added more functionality to pkg_release script

### DIFF
--- a/scripts/pkg_release
+++ b/scripts/pkg_release
@@ -41,8 +41,8 @@ elif echo $TEST_OUTPUT | grep "Permission denied\|no kex alg" > /dev/null; then
   git clone "${URL}" "${TEMP}"
 else
   echo "Error: $TEST_OUTPUT"
+  exit
 fi
-unset TEST_OUTPUT
 set +e
 echo "Checking out tag..."
 pushd "${TEMP}"


### PR DESCRIPTION
## Description
Changed HTTP request of the repository to a ping of github.com. Added the functionality to use SSH for the git clone. Decides whether to use HTTPS or SSH based on a check of ssh keys against Github servers.

## Motivation and Context
The HTTP request was problematic because it did not provide authentication to see private repositories. This additionally takes away checking the existence of a public repository but If the repo doesn't exist, the git clone will say so. The ping allows for the simple check of whether a connection can be made and will stop the process on machines like psdev which can not access Github. If your ssh key has already been linked with your Github profile, this change allows you to use that key instead of having to type in your password.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested this script by running it on machines with access to github (rhel7 works as expected, rhel5 runs a old version of SSH client and therefore opts for HTTPS cloning), machines without access (psdev and xcs-control). I tested the script on a repository that does exist and one that does not. I checked the SSH test by running from my account with a linked key and from an account without SSH key linked to Github (sabbah01). I do not foresee any effect on other areas of the code from this change.

## Where Has This Been Documented?
The script is explained in the form of comments and echos.
