### PR TITLE
ENH: check that the path exists when registering a module/bin

### DIFF
--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -18,9 +18,9 @@ if [ -z "${1}" ]; then
   usage
   exit
 elif [ ! -e "${1}" ]; then
-  echo "Path Does Not Exist"
+  echo "Path Does Not Exist" >&2
   usage
-  exit
+  exit 1
 fi
 
 PYDEV_DIR=~/pydev

--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -17,7 +17,7 @@ fi
 if [ -z "${1}" ]; then
   usage
   exit
-elif [ ! -f "${1}" ]; then
+elif [ ! -e "${1}" ]; then
   echo "Path Does Not Exist"
   usage
   exit

--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -17,7 +17,12 @@ fi
 if [ -z "${1}" ]; then
   usage
   exit
+elif [ ! -f "${1}" ]; then
+  echo "Path Does Not Exist"
+  usage
+  exit
 fi
+
 PYDEV_DIR=~/pydev
 full_path="$(readlink -f $1)"
 if [ "${2}" == "module" ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Added a check in the if statement that verifies the module to be registered exists.

## Motivation and Context
pydev_register will currently happily allow you to register modules that don't exist.
Closes #62 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This was tested by running the script with a module that exist and does not exist and checking to see what shows up in ~/pydev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
