### PR TITLE
Change default cameras in camviewer

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -226,6 +226,8 @@ if [ $CAMNUM -eq 0 ]; then
         CAMNAME=mfx_dg1_yag
     elif [ $hutch = "cxi" ]; then
         CAMNAME=cxi_dg1_yag
+    elif [ $hutch = "mec" ]; then
+        CAMNAME=GigE_Questar1
     else
 	CAMNAME=xcs_yag2
     fi


### PR DESCRIPTION
Just change the default xpp gige in camViewer to a camera that would not give an error when running it with no argument.
