### PR TITLE
rhel7 fix for ipmConfigEpics

### DIFF
--- a/scripts/ipmConfigEpics
+++ b/scripts/ipmConfigEpics
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-export STRIPTOOL=/reg/g/pcds/package/epics/3.14/extensions/R3.14.12/bin/rhel6-x86_64/StripTool
-export LD_LIBRARY_PATH=/reg/common/package/python/2.5.5/lib:/reg/common/package/qt/4.6.2/lib/x86_64-linux:/reg/g/pcds/package/epics/3.14/base/current/lib/linux-x86_64:/reg/g/pcds/package/epics/3.14/extensions/current/lib/linux-x86_64
-export PATH=/reg/g/pcds/package/epics/3.14/base/current/bin/linux-x86_64:/reg/g/pcds/package/epics/3.14/extensions/current/bin/linux-x86_64:/reg/common/package/python/2.5.5/bin:/reg/common/package/qt/4.6.2/bin:/bin:/usr/bin:/reg/g/pcds/engineering_tools/xpp/scripts
 export EPICS_CA_MAX_ARRAY_BYTES=8388608
 ulimit -c unlimited
 
@@ -233,7 +230,7 @@ ipmGUI(){
         if [ ${#WAVE8} -gt 0 ]; then
             /reg/g/pcds/pyps/apps/wave8/latest/wave8 --base $BASE --evr $EVR --ioc $IOC
         else
-            /reg/g/pcds/controls/pycaqt/ipimb/ipimb.py --base $BASE --ioc $IOC --evr $EVR --dir /reg/g/pcds/controls/pycaqt/ipimb
+            /reg/g/pcds/controls/pycaqt/ipimb/ipimb --base $BASE --ioc $IOC --evr $EVR --dir /reg/g/pcds/controls/pycaqt/ipimb
         fi
     else
         echo "Could not connect to ${BASE}. Exiting..."


### PR DESCRIPTION
## Description
Removes bad setting of environment variables and points `ipmConfigEpics` to use the new script to properly set them up before running `ipimb.py`
The changes to ipimb were svn-controlled and have already been released. Part of the changes was a replacement of `ipimbtool` with `ipimb`. If any scripts or screens rely on `ipimbtool`, they will have to be updated to use `ipimb`.

## Motivation and Context
This change allows ipmConfigEpics to use the new version of ipimb which is compatible with rhel7 hosts.

## How Has This Been Tested?
I ran this from mfx-control, which is a rhel7 machine, and looked at a few ipm boxes and it seemed to work fine. I've also run it from some rhel6 machines and it did not appear to break anything.

## Where Has This Been Documented?
The changes to `ipimb.py` were commented and the changes to `ipmConfigEpics` are pretty transparent.