### PR TITLE
grep_ioc default to all

### DIFF
--- a/scripts/grep_ioc
+++ b/scripts/grep_ioc
@@ -18,8 +18,8 @@ if [[ -z $2 ]]; then
     HUTCH="all"
 else
     for hutchname in "xpp" "xcs" "cxi" "mfx" "mec" "xrt" "aux" "det" "fee" "hpl" "icl" "las" "lfe" "tst" "thz" "all"; do 
-        if [[ "${2}" == $hutchname ]]; then
-            HUTCH="${2}"
+        if [[ "${2,,}" == $hutchname ]]; then
+            HUTCH=$hutchname
         fi
     done
 fi
@@ -27,8 +27,8 @@ if [[ -z $HUTCH ]]; then
     echo "incorrect hutch name given.  Enter hutch name in lower case (example: xpp)"
 else
     if [[ $HUTCH == "all" ]]; then
-        grep "${1}" /reg/g/pcds/pyps/config/*/iocmanager.cfg
+        grep -i "${1}" /reg/g/pcds/pyps/config/*/iocmanager.cfg
     else
-        grep "${1}" /reg/g/pcds/pyps/config/${HUTCH}/iocmanager.cfg
+        grep -i "${1}" /reg/g/pcds/pyps/config/${HUTCH}/iocmanager.cfg
     fi
 fi


### PR DESCRIPTION
## Description
Changed script so that it no longer requires a hutch argument and will default to searching all hutches if not given one. Not sure how desired this is, but its been helpful for me so I decided to share.

## Motivation and Context
Saves the minimal time/hassle of typing "all", or in most cases the hutch you want as an ioc isn't often running in multiple IocManagers. I had this in my personal version of grep_ioc and thought it might be helpful for others. It also makes the script closer to Tyler Johnson's iocgrep function as the change allows it to be used with the same syntax.

## How Has This Been Tested?
I've been using it regularly for the past week without any problems. Haven't tested it outright.

## Where Has This Been Documented?
It hasn't been. The script is short and readable.