### PR TITLE
Ami_offline_psana upgrade help options

### DIFF
--- a/scripts/ami_offline_psana
+++ b/scripts/ami_offline_psana
@@ -23,7 +23,7 @@ if [[ $1 =~ ^(h|-h|-help|--help) ]]; then
 	exit 0
 fi
 
-while getopts "h:u:e:ntR" OPTION
+while getopts "u:e:ntR" OPTION
 do
     case $OPTION in
 	u)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Moved `-h` out of `getopts` and added `--help` option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Standardizing access to script's `usage`.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally using the `-h` and `--help` option. 
<!--- Include details of your testing environment, and the tests you ran to -->
Using Ubuntu 18.04.04 Bash Shell:
`ami_offline_psana -h`
`ami_offline_psana --help`
`ami_offline_psana`
Using RHEL 7.8
`ami_offline_psana` 

<!--- see how your change affects other areas of the code, etc. -->
Changes show no effect on calling the script with no arguments.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://github.com/slaclab/engineering_tools
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
