### PR TITLE
Add imgr and merge iocmanager into one bash file

### DIFF
--- a/scripts/imgr
+++ b/scripts/imgr
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+# Define usage here for faster return
+usage()
+{
+cat << EOF
+usage: imgr <IOCNAME> [--hutch HUTCH] <OPTION>
+
+Control status of all IOCs running in a particular hutch from the command line.
+Current hutch is used if not provided.
+
+List of options:
+imgr IOCNAME [--hutch HUTCH] --reboot soft
+imgr IOCNAME [--hutch HUTCH] --reboot hard
+imgr IOCNAME [--hutch HUTCH] --enable
+imgr IOCNAME [--hutch HUTCH] --disable
+imgr IOCNAME [--hutch HUTCH] --upgrade RELEASE_DIR
+imgr IOCNAME [--hutch HUTCH] --move HOST
+imgr IOCNAME [--hutch HUTCH] --move HOST:PORT
+imgr [--hutch HUTCH] --list [--host HOST] [--enabled_only|--disabled_only]
+ 
+EOF
+}
+if [ $# -lt 1 ]; then
+    echo 'Missing required arguments' >&2
+    usage
+    exit 1
+elif [[ ($1 == "--help") || ($1 == "-h") ]]; then
+    usage
+    exit 0
+fi
+
 # Setup environment
 if [ -x /etc/pathinit ]; then
     source /etc/pathinit

--- a/scripts/imgr
+++ b/scripts/imgr
@@ -74,5 +74,5 @@ if [[ "$HUTCH" == "unknown_hutch" ]]; then
     echo "Unknown hutch, please use --hutch argument" >&2
     exit 1
 else
-    /reg/g/pcds/pyps/config/${HUTCH}/iocmanager/imgr.py "$@" --hutch $HUTCH
+    /reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/imgr.py "$@" --hutch "${HUTCH,,}"
 fi

--- a/scripts/imgr
+++ b/scripts/imgr
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Setup environment
+if [ -x /etc/pathinit ]; then
+    source /etc/pathinit
+else
+    export PSPKG_ROOT=/cds/group/pcds/pkg_mgr
+    export PYPS_ROOT=/cds/group/pcds/pyps
+    export IOC_ROOT=/cds/group/pcds/epics/ioc
+    export CAMRECORD_ROOT=/cds/group/pcds/controls/camrecord
+    export IOC_DATA=/cds/data/iocData
+    export IOC_COMMON=/cds/data/iocCommon
+fi
+export PSPKG_OS=`${PSPKG_ROOT}/etc/pspkg_os.sh`
+if [ $PSPKG_OS == rhel5 ]; then
+    echo "IocManager 2.0.0 and higher does not run on RHEL5!" >&2
+    exit 1
+fi
+export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
+export PSPKG_RELEASE=controls-0.1.9
+source $PSPKG_ROOT/etc/set_env.sh
+
+# Search for hutch in args
+for (( i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "--hutch" ]]; then
+        ARGHUTCH_INDEX=$((i+1))
+        ARGHUTCH=${!ARGHUTCH_INDEX}
+        break
+    fi
+done
+
+# Hutch choice priority order:
+# 1. --hutch arg
+# 2. HUTCH environment variable
+# 3. get_hutch_name
+HUTCH=${ARGHUTCH:-$HUTCH}
+HUTCH=${HUTCH:-`get_hutch_name`}
+
+if [[ "$HUTCH" == "unknown_hutch" ]]; then
+    echo "Unknown hutch, please use --hutch argument" >&2
+    exit 1
+else
+    /reg/g/pcds/pyps/config/${HUTCH}/iocmanager/imgr.py "$@" --hutch $HUTCH
+fi

--- a/scripts/imgr
+++ b/scripts/imgr
@@ -20,6 +20,8 @@ fi
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 export PSPKG_RELEASE=controls-0.1.9
 source $PSPKG_ROOT/etc/set_env.sh
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$PATH:$DIR
 
 # Search for hutch in args
 for (( i=1; i<=$#; i++)); do

--- a/scripts/imgr
+++ b/scripts/imgr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Setup environment
 if [ -x /etc/pathinit ]; then
@@ -11,8 +11,9 @@ else
     export IOC_DATA=/cds/data/iocData
     export IOC_COMMON=/cds/data/iocCommon
 fi
-export PSPKG_OS=`${PSPKG_ROOT}/etc/pspkg_os.sh`
-if [ $PSPKG_OS == rhel5 ]; then
+PSPKG_OS=$(${PSPKG_ROOT}/etc/pspkg_os.sh)
+export PSPKG_OS
+if [ "$PSPKG_OS" == rhel5 ]; then
     echo "IocManager 2.0.0 and higher does not run on RHEL5!" >&2
     exit 1
 fi
@@ -34,8 +35,9 @@ done
 # 2. HUTCH environment variable
 # 3. get_hutch_name
 HUTCH=${ARGHUTCH:-$HUTCH}
-HUTCH=${HUTCH:-`get_hutch_name`}
+HUTCH=${HUTCH:-$(get_hutch_name)}
 
+# Run if possible
 if [[ "$HUTCH" == "unknown_hutch" ]]; then
     echo "Unknown hutch, please use --hutch argument" >&2
     exit 1

--- a/scripts/imgr
+++ b/scripts/imgr
@@ -30,6 +30,33 @@ elif [[ ($1 == "--help") || ($1 == "-h") ]]; then
     exit 0
 fi
 
+# Add engineering_tools to PATH for get_hutch_name
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$PATH:$DIR
+
+# Search for hutch in args
+for (( i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "--hutch" ]]; then
+        ARGHUTCH_INDEX=$((i+1))
+        ARGHUTCH=${!ARGHUTCH_INDEX}
+        break
+    fi
+done
+
+# Hutch choice priority order:
+# 1. --hutch arg
+# 2. HUTCH environment variable
+# 3. get_hutch_name
+HUTCH=${ARGHUTCH:-$HUTCH}
+HUTCH=${HUTCH:-$(get_hutch_name)}
+
+# Exit if hutch is still unknown
+# TODO: Replace with check for actual hutch names
+if [[ "$HUTCH" == "unknown_hutch" ]]; then
+    echo "Unknown hutch, please use --hutch argument" >&2
+    exit 1
+fi
+
 # Setup environment
 if [ -x /etc/pathinit ]; then
     source /etc/pathinit
@@ -50,29 +77,5 @@ fi
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 export PSPKG_RELEASE=controls-0.1.9
 source $PSPKG_ROOT/etc/set_env.sh
-DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
-PATH=$PATH:$DIR
 
-# Search for hutch in args
-for (( i=1; i<=$#; i++)); do
-    if [[ "${!i}" == "--hutch" ]]; then
-        ARGHUTCH_INDEX=$((i+1))
-        ARGHUTCH=${!ARGHUTCH_INDEX}
-        break
-    fi
-done
-
-# Hutch choice priority order:
-# 1. --hutch arg
-# 2. HUTCH environment variable
-# 3. get_hutch_name
-HUTCH=${ARGHUTCH:-$HUTCH}
-HUTCH=${HUTCH:-$(get_hutch_name)}
-
-# Run if possible
-if [[ "$HUTCH" == "unknown_hutch" ]]; then
-    echo "Unknown hutch, please use --hutch argument" >&2
-    exit 1
-else
-    /reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/imgr.py "$@" --hutch "${HUTCH,,}"
-fi
+/reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/imgr.py "$@" --hutch "${HUTCH,,}"

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -14,6 +14,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
+# Setup environment
 if [ -x /etc/pathinit ]; then
     source /etc/pathinit
 else
@@ -24,8 +25,9 @@ else
     export IOC_DATA=/reg/d/iocData
     export IOC_COMMON=/reg/d/iocCommon
 fi
-export PSPKG_OS=`${PSPKG_ROOT}/etc/pspkg_os.sh`
-if [ $PSPKG_OS == rhel5 ]; then
+PSPKG_OS=$(${PSPKG_ROOT}/etc/pspkg_os.sh)
+export PSPKG_OS
+if [ "$PSPKG_OS" == rhel5 ]; then
     echo "IocManager 2.0.0 and higher does not run on RHEL5!"
     exit 1
 fi
@@ -34,24 +36,26 @@ export PSPKG_RELEASE=controls-0.1.9
 source $PSPKG_ROOT/etc/set_env.sh
 ulimit -c unlimited
 
-DIR=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 PATH=$PATH:$DIR
 
 if [ "$#" -eq 0 ]; then
-    HUTCH=`get_hutch_name`
+    HUTCH=$(get_hutch_name)
 else
     HUTCH=$1
 fi
 
+# Run if possible
 if [[ "$HUTCH" == "unknown_hutch" ]]; then
     echo "Unknown hutch, please specify e.g. 'iocmanager xrt'" >&2
     exit 1
 else
-    /reg/g/pcds/pyps/config/${HUTCH}/iocmanager/IocManager.py --hutch $HUTCH > /dev/null &
+    /reg/g/pcds/pyps/config/"${HUTCH}"/iocmanager/IocManager.py --hutch "$HUTCH" > /dev/null &
 fi
 
-if [ `whoami` == "xppopr" ]; then
-    window_id=`xdotool search --sync --onlyvisible --name 'IocManager'` 
+# Do some window cleanup for xpp
+if [ "$(whoami)" == "xppopr" ]; then
+    window_id=$(xdotool search --sync --onlyvisible --name 'IocManager')
     if [ "xpp-control"  == "$HOSTNAME" ]; then
 	wmctrl -v -i -r "$window_id" -e 0,3310,1100,530,1000
     elif [ "xpp-daq" == "$HOSTNAME" ]; then

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -35,15 +35,11 @@ export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 export PSPKG_RELEASE=controls-0.1.9
 source $PSPKG_ROOT/etc/set_env.sh
 ulimit -c unlimited
-
 DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 PATH=$PATH:$DIR
 
-if [ "$#" -eq 0 ]; then
-    HUTCH=$(get_hutch_name)
-else
-    HUTCH=$1
-fi
+# Check hutch
+HUTCH=${1:-$(get_hutch_name)}
 
 # Run if possible
 if [[ "$HUTCH" == "unknown_hutch" ]]; then

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -15,6 +15,18 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
+# Check hutch
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$PATH:$DIR
+HUTCH=${1:-$(get_hutch_name)}
+
+# Exit if hutch is still unknown
+# TODO: Replace with check for actual hutch names
+if [[ "$HUTCH" == "unknown_hutch" ]]; then
+    echo "Unknown hutch, please specify e.g. 'iocmanager xrt'" >&2
+    exit 1
+fi
+
 # Setup environment
 if [ -x /etc/pathinit ]; then
     source /etc/pathinit
@@ -36,19 +48,8 @@ export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 export PSPKG_RELEASE=controls-0.1.9
 source $PSPKG_ROOT/etc/set_env.sh
 ulimit -c unlimited
-DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
-PATH=$PATH:$DIR
 
-# Check hutch
-HUTCH=${1:-$(get_hutch_name)}
-
-# Run if possible
-if [[ "$HUTCH" == "unknown_hutch" ]]; then
-    echo "Unknown hutch, please specify e.g. 'iocmanager xrt'" >&2
-    exit 1
-else
-    /reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/IocManager.py --hutch "${HUTCH,,}" > /dev/null &
-fi
+/reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/IocManager.py --hutch "${HUTCH,,}" > /dev/null &
 
 # Do some window cleanup for xpp
 if [ "$(whoami)" == "xppopr" ]; then

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -47,7 +47,7 @@ if [[ "$HUTCH" == "unknown_hutch" ]]; then
     echo "Unknown hutch, please specify e.g. 'iocmanager xrt'" >&2
     exit 1
 else
-    /reg/g/pcds/pyps/config/"${HUTCH}"/iocmanager/IocManager.py --hutch "$HUTCH" > /dev/null &
+    /reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/IocManager.py --hutch "${HUTCH,,}" > /dev/null &
 fi
 
 # Do some window cleanup for xpp

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -1,14 +1,15 @@
 #!/bin/bash
+
+# Define usage here for faster return
 usage()
 {
 cat << EOF
-usage: $0 [hutch]
+usage: iocmanager [hutch]
 
 Control status of all IOCs running in a particular hutch in an interactive GUI.
 Current hutch is used if not provided.
 EOF
 }
-
 if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	usage
 	exit 0

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -14,23 +14,41 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
+if [ -x /etc/pathinit ]; then
+    source /etc/pathinit
+else
+    export PSPKG_ROOT=/reg/g/pcds/pkg_mgr
+    export PYPS_ROOT=/reg/g/pcds/pyps
+    export IOC_ROOT=/reg/g/pcds/epics/ioc
+    export CAMRECORD_ROOT=/reg/g/pcds/controls/camrecord
+    export IOC_DATA=/reg/d/iocData
+    export IOC_COMMON=/reg/d/iocCommon
+fi
+export PSPKG_OS=`${PSPKG_ROOT}/etc/pspkg_os.sh`
+if [ $PSPKG_OS == rhel5 ]; then
+    echo "IocManager 2.0.0 and higher does not run on RHEL5!"
+    exit 1
+fi
+export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
+export PSPKG_RELEASE=controls-0.1.9
+source $PSPKG_ROOT/etc/set_env.sh
 ulimit -c unlimited
 
-source /reg/g/pcds/setup/pathmunge.sh
-ldpathmunge /usr/local/lib
+DIR=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+PATH=$PATH:$DIR
 
-DIRTMP=`dirname  "${BASH_SOURCE[0]}"`
-DIR="$( cd $DIRTMP && pwd -P )"
-pathmunge $DIR
-#PATH=$PATH:$DIR
-
-if [ "$#" -ne 1 ]; then
+if [ "$#" -eq 0 ]; then
     HUTCH=`get_hutch_name`
 else
     HUTCH=$1
 fi
 
-/reg/g/pcds/pyps/config/${HUTCH}/iocmanager/IocManager --hutch $HUTCH > /dev/null &
+if [[ "$HUTCH" == "unknown_hutch" ]]; then
+    echo "Unknown hutch, please specify e.g. 'iocmanager xrt'" >&2
+    exit 1
+else
+    /reg/g/pcds/pyps/config/${HUTCH}/iocmanager/IocManager.py --hutch $HUTCH > /dev/null &
+fi
 
 if [ `whoami` == "xppopr" ]; then
     window_id=`xdotool search --sync --onlyvisible --name 'IocManager'` 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add imgr
- Change iocmanager to bypass the IocManager bash script in the IocManager package

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The bash scripts to access imgr and iocmanager should exist in one place only and engineering_tools is a convenient place because it houses many other commonly used scripts and is already on most peoples's PATHs. This is the first step in moving the scripts from the iocmanager package to engineering_tools. After all hutches have adopted a new release of engineering_tools containing these scripts, I will remove the no-longer-useful bash scripts from the iocmanager package.

## How Has This Been Tested?
Interactively.
Shellcheck passes with only SC1091 messages.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Commented each section in both scripts.

<!--
## Screenshots (if appropriate):
-->