### PR TITLE
ENH: add simple motor-typhos script

### DIFF
--- a/scripts/motor-typhos
+++ b/scripts/motor-typhos
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+usage()
+{
+cat << EOF
+usage: $0 options <motor_pv_basename>
+
+Start a typhos screen for the specified motor.
+Attempts to choose the correct type.
+
+OPTIONS:
+-h shows the usage information
+EOF
+}
+
+PREFIX=`echo $1 | cut -d . -f 1`
+
+if [ -z "${PREFIX}" ]; then
+    usage;
+    exit 1;
+fi
+
+# Use the latest tagged environment
+source /reg/g/pcds/pyps/conda/pcds_conda
+
+caget "${PREFIX}:PLC:nErrorId_RBV" > /dev/null 2>&1
+
+if [ $? -eq 0 ]; then
+    echo "* This looks like a Beckhoff axis."
+    DEVICE_CLASS="pcdsdevices.epics_motor.BeckhoffAxis"
+    NAME="${PREFIX}"  # maybe we can do better?
+else
+    echo "* Falling back to a standard EpicsMotor."
+    DEVICE_CLASS="ophyd.EpicsMotor"
+    NAME="${PREFIX}"
+fi
+
+TYPHOS_ARGS="${DEVICE_CLASS}[{'prefix':'${PREFIX}','name':'${NAME}'}]"
+echo "* Launching typhos with arguments: ${TYPHOS_ARGS}"
+echo "* This may take a bit, please wait..."
+typhos ${TYPHOS_ARGS} > /dev/null 2>&1 &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add `motor-typhos` script.
The `motor-expert-screen` script has so much `edm` stuff baked into it, I'm not sure the two can be merged reliably.
If you think otherwise, please advise on how to combine them.

## Motivation and Context
Requested on SLAC Slack by @silkenelson 

## How Has This Been Tested?
On psbuild:
```
$ ./motor-typhos AT2L0:XTES:MMS:02
* This looks like a Beckhoff axis.
* Launching typhos with arguments: pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'AT2L0:XTES:MMS:02','name':'AT2L0:XTES:MMS:02'}]
* This may take a bit, please wait...
```

## Screenshots (if appropriate):
Results in:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/5139267/90923824-36fdd280-e3a3-11ea-9a1e-f8f85ec77d17.png">

