### PR TITLE
CamViewer upgrade help options

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -164,13 +164,9 @@ WAIT=0
 RATE=-1
 REBOOT=0
 
-while getopts "c:w:u:H:hlmr" OPTION
+while getopts "c:w:u:H:lmr" OPTION
 do
     case $OPTION in
-	h)
-	    usage
-	    exit 1
-	    ;;
 	l)
 	    list_cams $hutch
 	    exit 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Moved `-h` out of `getopts` and added `--help` option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Standardizing access to script's `usage`.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally using the `-h` and `--help` option. 
<!--- Include details of your testing environment, and the tests you ran to -->
Using Ubuntu 18.04.04 Bash Shell:
`camViewer -h`
`camViewer --help`
`camViewer`
Using RHEL 7.8
`camViewer` 

<!--- see how your change affects other areas of the code, etc. -->
Changes show no effect on calling the script with no arguments.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://github.com/slaclab/engineering_tools
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->