### PR TITLE
ENH: verify module or bin exist in pydev_register

### DIFF
--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -20,8 +20,8 @@ if [ -z "${1}" ]; then
 fi
 PYDEV_DIR=~/pydev
 
-full_path="$(readlink -f $1)"
-if [ ! -f $full_path ]; then
+full_path="$(readlink -f "$1")"
+if [ ! -f "$full_path" ]; then
   echo "File does not exist"
   usage
   exit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a check to make sure that the user supplied a valid module or bin path.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently `pydev_register` will happily create links to modules or binaries that do not exist.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested script locally with a false path and valid path. 
<!--- Include details of your testing environment, and the tests you ran to -->
The valid path created a linked file in `~/pydev` as expected.
An invalid path reported invalid file and printed `usage()`
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
https://github.com/slaclab/engineering_tools/
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
