### PR TITLE
ServerStat expert option

### DIFF
--- a/scripts/check_host
+++ b/scripts/check_host
@@ -53,7 +53,7 @@ echo -e " "
 if [[ $CDS_ONLINE == 1 ]]; then
     ssh -qT $HOSTNAME <<EOF
 	source /reg/g/pcds/setup/pcds_shortcuts.sh
-	export PATH=$PATH:/sbin/:/usr/sbin
+	export PATH=\$PATH:/sbin/:/usr/sbin
 	echo -e "Red Hat Version:"
 	echo -e "-------------------------------------------------"
 	uname -r | cut -d '.' -f 6

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -260,7 +260,7 @@ elif [[ $CMD == "expert" ]]; then
     if [[ $CDS_ONLINE == 1 ]]; then
 	ssh -qT $NAME <<EOF
 	    source /reg/g/pcds/setup/pcds_shortcuts.sh
-	    export PATH=$PATH:/sbin/:/usr/sbin
+	    export PATH=\$PATH:/sbin/:/usr/sbin
 	    echo -e "Red Hat Version:"
 	    echo -e "-------------------------------------------------"
 	    uname -r | cut -d '.' -f 6


### PR DESCRIPTION
Added 'expert' option to `serverStat` which runs the same checks as the `check_host` abd changed formatting in some areas. Also cleaned up check_host a bit.

## Motivation and Context
Adds functionality for more detailed checks to serverStat, which beamline scientists have been trained to use.

## How Has This Been Tested?
Ran the expert option on a couple servers like ioc-xrt-vacuum, daq-mfx-wave8, ioc-xpp-wave8. Output is same as `check_host`.
When run on ioc-xrt-vacuum, I get weird errors where the server apparently doesn't recognize basic commands like hostname, sed, grep, and ps.

## Where Has This Been Documented?
Description added to helptext.