### PR TITLE
Enh/lcls2 hutches

### DIFF
--- a/scripts/get_info
+++ b/scripts/get_info
@@ -218,6 +218,9 @@ if args.run:
                 print('ended')
 
 if args.files_for_run or args.nfiles_for_run:
+    if not rundoc:
+        print('no runs started yet, exiting')
+        sys.exit()
     if args.files_for_run:
         run = int(args.files_for_run)
     if args.nfiles_for_run:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Reference LCLS2 hutches as lower cased, currently only affects TMO.
Change logic so all run information references either the hutch found or the hutch passed in from args
All other changes should be benign
<!--- Describe your changes in detail -->
Order logic for finding hutch from a multitude of conditions in a more readable way
Add lcls2 hutches so we know when we should pass a lower case or upper case hutch name
to retrieve metadata from elog
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows get_info to work for lcls2 hutches
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've run through all the commands on
tmo-console
cxi-daq
pslogin
and verified that I get the desired responses
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This shouldn't affect the other three get_* scripts, but I don't know what else uses this script and in what way.
There were some implementation details that could fail if you don't set the args appropriately, I tried to make this a bit more straight forward for a user

## Where Has This Been Documented?
Added loads of comments, I think at least 50% of them are useful :)
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
