### PR TITLE
ENH: Changed the takepeds to automatically pick a station

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,14 @@ Stop the daq in the current hutch.
 </tr>
 
 <tr>
+    <td>takepeds</td> 
+    <td>
+usage: takepeds <br/>
+Takes a run with dark images for use in pedestals, and posts to the elog.
+    </td>
+</tr> 
+
+<tr>
     <td>wheredaq</td>
     <td>
 Discover what host is running the daq in the current hutch, if any.

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -7,6 +7,8 @@ cat << EOF
 
 Generates the background (dark) image and the noise values for each pixel, and posts to the elog.
 
+
+
 EOF
 }
 

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -3,21 +3,17 @@
 usage()
 {
 cat << EOF
-
+usage: $0
 
 Generates the background (dark) image and the noise values for each pixel, and posts to the elog.
 
-
-
 EOF
 }
-
 
 if [[($1 == "--help") || ($1 == "-h")]]; then
         usage
         exit 0
 fi
-
 
 DAQ_RELEASE=/cds/group/pcds/dist/pds/current
 

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -5,7 +5,7 @@ usage()
 cat << EOF
 usage: $0
 
-Generates the background (dark) image and the noise values for each pixel, and posts to the elog.
+Takes a run with dark images for use in pedestals, and posts to the elog.
 
 EOF
 }

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -3,7 +3,8 @@
 DAQ_RELEASE=/cds/group/pcds/dist/pds/current
 
 # -R: for norecord , -r forces recording
-$DAQ_RELEASE/tools/scanning/take_pedestals -p 0 -r
+station=$(get_info --getstation)
+$DAQ_RELEASE/tools/scanning/take_pedestals -p $station -r
 
 elogMessage="DARK"
 source pcds_conda

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+usage()
+{
+cat << EOF
+
+
+Generates the background (dark) image and the noise values for each pixel, and posts to the elog.
+
+EOF
+}
+
+
+if [[($1 == "--help") || ($1 == "-h")]]; then
+        usage
+        exit 0
+fi
+
+
 DAQ_RELEASE=/cds/group/pcds/dist/pds/current
 
 # -R: for norecord , -r forces recording


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Used  `get_info --getstation` to get the current station.
Added a usage function.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It automatically gets the station for the user as opposed to the default station 0 before.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on cxi-daq and cxi-monitor and it works fine.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added a usage fucntion in the script
<!--
## Screenshots (if appropriate):
-->
