### PR TITLE
camViewer start & stop acquisition

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -158,7 +158,8 @@ OPTIONS:
 -H|--hutch <hutch>  : use a specific hutches camviewer config file
 -e|--enable         : enable camera ioc
 -d|--disable        : disable camera ioc
-
+-a|--aquire         : start acquiring images
+-s|--stop           : stop acquiring images
 EOF
 }
 
@@ -179,9 +180,11 @@ REBOOT=0
 ENABLE=0
 DISABLE=0
 MAINSCREEN=0
+ACQUIRE=0
+STOP=0
 
 
-OPTIONS=$(getopt -o lmredc:w:u:H: --long list,main,reboot,enable,disable,cam:,wait:,rate:,hutch: -n \'$0\' -- "$@")
+OPTIONS=$(getopt -o lmredasc:w:u:H: --long list,main,reboot,enable,disable,acquire,stop,cam:,wait:,rate:,hutch: -n \'$0\' -- "$@")
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 
@@ -224,6 +227,14 @@ do
             ;;
         -d|--disable)
             DISABLE=1
+            shift
+            ;;
+        -a|--acquire)
+            ACQUIRE=1
+            shift
+            ;;
+        -s|--stop)
+            STOP=1
             shift
             ;;
         ?)
@@ -335,6 +346,19 @@ if [ $DISABLE -gt 0 ]; then
     imgr "$ioc" --hutch "$iochutch" --disable    
     exit
 fi
+
+if [ $ACQUIRE -gt 0 ]; then
+    echo "Acquiring images for ${CAMNAME}"
+    caput -n "$CAMPVFULL":Acquire 1
+    exit
+fi
+
+if [ $STOP -gt 0 ]; then
+    caput -n "$CAMPVFULL":Acquire 0
+    echo "Done acquiring images for ${CAMNAME}"
+    exit
+fi
+    
 
 IS_ACQUIRING=$(caget -t -n "$CAMPVFULL":Acquire_RBV)
 if isNum "$IS_ACQUIRING"; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added the options to start and stop image acquisition from the command line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves jira ticket [[LCLSECSD-381]([LCLSECSD-381](https://jira.slac.stanford.edu/browse/LCLSECSD-381))]

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested from a hutch machine using an established gigE camera

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated usage function
<!--
## Screenshots (if appropriate):
-->
