### PR TITLE
Point to the procmgr script in the current DAQ release

### DIFF
--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -91,7 +91,7 @@ DAQHOST=`wheredaq`
 if [[ $DAQHOST != *$NOTRUNNING* ]]; then
     echo stop the DAQ on $DAQHOST from $HOSTNAME
     T="$(date +%s%N)"
-    /reg/g/pcds/dist/pds/tools/procmgr/procmgr stop \
+    /reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr stop \
 	/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT 
 
     PLATFORM=`grep 'if not platform' /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT | awk '{print $NF}' | sed s/\'//g`
@@ -113,7 +113,7 @@ echo start DAQ on $AIMHOST
 if [ $HOSTNAME == $AIMHOST ]; then
     unset PYTHONPATH
     unset LD_LIBRARY_PATH
-    /reg/g/pcds/dist/pds/tools/procmgr/procmgr start \
+    /reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr start \
 	/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT -c 2000000000 -o /reg/g/pcds/pds/$HUTCH/logfiles
 else
     ssh -Y $AIMHOST restartdaq

--- a/scripts/startami
+++ b/scripts/startami
@@ -70,9 +70,9 @@ if [ $HOSTNAME == $DAQHOST ]; then
     read -p "Do you really intend to restart the ami_client on $DAQHOST? (y/n)"
     if [ "$REPLY" == "y" ];then
 	echo "Restarting the ami_client...";
-	/reg/g/pcds/dist/pds/tools/procmgr/procmgr stop \
+	/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr stop \
 	    /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT ami_client 
-	/reg/g/pcds/dist/pds/tools/procmgr/procmgr start \
+	/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr start \
  	    /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT -c 2000000000 -o /reg/g/pcds/pds/$HUTCH/logfiles ami_client 
 	exit
     else

--- a/scripts/stopami
+++ b/scripts/stopami
@@ -9,7 +9,7 @@ if [ $RESCNT -eq 1 ]; then
 	read -p "Do you really intend to stop the ami_client on $DAQHOST where the daq is running? (y/n)"
 	if [ "$REPLY" == "y" ];then
 	    echo "Restarting the ami_client...";
-	    /reg/g/pcds/dist/pds/tools/procmgr/procmgr stop \
+	    /reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr stop \
 		/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf ami_client 
 	fi
     fi

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -20,14 +20,14 @@ NOTRUNNING='Not running'
 
 if  [ $HUTCH == 'cxi' ]; then
     if [ $HOSTNAME == 'cxi-daq' ]; then
-	STATUS=`/reg/g/pcds/dist/pds/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH\_0.cnf | grep started`
+	STATUS=`/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH\_0.cnf | grep started`
 	if [[ $STATUS == *$NOTRUNNING* ]]; then
 	    echo 'cxi_0 - Main DAQ is not running'
 	else
 	    echo 'cxi_0 - Main DAQ is running on '$HOSTNAME
 	fi
     elif [ $HOSTNAME == 'cxi-monitor' ]; then
-	STATUS=`/reg/g/pcds/dist/pds/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH\_1.cnf | grep started`
+	STATUS=`/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH\_1.cnf | grep started`
 	if [[ $STATUS == *$NOTRUNNING* ]]; then
 	    echo 'cxi_1  - Secondary DAQ is not running'
 	else
@@ -39,7 +39,7 @@ if  [ $HUTCH == 'cxi' ]; then
     exit
 fi
 
-STATUS=`/reg/g/pcds/dist/pds/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf | grep started`
+STATUS=`/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf | grep started`
 if [[ $STATUS == *$NOTRUNNING* ]]; then
     echo 'DAQ is not running in' ${HUTCH^^}
     exit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fix the various daq start/stop scripts so that they use the procmgr script that is bundled with the daq release currently being used by the hutch. Before it was pointing to a random ancient version on nfs.
<!--- Describe your changes in detail -->

## Motivation and Context
This is needed so that hutches can be migrated to the new offline/logbook system. The procmgr script need to be updated to handle getting the current experiment from the new offline database. The procmgr script has always been bundled with the daq release, so this backwards compatible with old releases.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested this in XCS.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
