### PR TITLE
BUG: Fix auto current experiment in eloggrabber

### DIFF
--- a/scripts/eloggrabber
+++ b/scripts/eloggrabber
@@ -93,7 +93,7 @@ fi
 ##who am I doing this? Why don't just use the actual username?
 #USERNAME=`get_info --gethutch`opr
 USERNAME=`whoami`
-EXPNAME=current
+EXPNAME=`get_curr_exp`
 HUTCH=`get_info --gethutch`
 
 while getopts "e:u:s:xct" OPTION


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changed initial value of `EXPNAME` to use `get_curr_exp`.
Essentially, uses our `get_curr_exp` script instead of LogBookWebService.py's `ws_get_current_run` function . Maybe it would be better to fix that function? It lives here: https://github.com/slaclab/LogBookClient/blob/b71e02014dd24445fe31dee67e7f8fe915cf66f1/LogBookClient/LogBookWebService.py#L119

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jyoti requested this fix because the current behavior causes problems in TMO and RIX due to their multiple platforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Been running in RIX.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It hasn't

<!--
## Screenshots (if appropriate):
-->
