### PR TITLE
MNT: include vac stylesheets

### DIFF
--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -23,6 +23,8 @@ export PYTHONPATH=/reg/g/pcds/pyps/apps/dev/pythonpath
 export PYQTDESIGNERPATH=/reg/g/pcds/pyps/conda/dev_designer_plugins/:$PYQTDESIGNERPATH
 export PYDM_DESIGNER_ONLINE=1
 export PYDM_DISPLAYS_PATH=$EPICS_ROOT/screens/pydm:$EPICS_ROOT
+export PYDM_STYLESHEET=$EPICS_ROOT/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
+export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
 export LUCID_CONFIG=/reg/g/pcds/pyps/apps/hutch-python/lucid_config/
 export HAPPI_CFG=/reg/g/pcds/pyps/apps/hutch-python/device_config/happi.cfg
 

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -29,6 +29,8 @@ EPICS_ROOT="/reg/g/pcds/epics-dev"
 
 export PYDM_DESIGNER_ONLINE=1
 export PYDM_DISPLAYS_PATH=$EPICS_ROOT/screens/pydm:$EPICS_ROOT
+export PYDM_STYLESHEET=$EPICS_ROOT/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
+export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
 export LUCID_CONFIG=/reg/g/pcds/pyps/apps/hutch-python/lucid_config/
 export HAPPI_CFG=/reg/g/pcds/pyps/apps/hutch-python/device_config/happi.cfg
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Include the correct vacuum stylesheets in the environment setup scripts
For now, both dev and prod point to dev...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Joseph made these stylesheets to be better than the defaults, tooled to vacuum vacuum widgets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I opened the LFE vacuum screens with and without this change, and verified that there were differences between the two screens. For example, there is an errored valve that shows up with a red outline with the stylesheets active, and no red outline with the stylesheets inactive.