### PR TITLE
Add hutch argument handling to pmgr

### DIFF
--- a/scripts/pmgr
+++ b/scripts/pmgr
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# pmgr [hutch] [--debug] [--applyenable]
+#
+# --debug	: Displays the debug button, which prints out any edits made
+# --applyenable	: Displays the apply all button, which applies settings to all motors
+#
 if [[ -n $1 && ! $1 =~ '--' ]]; then
     HUTCH=$1
     shift


### PR DESCRIPTION
## Description
Swapped out the `get_info --gethutch` for an if statement allowing it to be set manually. Had to use `shift` to get pass the right arguments through to the script.

## Motivation and Context
I primarily wanted it so that we could access the XRT pmgr, but it's also nice to be able to specify which hutch.

## How Has This Been Tested?
I was able to access the XRT PMGR from xcd-control but was unable to access the XCS PMGR from either my script or the production version. Might need to look into that further.

## Where Has This Been Documented?
Nowhere

<img width="1384" alt="Screen Shot 2020-03-16 at 6 30 49 PM" src="https://user-images.githubusercontent.com/6636512/76813384-0b077100-67b5-11ea-82d1-16e5661b3a6b.png">

