### PR TITLE
FIX: fixing variables name errors

### DIFF
--- a/scripts/epicsArchChecker
+++ b/scripts/epicsArchChecker
@@ -36,10 +36,10 @@ def main():
     os.chdir(dirpath)
     entries, extraKeys, noKeyPVs = read_file(filename)
     if args.warnings:
-        myKeys, myPvs, myFiles, lineumbers = create_Lists(entries)
+        myKeys, myPvs, myFiles, lineNumbers = create_Lists(entries)
         indKeys, indPvs = find_index(myKeys, myPvs, myFiles)
         report_duplicates(indKeys, indPvs, myKeys, myPvs, myFiles, lineNumbers)
-        report_warning(extraKeys, noKeyPVs)
+        report_warnings(extraKeys, noKeyPVs)
     elif args.status:
         myKeys, myPvs, myFiles, lineNumbers = create_Lists(entries)
         report_statusPv(myKeys, myPvs, myFiles)


### PR DESCRIPTION
**Description**
Fixing 2 variable names errors of the script epicsArchChecker that checks epicsArch.txt files.

 **Motivation and Context**
Two variables inside of the script were missing a character. After adding the missing character to the two variables the script was tested.

**How Has This Been Tested?**

The script was re-tested against a set of epicArch.txt from the hutches XPP and CXI, 

**How Has This Been Documented?**
N/A
