### PR TITLE
Switch `epicsenv` from 3.14.12 to 3.15.20

### DIFF
--- a/rc/bashrc
+++ b/rc/bashrc
@@ -28,7 +28,6 @@ export PATH=$PATH:/reg/g/pcds/engineering_tools/latest/scripts/
 ########################################
 ### Specific PCDS environment logins ###
 ########################################
-alias epicsenv='. /reg/g/pcds/setup/epics-cur.sh'
+alias epicsenv='. /reg/g/pcds/setup/epicsenv-cur.sh'
 alias ana_env='source /reg/g/psdm/psconda.sh'
 alias plc_env='. /reg/g/pcds/setup/plcenv.sh'
-


### PR DESCRIPTION
We have been sourcing an old epics environment in the common PCDS rc.  This version is compatible with the PCDS Conda env and will save us a lot of pain.  