### PR TITLE
Remove Bash 4 lowercase substitution from grep_ioc

### DIFF
--- a/scripts/grep_ioc
+++ b/scripts/grep_ioc
@@ -18,7 +18,7 @@ if [[ -z $2 ]]; then
     HUTCH="all"
 else
     for hutchname in "xpp" "xcs" "cxi" "mfx" "mec" "xrt" "aux" "det" "fee" "hpl" "icl" "las" "lfe" "tst" "thz" "all"; do 
-        if [[ "${2,,}" == $hutchname ]]; then
+        if [[ "${2}" == $hutchname ]]; then
             HUTCH=$hutchname
         fi
     done


### PR DESCRIPTION
Simple change. Removed the lowercase substitution for hutch names.

## Motivation and Context
This syntax was implemented in Bash 4 and allows for simple lowercase substitution of variable values. Unfortunately, our rhel5 machines run Bash 3.2 so this is not supported. This fix is a simple way to enable this script on such machines.

## How Has This Been Tested?
Quick test in my shell

## Where Has This Been Documented?
Nowhere