### PR TITLE
Update ipmConfigEpics

### DIFF
--- a/scripts/ipmConfigEpics
+++ b/scripts/ipmConfigEpics
@@ -256,12 +256,15 @@ usage: $0 [-b boxname] [-d] [-h] [-l]
 EOF
 }
 
+# Turns off statsPlugin for these IPIMB boxes to prevent bogging down server and help Bld run at 120Hz
 helpBld(){
-    if [ $hutch == 'xcs' ]; then 
-	if  [[ $BOXNAME == 'ipm3'  ||  $BOXNAME == 'dio3' ]]; then
-	    caput XCS:DG3:CVV:02:Stat2:EnableCallbacks 0
-	    caput HFX:DG3:CVV:01:Stat2:EnableCallbacks 0
-	fi
+    if [[ $hutch == 'xcs' && ($BOXNAME == 'ipm3' || $BOXNAME == 'dio3') ]]; then
+        caput XCS:DG3:CVV:02:Stat2:EnableCallbacks 0
+        caput HFX:DG3:CVV:01:Stat2:EnableCallbacks 0
+        echo 'Turned off statsPlugin for XCS ipm3 and dio3' # TODO: Actually check if off
+    else
+        echo 'Selected box has no known Bld issue to fix'
+	exit 1
     fi
 }
 


### PR DESCRIPTION
## Description
Changes were made to allow for shared IPM boxes to be displayed/used in all applicable hutches.
A fix was also introduced for the mis-indentation of a check for IPM boxname assignment.
Additionally, I moved the list boxnames function to its own option, rewrote the usage documentation, and added some comments.

## Motivation and Context
These changes fix the problem that shared IPMs were not displayed for multiple hutches and the problem that the boxname assignment check was only being run in the MEC hutch.

## How Has This Been Tested?
I tested the script by running it with each of its arguments and by picking different IPM boxes. Choosing certain boxes lead to error. I believe that is not due to this script, but errors in other scripts attempting to read from the IPM. Each of the options given worked as expected.
I ran these tests from multiple nodes, including psbuild, xcs-control, and xpp-control.

There is currently an error where the the script is not able to turn off the statsPlugin:
`Channel connect timed out: 'XCS:DG3:CVV:02:Stat2:EnableCallbacks' not found.`
I need to figure out if this is something that needs to be fixed or if it's something simple like the IOC is not running. This will be addressed by a fix for #25.

I also noticed that the wave8 viewer seg faults when closing. Can that be made cleaner?

## Where Has This Been Documented?
I have updated the usage documentation function, added comments to distinguish the shared boxes from the hutch-specific boxes, and added a comment to note that the UM6 IPM is also known as, and was previously categorized as XCS's ipm1.