### PR TITLE
BUG: Fix a few issues in wheredaq and restartdaq

### DIFF
--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -11,7 +11,7 @@ OPTIONS:
 EOF
 }
 
-NOTRUNNING='Not running'
+NOTRUNNING='not running'
 AIMHOST=$HOSTNAME
 SELPART=''
 DOWIN=''
@@ -74,7 +74,7 @@ if [[ ($HUTCH == 'tmo') || ($HUTCH == 'rix') ]]; then
     PROCMGR='procmgr'
     DAQNETWORK='drp'
 else
-    PROCMGR='/reg/g/pcds/dist/pds/tools/procmgr/procmgr'
+    PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 fi
 
 IS_DAQ_HOST=`netconfig search $HNAME-$DAQNETWORK --brief | grep $DAQNETWORK | wc -l`

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -24,13 +24,13 @@ fi
 
 if [[ ! -f /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM.cnf.running ]]; then
     if [ $HOSTNAME == 'cxi-daq' ]; then
-	echo 'Main DAQ cxi_0 is not running on $HOSTNAME '
+	echo 'Main DAQ cxi_0 is not running on '$HOSTNAME
     elif [ $HOSTNAME == 'cxi-monitor' ]; then
-	echo 'Secondary DAQ cxi_1 is not running on $HOSTNAME '
+	echo 'Secondary DAQ cxi_1 is not running on '$HOSTNAME
     else
 	echo 'DAQ is not running in '$HUTCH
     fi
 else
-    DAQ_HOST=`grep HOST /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM.cnf.running | awk {'print $3'} | sed s/\'//g`
+    DAQ_HOST=`grep "'HOST'" /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM.cnf.running | awk {'print $3'} | sed s/\'//g`
     echo 'DAQ is running on '$DAQ_HOST
 fi


### PR DESCRIPTION
## Description
A couple small fixes to make wheredaq run smoother plus a change to get restartdaq to properly launch the daq in CXI.

## Motivation and Context
The most recent versions of the scripts did not work in CXI. The PR is to fix that.

## How Has This Been Tested?
I've tested that both scripts work in CXI. Silke has tested in TMO and XCS as well.

## Where Has This Been Documented?
Nowhere.