### PR TITLE
Check if statsPlugin turned off in ipmConfigEpics 

### DIFF
--- a/scripts/ipmConfigEpics
+++ b/scripts/ipmConfigEpics
@@ -271,7 +271,7 @@ helpBld(){
         caput HFX:DG3:CVV:01:Stats2:EnableCallbacks 0
         caput XCS:DG3:CVV:02:Stats2:EnableCallbacks 0
         # Check if actually set      
-        if [[ $(caget -nt HFX:DG3:CVV:01:Stat2:EnableCallbacks 2> /dev/null) == 0 ]] && [[ $(caget -nt XCS:DG3:CVV:02:Stat2:EnableCallbacks 2> /dev/null) == 0 ]]; then
+        if [[ $(caget -nt HFX:DG3:CVV:01:Stats2:EnableCallbacks 2> /dev/null) == 0 ]] && [[ $(caget -nt XCS:DG3:CVV:02:Stats2:EnableCallbacks 2> /dev/null) == 0 ]]; then
             echo 'Turned off statsPlugin for XCS ipm3 and dio3'
         else
             echo 'Was unable to turn off statsPlugin'


### PR DESCRIPTION
## Description
Added simple if structure which cagets the values to check that they are set to the desired values.

## Motivation and Context
Fix for issue #25. I was expecting to create some error handling for the caputs but it seems like the EPICS base version has been updated so the default messages aren't messy as quoted in the issue page.

## How Has This Been Tested?
I can't seem to test the positive case right now as those PVs don't seem to be up at the moment. In the meantime, I tested by changing the PVs to something that is actually running and saw the script output as expected.

## Where Has This Been Documented?
Comments added to function.