### PR TITLE
ENH: add ued to get_info

### DIFF
--- a/scripts/get_info
+++ b/scripts/get_info
@@ -22,7 +22,7 @@ parser.add_argument("--nfiles_for_run", help="get xtc files for run")
 parser.add_argument("--setExp", help="set experiment name")
 args = parser.parse_args()
 
-hutches=['tmo','txi','rix','xpp','xcs','mfx','cxi','mec', 'det', 'lfe','kfe','tst', 'las', 'hpl']
+hutches=['tmo','txi','rix','xpp','xcs','mfx','cxi','mec', 'ued', 'det', 'lfe','kfe','tst', 'las', 'hpl']
 foundHutch=False
 hutch=''
 
@@ -35,6 +35,7 @@ hutch_subnets={'tmo': ['28','132','133','134','135'],
                'cxi': ['26','68','69','70','71'],
                'mfx': ['24','72','73','74','75'],
                'mec': ['27','76','77','78','79'],
+               'ued': ['36'],
                'det': ['58', '59'],
                'lfe': ['88','89','90','91'],
                'kfe': ['92','93','94','95'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add an entry for UED to get_info

Here is the interface configuration on ued-daq for reference:
```
$ ifconfig
enp65s0f0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9000
        inet 172.21.36.27  netmask 255.255.255.0  broadcast 172.21.36.255
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`get_hutch_name` fails in `ued`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
zlentz@ued-daq:~/.../engineering_tools/scripts(add-ued +)$ ./get_info --gethutch
ued
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
