### PR TITLE
rhel7 fix for ipmConfigEpics

### DIFF
--- a/scripts/ipmConfigEpics
+++ b/scripts/ipmConfigEpics
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-export STRIPTOOL=/reg/g/pcds/package/epics/3.14/extensions/R3.14.12/bin/rhel6-x86_64/StripTool
-export LD_LIBRARY_PATH=/reg/common/package/python/2.5.5/lib:/reg/common/package/qt/4.6.2/lib/x86_64-linux:/reg/g/pcds/package/epics/3.14/base/current/lib/linux-x86_64:/reg/g/pcds/package/epics/3.14/extensions/current/lib/linux-x86_64
-export PATH=/reg/g/pcds/package/epics/3.14/base/current/bin/linux-x86_64:/reg/g/pcds/package/epics/3.14/extensions/current/bin/linux-x86_64:/reg/common/package/python/2.5.5/bin:/reg/common/package/qt/4.6.2/bin:/bin:/usr/bin:/reg/g/pcds/engineering_tools/xpp/scripts
 export EPICS_CA_MAX_ARRAY_BYTES=8388608
 ulimit -c unlimited
 
@@ -233,7 +230,7 @@ ipmGUI(){
         if [ ${#WAVE8} -gt 0 ]; then
             /reg/g/pcds/pyps/apps/wave8/latest/wave8 --base $BASE --evr $EVR --ioc $IOC
         else
-            /reg/g/pcds/controls/pycaqt/ipimb/ipimb.py --base $BASE --ioc $IOC --evr $EVR --dir /reg/g/pcds/controls/pycaqt/ipimb
+            /reg/g/pcds/controls/pycaqt/ipimb/ipimb --base $BASE --ioc $IOC --evr $EVR --dir /reg/g/pcds/controls/pycaqt/ipimb
         fi
     else
         echo "Could not connect to ${BASE}. Exiting..."


### PR DESCRIPTION
This PR assumes the merging of the ipmConfigEpics Enhancements PR.

## Description
Removes bad environment variables and points to the new ipimb executable, which has been releasing using svn earlier today.
A point of note: `ipimbtool` was deleted and replaced with `ipimb`. This change needs to be reflected in other files.

## Motivation and Context
This allows ipimb and therefore ipmConfigEpics to be used on rhel7 hosts.

## How Has This Been Tested?
Tested by running it on mfx-control and looking at a few ipm boxes and it seems to work fine. I have also used it a few times on some rhel6 machines and it appears to still work there too.

## Where Has This Been Documented?
Added some comments in ipimb.py. The changes to ipmConfigEpics are pretty transparent.