### PR TITLE
FIX: Force Software rastering for QtQuick when using SSH.

### DIFF
--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -17,3 +17,11 @@ export PYDM_DESIGNER_ONLINE=1
 export PYDM_DISPLAYS_PATH=/reg/g/pcds/epics-dev/
 export LUCID_CONFIG=/reg/g/pcds/pyps/apps/hutch-python/lucid_config/
 export HAPPI_CFG=/reg/g/pcds/pyps/apps/hutch-python/device_config/happi.cfg
+
+# Revert to Software Raster when SSH to avoid issues with QtQuick.
+# The same was done with PyDM and this fixes Designer and friends.
+if [ -n "SSH_CONNECTION" ]; then
+	echo "Using SSH, reverting QtQuick rendering to Software."
+	export QT_QUICK_BACKEND="software"
+fi
+

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -21,3 +21,10 @@ fi
 
 export PYDM_DESIGNER_ONLINE=1
 export HAPPI_CFG=/reg/g/pcds/pyps/apps/hutch-python/device_config/happi.cfg
+
+# Revert to Software Raster when SSH to avoid issues with QtQuick.
+# The same was done with PyDM and this fixes Designer and friends.
+if [ -n "SSH_CONNECTION" ]; then
+	echo "Using SSH, reverting QtQuick rendering to Software."
+	export QT_QUICK_BACKEND="software"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a check to make sure we force rendering to Software when using SSH.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To allow users to use QtQuick widgets (such as the WebBrowser) with QtDesigner and other apps.
Without this, users will get a segfault or a crash at Designer and apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested at PSBUILD machines.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
