### PR TITLE
ENH: Allow serverStat PV input from anywhere

### DIFF
--- a/scripts/get_curr_exp
+++ b/scripts/get_curr_exp
@@ -32,9 +32,8 @@ do
 	esac
 done
 
-DIRTMP=`dirname  "${BASH_SOURCE[0]}"`
-DIR="$( cd $DIRTMP && pwd -P )"
-PATH=$PATH:$DIR
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$DIR:$PATH
 
 if [ $INSTRUMENT != 'xxx' ]; then
     CURR_EXP=`get_info --hutch ${INSTRUMENT^^} --exp`

--- a/scripts/get_hutch_name
+++ b/scripts/get_hutch_name
@@ -13,9 +13,8 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-DIRTMP=`dirname  "${BASH_SOURCE[0]}"`
-DIR="$( cd $DIRTMP && pwd -P )"
-PATH=$PATH:$DIR
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$DIR:$PATH
 
 hutch=`get_info --gethutch`
 echo $hutch

--- a/scripts/get_lastRun
+++ b/scripts/get_lastRun
@@ -19,9 +19,8 @@ AskLive=0
 Ended=0
 INSTRUMENT='xxx'
 
-DIRTMP=`dirname  "${BASH_SOURCE[0]}"`
-DIR="$( cd $DIRTMP && pwd -P )"
-PATH=$PATH:$DIR
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$DIR:$PATH
 
 while getopts "H:i:le" OPTION
 do

--- a/scripts/imgr
+++ b/scripts/imgr
@@ -32,7 +32,7 @@ fi
 
 # Add engineering_tools to PATH for get_hutch_name
 DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
-PATH=$PATH:$DIR
+PATH=$DIR:$PATH
 
 # Search for hutch in args
 for (( i=1; i<=$#; i++)); do

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -17,7 +17,7 @@ fi
 
 # Check hutch
 DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
-PATH=$PATH:$DIR
+PATH=$DIR:$PATH
 HUTCH=${1:-$(get_hutch_name)}
 
 # Exit if hutch is still unknown

--- a/scripts/ioctool
+++ b/scripts/ioctool
@@ -24,7 +24,6 @@ function iocdir {
    if [[ ! $iocpath =~ ^/.* ]]; then
       iocpath=/reg/g/pcds/epics/"${iocpath}"
    fi
-
 }
 
 function ioccfg {
@@ -37,7 +36,6 @@ function ioccfg {
          exit 1
       fi
    fi
-
 }
 
 usage(){
@@ -132,8 +130,15 @@ elif [ "$CMD" == "telnet" ]; then
    echo "$HOST":"$PORT"
    telnet "$HOST" "$PORT"
 
+#################################################################
 
 elif [ "$CMD" == "host" ]; then
    iocinfo "$NAME"
    echo "$INFO" | sed -n "s/^.*host: '\(\S*\)'.*$/\1/p"
+
+#################################################################
+
+else
+   echo "Command not supported: $CMD" >&2
+   exit 1
 fi

--- a/scripts/ioctool
+++ b/scripts/ioctool
@@ -9,17 +9,20 @@ function iocfpv {
    fi
 }
 
-function iocdir {
-   ioc=$1
-   iocpath=""
-   iocpath=$(grep_ioc "$ioc" all | grep "id:'$ioc'" | sed -n "s/^.*dir: '\(\S*\)'.*$/\1/p");
-   if [[ -z $iocpath ]]; then
-      echo "Did not find ${ioc} running anywhere. Exiting..." >&2
+function iocinfo {
+   INFO=""
+   INFO=$(grep_ioc "$1" all | grep "id:'$NAME'")
+   if [ -z "$INFO" ]; then
+      echo "$1 could not be found. Exiting..." >&2
       exit 1
    fi
-   
+}
+
+function iocdir {
+   iocinfo "$1"
+   iocpath=$(echo $INFO | sed -n "s/^.*dir: '\(\S*\)'.*$/\1/p");
    if [[ ! $iocpath =~ ^/.* ]]; then
-      iocpath=/reg/g/pcds/epics/"${iocpath}"  
+      iocpath=/reg/g/pcds/epics/"${iocpath}"
    fi
 
 }
@@ -121,11 +124,7 @@ elif [ "$CMD" == "data" ]; then
 #################################################################
 
 elif [ "$CMD" == "telnet" ]; then
-   INFO=$(grep_ioc "$NAME" all | grep "id:'$NAME'")
-   if [ -z "$INFO" ]; then
-      echo "$NAME could not be found. Exiting..." >&2
-      exit 1
-   fi
+   iocinfo "$NAME"
    HOST=$(echo "$INFO" | sed -n "s/^.*host: '\(\S*\)'.*$/\1/p")
    PORT=$(echo "$INFO" | sed -n "s/^.*port: \(\S*\),.*$/\1/p")
    #if [[ 39000 >= "$PORT" >=39999 ]];
@@ -135,10 +134,6 @@ elif [ "$CMD" == "telnet" ]; then
 
 
 elif [ "$CMD" == "host" ]; then
-   INFO=$(grep_ioc "$NAME" all | grep "id:'$NAME'")
-   if [ -z "$INFO" ]; then
-      echo "$NAME could not be found. Exiting..." >&2
-      exit 1
-   fi
+   iocinfo "$NAME"
    echo "$INFO" | sed -n "s/^.*host: '\(\S*\)'.*$/\1/p"
 fi

--- a/scripts/ioctool
+++ b/scripts/ioctool
@@ -132,4 +132,13 @@ elif [ "$CMD" == "telnet" ]; then
     #  echo "Host no in subnet that connect"
    echo "$HOST":"$PORT"
    telnet "$HOST" "$PORT"
+
+
+elif [ "$CMD" == "host" ]; then
+   INFO=$(grep_ioc "$NAME" all | grep "id:'$NAME'")
+   if [ -z "$INFO" ]; then
+      echo "$NAME could not be found. Exiting..." >&2
+      exit 1
+   fi
+   echo "$INFO" | sed -n "s/^.*host: '\(\S*\)'.*$/\1/p"
 fi

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -1,8 +1,7 @@
 #! /bin/bash
 
-DIRTMP=$(dirname  "$(readlink -f "${BASH_SOURCE[0]}")")
-DIR="$( cd $DIRTMP && pwd -P )"
-PATH=$PATH:$DIR
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$DIR:$PATH
 
 usage()
 {

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -91,9 +91,8 @@ expert  : display info and run checks on server
 EOF
 }
 
-DIRTMP=$(dirname  "${BASH_SOURCE[0]}")
-DIR=$( cd "$DIRTMP" && pwd -P )
-PATH=$PATH:$DIR
+DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$DIR:$PATH
 
 HUTCH=$(get_hutch_name)
 for name in "tmo" "rix" "txi" "xpp" "xcs" "mfx" "cxi" "mec" "det"; do

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -53,21 +53,24 @@ isCam(){
 host_from_PV(){
     if [[ $NAME == *':'* ]]  && [[ $HUTCH == 'unknown_hutch' ]]; then
 	echo 'Getting info for a host of a PV currently only works on the hutch networks'
-	exit
+	exit 1
     fi
     if [[ ${NAME:0:3} == "${HUTCH^^}" ]]; then
         HOST=$(cainfo "$NAME" | grep Host | awk '{print $2}' | awk 'BEGIN { FS = ":"}; {print $1}' | sed s/'.pcdsn'/''/g)
 	if [[ $HOST == *'disconnected'* ]]; then
-	    echo PV "$NAME" is disconnected
-	    exit
+	    echo "PV $NAME is disconnected"
+	    exit 1
 	fi
-	echo PV "$NAME" is hosted on server "$HOST"
-	NAME=$HOST
-	DEV=$HOST
     else
-	echo 'Getting info for a host of a PV currently only works on the hutch network (e.g. for MFX:xxx from the mfx network)'
-	exit
+        HOST=$(ioctool $NAME host)
+        if [[ -z "$HOST" ]]; then
+            echo "Host can't be found for PV $NAME"
+            exit 1
+        fi
     fi
+    echo PV "$NAME" is hosted on server "$HOST"
+    NAME=$HOST
+    DEV=$HOST
 }
 
 usage(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Primarily changed serverStat's `host_from_PV` function so that it could be used from other hutches or no hutch. Done by calling on ioctool's new `host` option
- Added a `host` option to `ioctool`, reorganized some duplicated code, and added error message for unknown command
- Also changed `PATH` variable setting in all scripts so that current version of engineering_tools is used over other versions that might be in a user's `PATH`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves [LCLSECSD-296](https://jira.slac.stanford.edu/browse/LCLSECSD-296)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively. I believe I've tested all typical cases, but welcome additional testing.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
