### PR TITLE
grep_ioc all hutches

### DIFF
--- a/scripts/grep_ioc
+++ b/scripts/grep_ioc
@@ -6,13 +6,17 @@ if [[ -z $1 ]] | [[ -z $2 ]]; then
     echo $USAGE
     exit
 fi
-for hutchname in "xpp" "xcs" "cxi" "mfx" "mec" "xrt" "aux" "det" "fee" "hpl" "icl" "las" "lfe" "tst" "thz"; do 
+for hutchname in "xpp" "xcs" "cxi" "mfx" "mec" "xrt" "aux" "det" "fee" "hpl" "icl" "las" "lfe" "tst" "thz" "all"; do 
     if [[ "${2}" == $hutchname ]]; then
-	HUTCH="${2}"
+        HUTCH="${2}"
     fi
 done
 if [[ -z $HUTCH ]]; then
     echo "incorrect hutch name given.  Enter hutch name in lower case (example: xpp)"
 else
-    grep "${1}" /reg/g/pcds/pyps/config/${HUTCH}/iocmanager.cfg
+    if [[ $HUTCH == "all" ]]; then
+        grep "${1}" /reg/g/pcds/pyps/config/*/iocmanager.cfg
+    else
+        grep "${1}" /reg/g/pcds/pyps/config/${HUTCH}/iocmanager.cfg
+    fi
 fi


### PR DESCRIPTION
## Description
Added functionality to grep all iocmanagers from grep_ioc using `grep_ioc <keyword> all` 

## Motivation and Context
Makes it easier to look for multiple instances of something or if you're not sure which iocmanager the ioc is running from.
Inspired by Tyler Johnson's iocgrep function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by searching for multiple keywords in 'xrt', 'xcs', and 'all' while on psdev. Results replicated on psbuild and xpp-control

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It's not. It's pretty simple but I guess I could add some comments