### PR TITLE
WIP: camViewer

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -250,15 +250,13 @@ if [ $REBOOT -gt 0 ]; then
     exit
 fi
 
-
-#ENABLE-e
 if [ $ENABLE -gt 0 ]; then 
-    echo "Enabling ${CAMNAME}
+    echo "Enabling ${CAMNAME}"
     IOC=$(iocfpv "${CAMPVFULL}")
     $imgr "$IOC" --hutch "$hutch" --enable   
     exit
 fi
-#DISABLE-d
+
 if [ $DISABLE -gt 0 ]; then
     echo "Disabling ${CAMNAME}
     IOC=$(iocfpv "${CAMPVFULL}")


### PR DESCRIPTION
## Description
Updated script enable and disable options for camera iocs

## Motivation and Context
We needed a simple way to control iocs running since it is hard to track whether machines are overloaded or not from unused camera iocs. Fixes #71.

## How Has This Been Tested?
These changes were tested from xcs-control. The tests did not affect any other areas of the code and gave the desired results when handling camera iocs that are running from xcs. When trying to access cameras running from different hutches, an error occurs because the correct hutch is not specified. When giving a camera with a PV associated with multiple iocs, it instead prints the list of iocs, which could be a problem when handling new hutches that use pgp cards.

## Where Has This Been Documented?
Script usage() function was updated to reflect changes.

<!--
## Screenshots (if appropriate):
-->
