### PR TITLE
Camviewer fix - Deal with spaces in config files and improve camera name matching.

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -149,7 +149,6 @@ RATE=-1
 MAINSCREEN=0
 
 EXE=/reg/g/pcds/pyps/config/$hutch/camviewer/run_viewer.csh
-#EXE='/reg/g/pcds/pyps/apps/camviewer/latest/run_viewer.csh'
 PVLIST=/reg/g/pcds/pyps/config/$hutch/camviewer.cfg
 CAMNUM=0
 WAIT=0


### PR DESCRIPTION
## Description
Changed use of awk so fields do not need to separated by ","-space, but just "," will be fine.

Changed name_to_pv to do a better job of finding the camera:
     - Let "-" and "_" match interchangeably and use case-invariant comparisons.
     - Look in the hutch first.
     - If no match, look in all hutches.
     - If more than one match, try to anchor the match at the start and end.  If this doesn't work, just match at the end.  If this doesn't work, report the ambiguity and abort.

## Motivation and Context
MFX had an issue where the camviewer.cfg files didn't have spaces after the commas, and so the cameras were ignored by this script.  I temporarily added spaces to their config file, but then decided this script needs to be worked on.

In the process of discussing this with Silke, she also pointed out that "xcs-yag3" vs. "xcs-yag3m" was an issue, so I added some disambiguation code.  (This also applies to looking for "*gige1" vs "*gige10".)

## How Has This Been Tested?
In MFX, verified that camViewer -l lists everything, and camViewer -c opens the proper screens when given on-axis, on_axis, yag3m, xcs_yag3, xcs-yag3, XCS-yag3, xcs_yag3m, or over1, and that yag3 or over give an ambiguous message.

## Where Has This Been Documented?
Comments in the script describe the matching process.
