### PR TITLE
Enhancements on ipmConfigEpics

### DIFF
--- a/scripts/ipmConfigEpics
+++ b/scripts/ipmConfigEpics
@@ -208,12 +208,12 @@ elif [ $hutch == 'mec' ]; then
 	IOC="IOC:MEC:IPIMB01"
 	EVR='MEC:TC1:EVR:01'
 	BASE='MEC:LAS:IMB:02'
-    elif [ $1 == 'ipm2' ]; then 
+    elif [ $1 == 'ipm2' ]; then
 	IOC="IOC:MEC:XT2-1:BMMON"
 	EVR="MEC:XT2-1:BMMON:EVR"
 	BASE="MEC:XT2-1:BMMON"
 	WAVE8='xt2-1bmmon'
-    elif [ $1 == 'ipm3' ]; then 
+    elif [ $1 == 'ipm3' ]; then
 	IOC="IOC:MEC:XT2-2:BMMON"
 	EVR="MEC:XT2-2:BMMON:EVR"
 	BASE="MEC:XT2-2:BMMON"
@@ -221,24 +221,26 @@ elif [ $hutch == 'mec' ]; then
     fi
 fi
 if [ ${#BASE} == 0 ]
-    then    
+    then
         echo 'Not a recognized boxname. Exiting...'
         exit 1
 fi
-} 
+}
 
+# Attempt to read the :SUM PV and open a GUI if successful and exits if not. Uses wave8 or ipimb accordingly
 ipmGUI(){
     if caget ${BASE}:SUM > /dev/null 2>&1; then
         if [ ${#WAVE8} -gt 0 ]; then
             /reg/g/pcds/pyps/apps/wave8/latest/wave8 --base $BASE --evr $EVR --ioc $IOC
         else
-            /reg/g/pcds/controls/pycaqt/ipimb/ipimb.py --base $BASE --ioc $IOC --evr $EVR --dir /reg/g/pcds/controls/pycaqt/ipimb	
+            /reg/g/pcds/controls/pycaqt/ipimb/ipimb.py --base $BASE --ioc $IOC --evr $EVR --dir /reg/g/pcds/controls/pycaqt/ipimb
         fi
     else
         echo "Could not connect to ${BASE}. Exiting..."
     fi
 }
 
+# Get hutch name, if not given, using get_info
 get_hutch(){
     if [ -z "$HUTCH" ]; then
         hutch=`get_info --gethutch`


### PR DESCRIPTION
## Description
Added a check of the SUM PV before attempting to bring up a GUI for a possibly unreachable IPM box. Added an option to override the automatic hutch selection using the -H flag.

## Motivation and Context
Checking the PV beforehand allows for faster response in case of error instead of the user waiting for the GUI to load only for it to not be able to connect.
The hutch override allows for accessing other hutches' boxes without having to move to a machine in said hutch.
Addresses issues #26 and #27.

## How Has This Been Tested?
Tested by running the script in XPP and looking at a few boxes in XCS and looking at XPP boxes from an CXI machine. If it could not connect, it properly exited after checking the PV and was able to successfully open the GUI otherwise. Also retested using multiple options together.

## Where Has This Been Documented?
Comments added for ipmGUI and get_hutch functions. Usage updated for new option.