### PR TITLE
evrStatus scripts

### DIFF
--- a/scripts/evrStatus
+++ b/scripts/evrStatus
@@ -12,8 +12,8 @@ Syntax: $0 \
         [ < area > <area> .. ]
         [ -h ] [ -Help ]
         [ -l ]
-        [ -pv ] [ -pv <EVR PV Name> <EVR PV Name>.. ]
-        [ -pvs ] [ -pvs  --< area >  --< area >  ]  
+        [ -pv ] [ <EVR PV Name> <EVR PV Name>.. ]
+        [ -pvs ] [  --< area >  --< area > ..  ]  
         
 Supported Arguments:
    -h, -Help: Display this help text
@@ -96,7 +96,7 @@ areas=(
 read_hutch () {   
     echo "Enter area you'd like to see ie (XPP, TMO, FEE, ALL..etc):" 
     echo "(Press enter to exit this session)"
-    read  hutch
+    read -r  hutch
     hutch=${hutch^^}  # make user input uppercase for user friendliness  
 
     if [[ "${hutch}" == "" ]]; then 
@@ -107,10 +107,10 @@ read_hutch () {
 # Checks if user inputted area is valid 
 
 in_areas() {
-    hutch_in_areas=$(echo ${areas[@]} | grep -o "$hutch" | wc -w) # 1 or 0 depending if user input returns a match or not
+    hutch_in_areas=$(echo "${areas[@]}" | grep -o "$hutch" | wc -w) # 1 or 0 depending if user input returns a match or not
 
-    if ! [ $hutch_in_areas -eq 1 ];then 
-        echo "The area you searched:"$hutch " does not correspond to any currently in the NEH or FEH where EVRs are located... the list of available areas is:"
+    if ! [ "$hutch_in_areas" -eq 1 ];then 
+        echo "The area you searched:" "$hutch" " does not correspond to any currently in the NEH or FEH where EVRs are located... the list of available areas is:"
         printf "\n"
         printf '%s\n' "${areas[@]}"
         printf "\n"
@@ -125,13 +125,13 @@ in_areas() {
 req_evrs_func() {
     req_evrs=()
     if [[ "$hutch" == "ALL" ]]; then  # all callable pvs are requested evr pvs 
-        for i in ${evrs[@]}; do
-            req_evrs+=($i)
+        for i in "${evrs[@]}"; do
+            req_evrs+=("$i")
         done
     else
         for i in "${evrs[@]}"; do # call only pvs that are associated with specified hutch
             if [[ $i == *"$hutch"* ]]; then
-	        req_evrs+=($i)
+	        req_evrs+=("$i")
 	    fi
         done
     fi
@@ -157,10 +157,10 @@ to_display () {
             macro_array+="EVR$j=${req_evrs[$j]}"
         done
     fi
-    local macros_exported=${macro_array[@]} # macros are exported to edm as a string
+    local macros_exported=${macro_array[*]} # macros are exported to edm as a string
     export macros_exported evr_num
 
-    echo "Displaying EVR status screen for" $hutch "..."    
+    echo "Displaying EVR status screen for " "$hutch" "..."    
     printf "\n"           
     
     /reg/g/pcds/epics-dev/screens/edm/common/current/evrStatus/edm-evrs.cmd
@@ -168,13 +168,13 @@ to_display () {
 
 # Begin Command line argument handling:
 
-command_args=$@
-command_args_string="$@"
+command_args=$*
+command_args_string="$*"
 
 # Argument to display the PVs of a requested area
 
 pvs_areas=()
-for i in ${areas[@]}; do pvs_areas+=("--$i"); done
+for i in "${areas[@]}"; do pvs_areas+=("--$i"); done
 
 # Other types of command line arguments:
 
@@ -189,21 +189,23 @@ except_args=()
 for i in $command_args_string; do
     i=${i^^}
     if [[ "$i" =~ ":" && ${#i} -gt 10 ]]; then
-        pv_args+=($i)
-    elif [[ "${areas[@]}" =~ $i ]]; then   # Initial classification filtering
-        for j in ${areas[@]}; do           
-            if [[ "$j" == $i ]]; then      # Exact Match Filtering
-                area_args+=($i)
+        pv_args+=("$i")
+    elif [[ "${areas[*]}" =~ $i ]]; then   # Initial classification filtering
+        for j in "${areas[@]}"; do           
+            if [[ "$j" == "$i" ]]; then      # Exact Match Filtering
+                area_args+=("$i")
             fi
         done
-    elif [[ "${opts_available[@]}" =~ "$i" ]]; then  # Initial classification filtering
-	for j in ${opts_available[@]}; do            
-	    if [[ "$j" == $i ]];then                 # Exact Match Filtering
-                opt_args+=($i)
+    elif [[ "${opts_available[*]}" =~ $i ]]; then  # Initial classification filtering
+	for j in "${opts_available[@]}"; do            
+	    if [[ "$j" == "$i" ]];then                 # Exact Match Filtering
+                opt_args+=("$i")
             fi
         done
+    elif [[ "${#i}" -eq  1 ]]; then 
+        except_args+=("$i")
     else
-        except_args+=($i)
+        except_args+=("$i")
     fi
 done
 
@@ -217,7 +219,7 @@ args_pv_handling() {
         evr_num=$((evr_num + 1))
     done
 
-    local macros_exported=${macro_array[@]}
+    local macros_exported=${macro_array[*]}
     export macros_exported evr_num
     
     /reg/g/pcds/epics-dev/screens/edm/common/current/evrStatus/edm-evrs.cmd
@@ -229,14 +231,14 @@ manual_pv_entry() {
     local evr_num=0
     echo "Enter the EVR PV(s) you would like to see the display status of. Please only enter one per line:" 
     echo "(Press Return to exit this dialog)"
-    read input
+    read -r input
     if [[ "$input" == "" ]]; then
         exit
     else
         local macro_array+="EVR0$evr_num=$input,"
         evr_num=$((evr_num + 1))
     fi
-    while read line; do
+    while read -r line; do
         if [[ "$line" == "" ]]; then
             break
         else
@@ -245,28 +247,35 @@ manual_pv_entry() {
         fi
     done 
                                                                                 
-    local macros_exported=${macro_array[@]}
+    local macros_exported=${macro_array[*]}
     export macros_exported evr_num
 
     /reg/g/pcds/epics-dev/screens/edm/common/current/evrStatus/edm-evrs.cmd
 }
 
 except_handling() {
-    for i in ${except_args[@]}; do
+    for i in "${except_args[@]}"; do
 
 # 1: Wrong type of PV format  
         if [[ "$i" =~ ":" && ${#i} -lt 10 ]]; then
-            echo "There seems to be a typo in your requested PV: " $i 
+            echo "There seems to be a typo in your requested PV: " "$i" 
             echo "Please try again"
 
 # 2: Wrong type of area format --> error handling is already executed in the in_areas function
 
 # 3: Option non-existant
-        elif ! [[ "${opts_available[@]}" =~ "$i" ]]; then
-            echo "Invalid Argument: " $i
+        elif ! [[ "${opts_available[*]}" =~ $i ]]; then
+            echo "Invalid Argument: " "$i"
             printf "The list of supported command line arguments are: \n <area> \n -PV \n -l \n -h \n --help \n -PVS -<area> \n"
             printf "\n"
 	    echo "For full documentation: $ evrStatus -h "
+	elif [[ "${#i}" -eq 1 ]]; then
+            echo "Invalid Argument: " "$i"
+            printf "The list of supported command line arguments are: \n <area> \n -PV \n -l \n -h \n --help \n -PVS -<area> \n"
+            printf "\n"
+            echo "For full documentation: $ evrStatus -h "
+
+
         fi
     done
 }
@@ -279,38 +288,38 @@ if [[ "$1" == "" ]]; then
     req_evrs_func 
     to_display
 fi
-if [[ "${opt_args[@]}" == *"-L"* ]]; then
+if [[ "${opt_args[*]}" == *"-L"* ]]; then
     echo "The areas available to see EVR status are:"
     printf '%s\n' "${areas[@]}"
     printf "\n"
 fi
-if [[ "${opt_args[@]}" == *"-H" || "$i" == *"HELP" ]]; then
-    echo " `usage` "
+if [[ "${opt_args[*]}" == *"-H" || "$i" == *"HELP" ]]; then
+    echo " $( usage ) "
     printf "\n"
 fi
-if [[ "${opt_args[@]}" == *"-PVS"* ]]; then
-    for i in ${opt_args[@]}; do
-        if [[ "${pvs_areas[@]}" =~ "$i" ]];then
+if [[ "${opt_args[*]}" == *"-PVS"* ]]; then
+    for i in "${opt_args[@]}"; do
+        if [[ "${pvs_areas[*]}" =~ $i ]];then
             hutch=${i:2:4}
             req_evrs_func
             printf "\n"
-            echo "Here are the PVs currently loaded into the script for:" $hutch
+            echo "Here are the PVs currently loaded into the script for:" "$hutch"
 	    printf "\n"
-            for j in ${req_evrs[@]}; do echo $j; done
+            for j in "${req_evrs[@]}"; do echo "$j"; done
             printf "\n"
-        elif [[ "${opt_args[@]}" == "-PVS" && ${#opt_args[@]} -eq 1 ]]; then
+        elif [[ "${opt_args[*]}" == "-PVS" && ${#opt_args[@]} -eq 1 ]]; then
 	    read_hutch
             in_areas
             printf "\n"
             req_evrs_func 
-            echo "Here are the PVs currently loaded into the script for:" $hutch
-	    for j in ${req_evrs[@]}; do echo $j; done
+            echo "Here are the PVs currently loaded into the script for:" "$hutch"
+	    for j in "${req_evrs[@]}"; do echo "$j"; done
             printf "\n" 
 	fi
     done
 fi
 if [[ ${#area_args[@]} -ne 0 ]]; then
-   for i in ${area_args[@]}; do
+   for i in "${area_args[@]}"; do
        hutch=$i
        in_areas
        req_evrs_func
@@ -319,7 +328,7 @@ if [[ ${#area_args[@]} -ne 0 ]]; then
 fi
 if [[ ${#pv_args[@]} -ne 0 ]]; then
    args_pv_handling
-elif [[ "${opt_args[@]}" == *"-PV"* && ${#pv_args[@]} -eq 0 ]]; then
+elif [[ "${opt_args[*]}" == *"-PV"* && ${#pv_args[@]} -eq 0 ]]; then
    manual_pv_entry
 fi
 if [[ ${#except_args[@]} -ne 0 ]]; then


### PR DESCRIPTION
## Description

Add an evrStatus script that allows the user to see an over view of the EVR statuses (Link, fiducial, etc) for a user defined hutch. An evrList file is then search for hutch key words and relevant EVR PVs are returned and an edm screen is displayed. For future EVRs in newer hutches (RIX, TXI etc) new PVs can be added to evrList in a new release or maybe dev version.


## Motivation and Context

EVRs have been flaky in several hutches and so a need has arisen to quickly look at the status of them as well as compare easily across hutches. Many EVRs were not displayed in home screens before either.

## How Has This Been Tested?

I ran this script from my home directory while logged into the hutch control machines as well as the daq and opr consoles. I have given read, write, execute permission for both evrStatus and evrList files as well as the display .edl files located in /reg/g/pcds/epics-dev/screens/common/currrent/evrStatus

## Where Has This Been Documented?

Documentation will be provided on confluence under EVRs.



