### PR TITLE
Added hutch-specific configfile, changed to use geometry_deploy_constants

### DIFF
--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -14,6 +14,12 @@ Make a pedestal file for offline use
 OPTIONS:
         -u|--user        
                user (needs to be able to log into the psananeh/feh)
+        -p|--post <text>  
+               add <text> to elog post
+        -F|--ffb
+                run job on FFB system
+        -t|--test
+                do not deploy pedestals (epix10k only)
         -r|--run         
                runnumber for pedestal
         -e|--experiment <expname> 
@@ -28,14 +34,8 @@ OPTIONS:
                make pedestals for Uxi/Icarus detector
         -j|--jungfrau3     
                make pedestals for Jungfrau - 3 run version(default only cspad/EPIX detectors)
-        -p|--post <text>  
-               add <text> to elog post
         -q|--queue <queue>
                queue for batch submisson
-        -g|--geometry <expname>
-                deploy geometry <needs experiment to take geometry from>
-        -F|--ffb
-                run job on FFB system
         -D|--xtcav_dark
                 dark run for XTCAV
         -L|--xtcav_lasingoff
@@ -58,8 +58,6 @@ OPTIONS:
                 start calibman. -r 0: show all darks, -r n: show runs (n-25) - 25
         -d|--calibdir
                 give path for alternative calibdir
-        -t|--test
-                do not deploy pedestals (epix10k only)
         -b|--nbunch
                 number of bunches for the laseroff XTCAV calculations
 EOF

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -23,8 +23,6 @@ OPTIONS:
                make pedestals for Jungfrau - 3 run version(default only cspad/EPIX detectors)
         -q|--queue <queue>
                queue for batch submisson
-        -g|--geometry <expname>
-                deploy geometry <needs experiment to take geometry from>
         -D|--xtcav_dark
                 dark run for XTCAV
         -L|--xtcav_lasingoff
@@ -135,6 +133,45 @@ xtcav_lasOff()
    exit
 }
 
+# Arg: DETECTOR class.  This could be a comma-separated list, but we're 
+# matching it in the config file as a string.
+get_config()
+{
+    awk 'BEGIN{n=0;}/'$1' \{/{n=1;next;}/\}/{n=0;next;}{if(n)print;}' <$CFGFILE >/tmp/script.$$
+    source /tmp/script.$$
+    rm /tmp/script.$$
+    #overwrite if argument is passed
+    if [ $MYNOISESIGMIN -ne -1 ]; then
+	NOISESIGMIN=$MYNOISESIGMIN
+    fi
+    if [ $MYNOISESIGMAX -ne -1 ]; then
+	NOISESIGMAX=$MYNOISESIGMAX
+    fi
+    if [ $MYADUMIN -ne -1 ]; then
+	ADUMIN=$MYADUMIN
+    fi
+    if [ $MYADUMAX -ne -1 ]; then
+	ADUMAX=$MYADUMAX
+    fi
+}
+
+# Args: Detector ID, Additional command to run.
+deploy_geometry()
+{
+    GEOPATH=`calibfile path -e $EXP -s $1 -t geometry | awk '{print $2;}' -`
+    GEODIR=`dirname $GEOPATH`
+    if [ ! -d $GEODIR ]; then
+	echo No geometry file found, deploying.
+	geometry_deploy_constants -e $EXP -r $RUN -d $1 -D -c ./calib
+	echo Geometry deployed.
+	if [ "$2" != "" ]; then
+	    echo Running additional command:
+	    echo $2
+	    $2
+	    echo Command complete.
+	fi
+    fi
+}
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]
@@ -211,11 +248,6 @@ do
 			;;
                 -v|--validity_start)
 		        VALSTR=("$2")
-			shift
-			shift
-			;;
-                -g|--geometry)
-		        GEOMETRY=("$2")
 			shift
 			shift
 			;;
@@ -297,6 +329,8 @@ if [ $EXP == 'xxx' ]; then
 else
     HUTCH=${EXP:0:3}
 fi
+
+CFGFILE=/reg/g/pcds/pyps/config/$HUTCH/makepeds.cfg
 
 if [[ $EXP == 'xxx' ]]; then
     printf "Please enter an experiment name HERE: \n"; read EXP
@@ -580,26 +614,8 @@ HAVE_JUNGFRAU=`grep Jungfrau /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
 if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 )  && ( $WANT_UXI -eq 0 ) ]]; then
     
     DETNAMES=`grep Jungfrau /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
-    if [ -v GEOMETRY ]; then
-	GEODIR=`echo /reg/d/psdm/${GEOMETRY:0:3}/$GEOMETRY/calib/`
-	SUBDIR=`ls $GEODIR | grep Jungfrau | grep -v workdir`
-	DORGNAME=`ls $GEODIR/$SUBDIR | grep Jungfrau `
-	for JUNGFRAU in $DETNAMES; do
-	    DNAME=`grep $JUNGFRAU /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | xargs`
-	    #get the latest geometry file deployed
-            ORGFILE='0-end.data'
-            if test -f $GEODIR/$SUBDIR/$DORGNAME/geometry/HISTORY; then
-    	        ORGFILE=`tail -n 1 $GEODIR/$SUBDIR/$DORGNAME/geometry/HISTORY | awk {'print$1'} | sed s/'file:'//`
-	    fi
-	    CMD=`echo calibfile deploy -t geometry -e $EXP -r 0-end -s $DNAME -f $GEODIR/$SUBDIR/$DORGNAME/geometry/$ORGFILE`
-            echo $CMD
-	    $CMD
-	    
-            echo 'Deploy the other jungfrau gain constants'
-	    jungfrau_gain_constants -d exp=${EXP}:run=${RUN} -D
-	    echo 'Deployed the other jungfrau gain constants'
- 	done
-	exit
+    for JUNGFRAU in $DETNAMES; do
+	deploy_geometry $JUNGFRAU "jungfrau_gain_constants -d exp=${EXP}:run=${RUN} -D"
     fi
 
     DSNAME='exp='$EXP':run='$RUN':smd:stream=0-79'
@@ -620,23 +636,8 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     fi
 
     #specify parameters for status bits in pixel mask
-    ADUMAX=16000
-    ADUMIN=1
-    NOISESIGMAX=16000
-    NOISESIGMIN=0.001
-    #NOISESIGMIN=1 #my script cannot deal with floats
-    if [[ $MYNOISESIGMIN -ne -1 ]]; then
-	      NOISESIGMIN=$MYNOISESIGMIN
-    fi
-    if [[ $MYNOISESIGMAX -ne -1 ]]; then
-	      NOISESIGMAX=$MYNOISESIGMAX
-    fi
-    if [[ $MYADUMIN -ne -1 ]]; then
-	      ADUMIN=$MYADUMIN
-    fi
-    if [[ $MYADUMAX -ne -1 ]]; then
-	      ADUMAX=$MYADUMAX
-    fi
+    get_config "Jungfrau"
+
     JFARG=$JFARG' --int_lo='$ADUMIN' --int_hi='$ADUMAX' --rms_lo='$NOISESIGMIN' --rms_hi='$NOISESIGMAX
 
     echo -------------------- START JUNGFRAU PEDESTALS at $(date +"%T") ----------------------------
@@ -740,41 +741,8 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
         JOBIDS=()
         NJOBS=0
     fi
-    if [ -v GEOMETRY ]; then
-	echo 'doing geometry.....DEBUG'
-	GEODIR=`echo /reg/d/psdm/${GEOMETRY:0:3}/$GEOMETRY/calib/`
-	for EPIX10K in $DETNAMES; do
-	    if ! [[ $EPIX10K =~ "2M" ]]; then
-		continue
-	    fi
-   	    SUBDIR=`ls $GEODIR | grep Epix10ka2M`
-	    DNAME=`grep $EPIX10K /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | xargs`
-	    #get the latest geometry file deployed
-            ORGFILE='0-end.data'
-            if test -f $GEODIR$SUBDIR/$DNAME/geometry/HISTORY; then
-    	        ORGFILE=`tail -n 1 $GEODIR/$SUBDIR/$DNAME/geometry/HISTORY | awk {'print$1'} | sed s/'file:'//`
-	    fi
-	    CMD=`echo calibfile deploy -t geometry -e $EXP -r 0-end -s $DNAME -f $GEODIR$SUBDIR/$DNAME/geometry/$ORGFILE`
-            echo $CMD
-	    $CMD
-	done
-	#this is so ugly - a second loop for the quad.
-	for EPIX10K in $DETNAMES; do
-	    if ! [[ $EPIX10K =~ "Quad" ]]; then
-		continue
-	    fi
-   	    SUBDIR=`ls $GEODIR | grep Epix10kaQuad`
-	    DNAME=`grep $EPIX10K /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | xargs`
-	    #get the latest geometry file deployed
-            ORGFILE='0-end.data'
-            if test -f $GEODIR$SUBDIR/$DNAME/geometry/HISTORY; then
-    	        ORGFILE=`tail -n 1 $GEODIR/$SUBDIR/$DNAME/geometry/HISTORY | awk {'print$1'} | sed s/'file:'//`
-	    fi
-	    CMD=`echo calibfile deploy -t geometry -e $EXP -r 0-end -s $DNAME -f $GEODIR$SUBDIR/$DNAME/geometry/$ORGFILE`
-            echo $CMD
-	    $CMD
-	done
-	exit
+    for EPIX10K in $DETNAMES; do
+	deploy_geometry $EPIX10K
     fi
     for EPIX10K in $DETNAMES; do
         echo Epix10ka name for $EXP is: $EPIX10K
@@ -890,7 +858,11 @@ DETS=''
 #always make pedestals if detectors are present in data
 if [[ ( $HAVE_CSPAD -ge 1) ]]; then
     DETS=`echo $DETS ' CSPAD,CSPAD2x2'`
-	
+
+    DETNAMES=`grep Cspad /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
+    for CSPAD in $DETNAMES; do
+	deploy_geometry $CSPAD
+    done
 fi
 if [[ ( $HAVE_EPIX -ge 1) ]]; then
     DETS=`echo $DETS ' Epix100a'`
@@ -939,11 +911,11 @@ if [[ ( $HAVE_RAYONIX -ge 1 ) && ( $WANT_RAYONIX -ge 1 ) ]]; then
 	DETS='Rayonix'	
     fi
     ARG=$ARG' --zeropeds'
-    #not sure if deplotgeo needs -P -D....
-    if [ -v GEOMETRY ]; then
-	calibrun -r $RUN -e $EXP -d $DETS --deploygeo -P -D
-	exit
-    fi
+    
+    DETNAMES=`grep Rayonix /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
+    for RAYONIX in $DETNAMES; do
+	deploy_geometry $RAYONIX
+    done
 fi
 
 if [[ ( $DETS == '' ) ]]; then
@@ -962,55 +934,7 @@ echo 'for the following detectors: ' $DETS
 for MYDET in $DETS; do
     #set thresholds for the detector in question
     #ADU minimum, maximum
-    if [[ ( $MYDET == 'Zyla') ]]; then
-	ADUMAX=10000
-	ADUMIN=1        
-	NOISESIGMAX=100  
-	NOISESIGMIN=1
-    elif [[ ( $MYDET == 'iStar') ]]; then
-	ADUMAX=10000
-	ADUMIN=1        
-	NOISESIGMAX=100  
-	NOISESIGMIN=1
-    elif [[ ( $MYDET == 'Opal') ]]; then
-	ADUMAX=10000
-	ADUMIN=1        
-	NOISESIGMAX=100  
-	NOISESIGMIN=1
-    elif [[ ( $MYDET == 'uxi') ]]; then
-	ADUMAX=30000
-	ADUMIN=0
-	NOISESIGMAX=1000
-	NOISESIGMIN=0
-    elif [[ ( $MYDET == 'Rayonix') ]]; then
-	ADUMAX=16000
-	ADUMIN=1        
-	NOISESIGMAX=10000  
-	NOISESIGMIN=0
-    elif [[ ( $MYDET == 'Epix100a') ]]; then
-	ADUMAX=10000
-	ADUMIN=10
-	NOISESIGMAX=7. #too loose? But this has been used.
-	NOISESIGMIN=1.5
-    else #CsPad cuts.
-	ADUMAX=10000
-	ADUMIN=10
-	NOISESIGMAX=7.
-	NOISESIGMIN=2.
-    fi
-    #overwrite if argument is passed
-    if [ $MYNOISESIGMIN -ne -1 ]; then
-	NOISESIGMIN=$MYNOISESIGMIN
-    fi
-    if [ $MYNOISESIGMAX -ne -1 ]; then
-	NOISESIGMAX=$MYNOISESIGMAX
-    fi
-    if [ $MYADUMIN -ne -1 ]; then
-	ADUMIN=$MYADUMIN
-    fi
-    if [ $MYADUMAX -ne -1 ]; then
-	ADUMAX=$MYADUMAX
-    fi
+    get_config $MYDET
 
     LOCARG=$ARG' --thr_int_min '$ADUMIN' --thr_int_max '$ADUMAX' --thr_rms_min '$NOISESIGMIN' --thr_rms '$NOISESIGMAX
     #this was likely to work with runs where the zyla rate was < readout rate....

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -54,18 +54,18 @@ check_running_jobs()
 {
     NJOBS=0
     REMJOBIDS=()
-    for JOBID in ${JOBIDS[@]}; do
-        if  squeue | grep -q $JOBID; then
-            REMJOBIDS+=( $JOBID )
-            NJOBS=$(($NJOBS+1))
+    for JOBID in "${JOBIDS[@]}"; do
+        if  squeue | grep -q "$JOBID"; then
+            REMJOBIDS+=( "$JOBID" )
+            NJOBS=$((NJOBS+1))
         fi
     done
-    if (( $NJOBS == 0 )); then
+    if (( NJOBS == 0 )); then
         echo Nothing running
         JOBIDS=''
     else
-        JOBIDS=(${REMJOBIDS[@]})
-        echo $NJOBS jobs are still running ${JOBIDS[@]}
+        JOBIDS=("${REMJOBIDS[@]}")
+        echo "$NJOBS" jobs are still running "${JOBIDS[@]}"
     fi
     return $NJOBS
 }
@@ -73,23 +73,23 @@ check_running_jobs()
 xtcav_dark()
 {
    if [[ $RUNLOCAL == 1 ]]; then
-       xtcavDark $EXP $RUN 
+       xtcavDark "$EXP" "$RUN"
    else
-       tmpScript=$(mktemp -p $WORKDIR xtcav_dark_tmpXXXXX.sh)
-       chmod u+x $tmpScript
-       printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda2/manage/bin/psconda.sh\n' > $tmpScript
-       CMD=`echo xtcavDark $EXP $RUN` 
-       printf '%s\n' "${CMD}" >> $tmpScript
-       xtcavCmd=`echo sbatch --exclusive -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript`
-       echo 'run in queue: ' $xtcavCmd
-       SUBMISSION=`$xtcavCmd`
-        echo $SUBMISSION
-       THISJOBID=`echo $SUBMISSION | awk {'print $4'}`
-       JOBIDS+=( $THISJOBID )
-       NJOBS=$(($NJOBS+1))
+       tmpScript=$(mktemp -p "$WORKDIR" xtcav_dark_tmpXXXXX.sh)
+       chmod u+x "$tmpScript"
+       printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda2/manage/bin/psconda.sh\n' > "$tmpScript"
+       CMD="xtcavDark $EXP $RUN"
+       printf '%s\n' "${CMD}" >> "$tmpScript"
+       xtcavCmd="sbatch --exclusive -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
+       echo "run in queue: $xtcavCmd"
+       SUBMISSION=$($xtcavCmd)
+       echo "$SUBMISSION"
+       THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
+       JOBIDS+=( "$THISJOBID" )
+       NJOBS=$((NJOBS+1))
 
        sleep 10
-       echo Running $NJOBS jobs are PIDS: ${JOBIDS[@]}
+       echo Running $NJOBS jobs are PIDS: "${JOBIDS[@]}"
        until check_running_jobs; do
            echo 'Checking again in 10s'
            sleep 10
@@ -107,23 +107,23 @@ xtcav_lasOff()
     #fi
 
    if [[ $RUNLOCAL == 1 ]]; then
-       xtcavLasingOff $EXP $RUN 
+       xtcavLasingOff "$EXP" "$RUN"
    else
-       tmpScript=$(mktemp -p $WORKDIR xtcav_dark_tmpXXXXX.sh)
-       chmod u+x $tmpScript
-       printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda2/manage/bin/psconda.sh\n' > $tmpScript
-       CMD=`echo xtcavLasingOff $EXP $RUN` 
-       printf '%s\n' "${CMD}" >> $tmpScript
-       xtcavCmd=`echo sbatch --exclusive -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript`
-       echo 'run in queue: ' $xtcavCmd
-       SUBMISSION=`$xtcavCmd`
-        echo $SUBMISSION
-       THISJOBID=`echo $SUBMISSION | awk {'print $4'}`
-       JOBIDS+=( $THISJOBID )
-       NJOBS=$(($NJOBS+1))
+       tmpScript=$(mktemp -p "$WORKDIR" xtcav_dark_tmpXXXXX.sh)
+       chmod u+x "$tmpScript"
+       printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda2/manage/bin/psconda.sh\n' > "$tmpScript"
+       CMD="xtcavLasingOff $EXP $RUN"
+       printf '%s\n' "${CMD}" >> "$tmpScript"
+       xtcavCmd="sbatch --exclusive -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
+       echo "run in queue: $xtcavCmd"
+       SUBMISSION=$($xtcavCmd)
+       echo "$SUBMISSION"
+       THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
+       JOBIDS+=( "$THISJOBID" )
+       NJOBS=$((NJOBS+1))
 
        sleep 20
-       echo Running $NJOBS jobs are PIDS: ${JOBIDS[@]}
+       echo Running $NJOBS jobs are PIDS: "${JOBIDS[@]}"
        until check_running_jobs; do
            echo 'Checking again in 10s'
            sleep 10
@@ -137,20 +137,20 @@ xtcav_lasOff()
 # matching it in the config file as a string.
 get_config()
 {
-    awk 'BEGIN{n=0;}/'$1' \{/{n=1;next;}/\}/{n=0;next;}{if(n)print;}' <$CFGFILE >/tmp/script.$$
+    awk 'BEGIN{n=0;}/'"$1"' \{/{n=1;next;}/\}/{n=0;next;}{if(n)print;}' <"$CFGFILE" >/tmp/script.$$
     source /tmp/script.$$
     rm /tmp/script.$$
     #overwrite if argument is passed
-    if [ $MYNOISESIGMIN -ne -1 ]; then
+    if [ "$MYNOISESIGMIN" -ne -1 ]; then
 	NOISESIGMIN=$MYNOISESIGMIN
     fi
-    if [ $MYNOISESIGMAX -ne -1 ]; then
+    if [ "$MYNOISESIGMAX" -ne -1 ]; then
 	NOISESIGMAX=$MYNOISESIGMAX
     fi
-    if [ $MYADUMIN -ne -1 ]; then
+    if [ "$MYADUMIN" -ne -1 ]; then
 	ADUMIN=$MYADUMIN
     fi
-    if [ $MYADUMAX -ne -1 ]; then
+    if [ "$MYADUMAX" -ne -1 ]; then
 	ADUMAX=$MYADUMAX
     fi
 }
@@ -158,15 +158,15 @@ get_config()
 # Args: Detector ID, Additional command to run.
 deploy_geometry()
 {
-    GEOPATH=`calibfile path -e $EXP -s $1 -t geometry | awk '{print $2;}' -`
-    GEODIR=`dirname $GEOPATH`
-    if [ ! -d $GEODIR ]; then
+    GEOPATH=$(calibfile path -e "$EXP" -s "$1" -t geometry | awk '{print $2;}' -)
+    GEODIR=$(dirname "$GEOPATH")
+    if [ ! -d "$GEODIR" ]; then
 	echo No geometry file found, deploying.
-	geometry_deploy_constants -e $EXP -r $RUN -d $1 -D
+	geometry_deploy_constants -e "$EXP" -r "$RUN" -d "$1" -D
 	echo Geometry deployed.
 	if [ "$2" != "" ]; then
 	    echo Running additional command:
-	    echo $2
+	    echo "$2"
 	    $2
 	    echo Command complete.
 	fi
@@ -271,12 +271,12 @@ do
 			shift
 			;;
                 -m|--adu_min)
-		        MYADMIN=("$2")
+		        MYADUMIN=("$2")
 			shift
 			shift
 			;;
                 -x|--adu_max)
-		        MYADMAX=("$2")
+		        MYADUMAX=("$2")
 			shift
 			shift
 			;;
@@ -295,7 +295,7 @@ set -- "${POSITIONAL[@]}"
 
 
 T="$(date +%s%N)"
-echo XXXXXXXXXXXXXXXXX START MAKEPEDS DEV at $(date +"%T") on $HOSTNAME XXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo "XXXXXXXXXXXXXXXXX START MAKEPEDS DEV at $(date +'%T') on $HOSTNAME XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 RUN=${RUN:=0}
 EXP=${EXP:='xxx'}
@@ -315,16 +315,16 @@ NUMBUNCH=${NUMBUNCH:=1}
 
 if [ $RUN == 0 ]; then
     if [ $INTERACTIVE -ne 1 ]; then
-	printf "Please enter a run number HERE: \n"; read RUN
+	printf "Please enter a run number HERE: \n"; read -r RUN
     fi
 fi
 
 if [ $EXP == 'xxx' ]; then
     echo 'no experiment passed!!!'
-    HUTCH=`/reg/g/pcds/engineering_tools/latest-released/scripts/get_info --gethutch`
-    echo HUTCH $HUTCH
-    if [[ $HUTCH != 'unknown_hutch' ]]; then
-        EXP=`/reg/g/pcds/engineering_tools/latest-released/scripts/get_info --exp --hutch $HUTCH`
+    HUTCH=$(/reg/g/pcds/engineering_tools/latest-released/scripts/get_info --gethutch)
+    echo HUTCH "$HUTCH"
+    if [[ "$HUTCH" != 'unknown_hutch' ]]; then
+        EXP=$(/reg/g/pcds/engineering_tools/latest-released/scripts/get_info --exp --hutch "$HUTCH")
     fi
 else
     HUTCH=${EXP:0:3}
@@ -333,13 +333,13 @@ fi
 CFGFILE=/reg/g/pcds/pyps/config/$HUTCH/makepeds.cfg
 
 if [[ $EXP == 'xxx' ]]; then
-    printf "Please enter an experiment name HERE: \n"; read EXP
+    printf "Please enter an experiment name HERE: \n"; read -r EXP
 fi
 
 # set the umask so all the files create are group writeable
 #umask 002
 LCLS2_HUTCHES="rix, tmo, ued"
-if echo $LCLS2_HUTCHES | grep -iw $HUTCH > /dev/null; then
+if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
     echo "This is a LCLS-II experiment"
     source /cds/sw/ds/ana/conda2/manage/bin/psconda.sh
     LCLS2=1
@@ -373,29 +373,29 @@ else
     fi
 fi
 WORKDIR=$CALIBDIR/pedestal_workdir
-if [ ! -d $WORKDIR ]; then
-    if [ -d $CALIBDIR ]; then
-	mkdir -p $WORKDIR
-	if [ ! -d $WORKDIR ]; then
-	    #inexp=`groups | grep $EXP | wc -l`
-	    #inhutch=`groups | grep ps-$HUTCH | wc -l`
+if [ ! -d "$WORKDIR" ]; then
+    if [ -d "$CALIBDIR" ]; then
+	mkdir -p "$WORKDIR"
+	if [ ! -d "$WORKDIR" ]; then
+	    #inexp=$(groups | grep -c $EXP)
+	    #inhutch=$(groups | grep -c ps-$HUTCH)
 	    #if [[ ( $inexp -gt 0 ) ||  ( $inhutch -gt 1 )]]; then
 	    echo 'Cannot create typical directory to store calib logfiles & results is not writeable, will attempt to work from /tmp, but things may fail'
-            $WORKDIR = '/tmp'
+            WORKDIR='/tmp'
 	fi
 	#else
 	#    echo 'not member of experiment '$EXP' of ps-'$HUTCH' group, QUIT!'
 	#fi
     else
-	echo 'experiments directory '$DIR' does not exist, quit'
+	echo "experiments directory $DIR does not exist, quit"
 	exit
     fi
 fi
-if [ ! -w $WORKDIR ]; then
+if [ ! -w "$WORKDIR" ]; then
     echo 'Typical directory to store calib logfiles & results is not writeable, will attempt to work from /tmp, but things may fail'
-    $WORKDIR = '/tmp'
+    WORKDIR='/tmp'
 fi 
-cd $WORKDIR
+cd "$WORKDIR"
 
 ######################
 # work on the XTCAV
@@ -440,31 +440,31 @@ if [ $DEPLOY == 1 ]; then
 fi
 
 
-CREATE_TIME=`date '+%m_%d_%Y_%H:%M:%S'`
-printf -v RUNSTR "%04g" $RUN
+CREATE_TIME=$(date '+%m_%d_%Y_%H:%M:%S')
+printf -v RUNSTR "%04g" "$RUN"
 
 if [[ $HOSTNAME =~ "drp-srcf" ]]; then
     echo check FFB files: 
-    ls -ltr /cds/data/drpsrcf/$HUTCH/$EXP/xtc/*r$RUNSTR*s*xtc*
+    ls -ltr /cds/data/drpsrcf/"$HUTCH"/"$EXP"/xtc/*r"$RUNSTR"*s*xtc*
     if [[ $LCLS2 -gt 0 ]]; then
-        detnames -r exp=${EXP},run=${RUN},dir=/cds/data/drpsrcf/$HUTCH/$EXP/xtc > /tmp/detnames_$EXP\_$CREATE_TIME
+        detnames -r exp="${EXP}",run="${RUN}",dir=/cds/data/drpsrcf/"$HUTCH"/"$EXP"/xtc > /tmp/detnames_"$EXP"_"$CREATE_TIME"
     else
-        detnames exp=${EXP}:run=${RUN}:dir=/cds/data/drpsrcf/$HUTCH/$EXP/xtc:stream=0-79 > /tmp/detnames_$EXP\_$CREATE_TIME
+        detnames exp="${EXP}":run="${RUN}":dir=/cds/data/drpsrcf/"$HUTCH"/"$EXP"/xtc:stream=0-79 > /tmp/detnames_"$EXP"_"$CREATE_TIME"
     fi
 else
     echo Process offline files: 
-    ls -ltr /reg/d/psdm/$HUTCH/$EXP/xtc/*r*$RUNSTR*s*xtc*
-    if [[ $LCLS2 -gt 0 ]]; then
-        detnames -r exp=${EXP},run=${RUN} > /tmp/detnames_$EXP\_$CREATE_TIME
+    ls -ltr /reg/d/psdm/"$HUTCH"/"$EXP"/xtc/*r*"$RUNSTR"*s*xtc*
+    if [[ "$LCLS2" -gt 0 ]]; then
+        detnames -r exp="${EXP}",run="${RUN}" > /tmp/detnames_"$EXP"_"$CREATE_TIME"
     else
-        detnames exp=${EXP}:run=${RUN}:stream=0-79 > /tmp/detnames_$EXP\_$CREATE_TIME
+        detnames exp="${EXP}":run="${RUN}":stream=0-79 > /tmp/detnames_"$EXP"_"$CREATE_TIME"
     fi
 fi
 #running local
-echo -----------------------
+echo "-----------------------"
 echo 'XTC files contain:'
-cat /tmp/detnames_$EXP\_$CREATE_TIME
-echo -----------------------
+cat /tmp/detnames_"$EXP"_"$CREATE_TIME"
+echo "-----------------------"
 
 #### 
 # Section for LCLS2 detectors.
@@ -474,19 +474,19 @@ if [[ $LCLS2 -gt 0 ]]; then
     # epix100 in LCLS2 related stuff. 
     ####
     #check if epix100 detectors are present
-    HAVE_EPIX100=`grep epix100 /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
+    HAVE_EPIX100=$(grep -c epix100 /tmp/detnames_"$EXP"_"$CREATE_TIME")
     if [[ $HAVE_EPIX100 -ge 1 ]]; then
-        DETNAMES=`grep epix100 /tmp/detnames_$EXP\_$CREATE_TIME | grep raw | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
-        DETTYPES=`grep epix100 /tmp/detnames_$EXP\_$CREATE_TIME | grep raw | awk  'BEGIN { FS = "|"}; {print $2}' | paste -d " " -s`
+        DETNAMES=$(grep epix100 /tmp/detnames_"$EXP"_"$CREATE_TIME" | grep raw | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
+        DETTYPES=$(grep epix100 /tmp/detnames_"$EXP"_"$CREATE_TIME" | grep raw | awk  'BEGIN { FS = "|"}; {print $2}' | paste -d " " -s)
         for i in "${!DETNAMES[@]}"; do
 	    LOCARG='' #optional cuts, I suspect this will not be developed for LV17.
 	    MYDET=${DETNAMES[i]}
 	    MYDETTYPE=${DETTYPES[i]}
-	    echo $MYDETTYPE $MYDET
-	    if [ $MYDETTYPE = 'epix100' ]; then
+	    echo "$MYDETTYPE" "$MYDET"
+	    if [ "$MYDETTYPE" = 'epix100' ]; then
                 echo 'now calibrate...'
-                cmd=`echo det_dark_proc -r $RUN  -d $MYDET -D -e $EXP $LOCARG`
-        	echo $cmd
+                cmd="det_dark_proc -r $RUN -d $MYDET -D -e $EXP $LOCARG"
+        	echo "$cmd"
     	        #$cmd
             fi
         done
@@ -494,50 +494,50 @@ if [[ $LCLS2 -gt 0 ]]; then
     ####
     # epixquad for UED
     ####
-    HAVE_EPIX10K=`grep epix10ka /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
+    HAVE_EPIX10K=$(grep -c epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME")
     if [[ $HAVE_EPIX10K -ge 1 ]]; then
-        DETNAMES=`grep epix10ka /tmp/detnames_$EXP\_$CREATE_TIME | grep raw | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
-        DETTYPES=`grep epix10ka /tmp/detnames_$EXP\_$CREATE_TIME | grep raw | awk  'BEGIN { FS = "|"}; {print $2}' | paste -d " " -s`
+        DETNAMES=$(grep epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME" | grep raw | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
+        DETTYPES=$(grep epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME" | grep raw | awk  'BEGIN { FS = "|"}; {print $2}' | paste -d " " -s)
         for i in "${!DETNAMES[@]}"; do
 	    LOCARG='' #optional cuts, I suspect this will not be developed for LV17.
-	    EPIX10K=$(sed "s/ //g" <<< ${DETNAMES[i]})
+	    EPIX10K="${DETNAMES[i]// /}"
 	    MYDETTYPE=${DETTYPES[i]}
-	    if [ $MYDETTYPE = 'epix10ka' ]; then
-                echo Epix10ka name for $EXP is: $EPIX10K
+	    if [ "$MYDETTYPE" = 'epix10ka' ]; then
+                echo "Epix10ka name for $EXP is: $EPIX10K"
                 ##run all at once - do not use
       	        #Do not use workdir as you'd need to run the full charge injection run there for this to work
 	        #revisit when we run into permission problems.
     	        for calibcycle in {0..4}; do
-                    nextcycle=$(( $calibcycle + 1 ))
-		    CMD=`echo epix10ka_pedestals_calibration -d $EPIX10K -e $EXP -r $RUN --stepnum $calibcycle --stepmax $nextcycle -L INFO`
+                    nextcycle=$(( calibcycle + 1 ))
+		    CMD="epix10ka_pedestals_calibration -d $EPIX10K -e $EXP -r $RUN --stepnum $calibcycle --stepmax $nextcycle -L INFO"
 		    if [[ $HOSTNAME =~ "drp-srcf" ]]; then
    		        CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc'
                     fi
-    	            echo ---------------EPIX10K PEDESTALS FOR CYCLE $calibcycle --------------------
+    	            echo "---------------EPIX10K PEDESTALS FOR CYCLE $calibcycle --------------------"
                     if [[ $RUNLOCAL != 1 ]]; then
                         tmpScript=$(mktemp -p $WORKDIR epix10ka_pedestals_tmpXXXXX.sh)
                         #trap "rm -f $tmpScript" EXIT
-                        chmod u+x $tmpScript
-                        printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda2/manage/bin/psconda.sh\n' > $tmpScript
-                        printf '%s\n' "${CMD}" >> $tmpScript
-                        ep10kaCmd=`echo sbatch --exclusive -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript`
-                        echo 'run in queue: ' $ep10kaCmd
-                        SUBMISSION=`$ep10kaCmd`
-                        echo $SUBMISSION
-                        THISJOBID=`echo $SUBMISSION | awk {'print $4'}`
-                        JOBIDS+=( $THISJOBID )
-                        NJOBS=$(($NJOBS+1))
+                        chmod u+x "$tmpScript"
+                        printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda2/manage/bin/psconda.sh\n' > "$tmpScript"
+                        printf '%s\n' "${CMD}" >> "$tmpScript"
+                        ep10kaCmd="sbatch --exclusive -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
+                        echo "run in queue: $ep10kaCmd"
+                        SUBMISSION=$($ep10kaCmd)
+                        echo "$SUBMISSION"
+                        THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
+                        JOBIDS+=( "$THISJOBID" )
+                        NJOBS=$((NJOBS+1))
                     else            
-                        echo $CMD
+                        echo "$cmd"
                         $CMD
                     fi
                 done
-	        ALLJOBIDS=${JOBIDS[@]}
+	        ALLJOBIDS=("${JOBIDS[@]}")
             fi
             if [[ $RUNLOCAL != 1 ]]; then
 	        echo 'Wait for 1 minute before checking jobs:'
                 sleep 60
-                echo Running $NJOBS jobs are PIDS: ${JOBIDS[@]}
+                echo Running "$NJOBS" jobs are PIDS: "${JOBIDS[@]}"
                 until check_running_jobs; do
                     echo 'Checking again in 10s'
                     sleep 10
@@ -547,28 +547,28 @@ if [[ $LCLS2 -gt 0 ]]; then
                 # currently, the epix10k jobs print DONE at the end. 
                 # Second check necessary as jobs can fail without printing an exit code to the logfile
    	        NFAILEDJOBS=0
-	        for JOBID in ${ALLJOBIDS[@]}; do
-	            echo 'Checking job '$JOBID
-	            if grep -q 'exit code' $WORKDIR/*$JOBID.out; then
-		        NFAILEDJOBS=$(($NFAILEDJOBS+1))
-	            elif ! grep -q 'DONE' $WORKDIR/*$JOBID.out; then
-		        NFAILEDJOBS=$(($NFAILEDJOBS+1))
+	        for JOBID in "${ALLJOBIDS[@]}"; do
+	            echo "Checking job $JOBID"
+	            if grep -q 'exit code' "$WORKDIR"/*"$JOBID".out; then
+		        NFAILEDJOBS=$((NFAILEDJOBS+1))
+	            elif ! grep -q 'DONE' "$WORKDIR"/*"$JOBID".out; then
+		        NFAILEDJOBS=$((NFAILEDJOBS+1))
 	            fi
 	        done
 	
             fi
 
-            echo ---------------EPIX10K PEDESTALS CALCULATED NOW DEPLOY     --------------------
+            echo "---------------EPIX10K PEDESTALS CALCULATED NOW DEPLOY     --------------------"
             if [ $DEPLOY == 1 ]; then
 	        if [ $NFAILEDJOBS -gt 0 ]; then
-	            read -p "$NFAILEDJOBS of the calibration tasks failed, do you want to continue anyways (y/n)?"
+	            read -r -p "$NFAILEDJOBS of the calibration tasks failed, do you want to continue anyways (y/n)?"
 	            if [ "$REPLY" != "y" ];then
 		        exit 1
 	            fi
 	        fi
 
                 for EPIX10K in $DETNAMES; do
-                    CMD=`echo epix10ka_deploy_constants -D -d $EPIX10K -e $EXP -r $RUN -L INFO`
+                    CMD="epix10ka_deploy_constants -D -d $EPIX10K -e $EXP -r $RUN -L INFO"
 		    if [[ $HOSTNAME =~ "drp-srcf" ]]; then
    		        CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc'
                     fi
@@ -576,30 +576,30 @@ if [[ $LCLS2 -gt 0 ]]; then
                     if [ $VALSTR != 'xxx' ]; then
                         CMD=$CMD' -t '$VALSTR
                     fi
-                    echo $CMD
+                    echo "$cmd"
                     $CMD
                 done
                 if [[ $RUNLOCAL != 1 ]]; then
     	            echo 'Print Information about batch jobs'
 	            JOBIDSTR=''
-    	            for JOBID in ${ALLJOBIDS[@]}; do
+    	            for JOBID in "${ALLJOBIDS[@]}"; do
 		        if [[ $JOBIDSTR != '' ]]; then 
  		            JOBIDSTR=$JOBIDSTR','
 		        fi
 		        JOBIDSTR=$JOBIDSTR$JOBID
 	            done
-	            sacct -j $JOBIDSTR --format=JobID,AveCPU,AveVMSize,CPUTime,Start,End,Elapsed
+	            sacct -j "$JOBIDSTR" --format=JobID,AveCPU,AveVMSize,CPUTime,Start,End,Elapsed
                 fi
             fi
         done
-        echo -------------------- STOP EPIX10K PEDESTALS at $(date +"%T") ----------------------------
+        echo "-------------------- STOP EPIX10K PEDESTALS at $(date +'%T') ----------------------------"
     fi
 
-    rm /tmp/detnames_$EXP\_$CREATE_TIME
+    rm /tmp/detnames_"$EXP"_"$CREATE_TIME"
     T2="$(($(date +%s%N)-T))"
     S="$((T2/1000000000))"
     M="$((T2/1000000))"
-    echo xxxxxxxxxxxxxxxxx END LCLS2 MAKEPEDS at $(date +"%T") after  '$S'.'$M' XXXXXXXXXXXXXXXXXXXXXXX
+    echo "xxxxxxxxxxxxxxxxx END LCLS2 MAKEPEDS at $(date +'%T') after  $S.$M XXXXXXXXXXXXXXXXXXXXXXX"
     exit
 fi
 
@@ -609,21 +609,21 @@ fi
 # Jungfrau related stuff. Different executable w/ different options. Ack.
 ###
 #check if jungfrau detectors are present
-HAVE_JUNGFRAU=`grep Jungfrau /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-#HAVE_JUNGFRAU=`detnames exp=${EXP}:run=${RUN} | grep Jungfrau | wc -l`
+HAVE_JUNGFRAU=$(grep -c Jungfrau /tmp/detnames_"$EXP"_"$CREATE_TIME")
+#HAVE_JUNGFRAU=$(detnames exp=${EXP}:run=${RUN} | grep Jungfrau | wc -l)
 if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 )  && ( $WANT_UXI -eq 0 ) ]]; then
     
-    DETNAMES=`grep Jungfrau /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
+    DETNAMES=$(grep Jungfrau /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
     for JUNGFRAU in $DETNAMES; do
-	deploy_geometry $JUNGFRAU "jungfrau_gain_constants -d exp=${EXP}:run=${RUN} -D"
+	deploy_geometry "$JUNGFRAU" "jungfrau_gain_constants -d exp=${EXP}:run=${RUN} -D"
     done
 
     DSNAME='exp='$EXP':run='$RUN':smd:stream=0-79'
     if [ -v OLD_JUNGFRAU ]; then
 	#get the dataset name
-	let RUN1=RUN+1
-	let RUN2=RUN+2
-	DSNAME='exp='$EXP':run='$RUN','$RUN1','$RUN2':smd:stream=0-79'
+	(( RUN1=RUN+1 ))
+	(( RUN2=RUN+2 ))
+	DSNAME="exp=$EXP:run=$RUN,$RUN1,$RUN2:smd:stream=0-79"
     fi
     if [[ $HOSTNAME =~ "drp-srcf" ]]; then
 	DSNAME=$DSNAME':dir=/cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/'
@@ -640,7 +640,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
 
     JFARG=$JFARG' --int_lo='$ADUMIN' --int_hi='$ADUMAX' --rms_lo='$NOISESIGMIN' --rms_hi='$NOISESIGMAX
 
-    echo -------------------- START JUNGFRAU PEDESTALS at $(date +"%T") ----------------------------
+    echo "-------------------- START JUNGFRAU PEDESTALS at $(date +'%T') ----------------------------"
 
     if [[ $RUNLOCAL != 1 ]]; then
         JOBIDS=()
@@ -648,8 +648,8 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     fi
  
     for JUNGFRAU in $DETNAMES; do
-	echo jungfrau loop $JUNGFRAU  -- $RUNLOCAL
-        CMD=`echo jungfrau_dark_proc $JFARG -s $JUNGFRAU`
+	echo "jungfrau loop $JUNGFRAU  -- $RUNLOCAL"
+        CMD="jungfrau_dark_proc $JFARG -s $JUNGFRAU"
         #now finally call the command
    	for calibcycle in {0..2}; do
             if [ -v OLD_JUNGFRAU ]; then
@@ -660,31 +660,31 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
             if [[ $RUNLOCAL != 1 ]]; then
                 tmpScript=$(mktemp -p $WORKDIR jungfrau_multi_tmpXXXXX.sh)
                 #trap "rm -f $tmpScript" EXIT
-                chmod u+x $tmpScript
-                printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda1/manage/bin/psconda.sh\n' > $tmpScript
-                printf '%s\n' "${CMDC}" >> $tmpScript
-                jfCmd=`echo sbatch --exclusive -p $QUEUE -o $WORKDIR/jungfrau_${EXP}_RUN${RUN}_%J.out $tmpScript`
-                echo 'run in queue: ' $jfCmd
-                SUBMISSION=`$jfCmd`
-                echo $SUBMISSION
-                THISJOBID=`echo $SUBMISSION | awk {'print $4'}`
-                JOBIDS+=( $THISJOBID )
-                NJOBS=$(($NJOBS+1))
+                chmod u+x "$tmpScript"
+                printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda1/manage/bin/psconda.sh\n' > "$tmpScript"
+                printf '%s\n' "${CMDC}" >> "$tmpScript"
+                jfCmd="sbatch --exclusive -p $QUEUE -o $WORKDIR/jungfrau_${EXP}_RUN${RUN}_%J.out $tmpScript"
+                echo "run in queue: $jfCmd"
+                SUBMISSION=$($jfCmd)
+                echo "$SUBMISSION"
+                THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
+                JOBIDS+=( "$THISJOBID" )
+                NJOBS=$((NJOBS+1))
 	    else
-                echo $CMDC
+                echo "$cmd"C
                 $CMDC
             fi
             if [ -v OLD_JUNGFRAU ]; then
        	        break
 	    fi
         done
-	ALLJOBIDS=${JOBIDS[@]}
+	ALLJOBIDS=("${JOBIDS[@]}")
     done
 
     if [[ $RUNLOCAL != 1 ]]; then
 	echo 'Wait for 1/2 minutes before checking jobs:'
         sleep 30
-        echo Running $NJOBS jobs are PIDS: ${JOBIDS[@]}
+	echo Running $NJOBS jobs are PIDS: "${JOBIDS[@]}"
         until check_running_jobs; do
                 echo 'Checking again in 10s'
                 sleep 10
@@ -692,10 +692,10 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
         echo 'All jobs finished'
 	# and now check that none of the jobs have existed with an error code:
 	NFAILEDJOBS=0
-	for JOBID in ${ALLJOBIDS[@]}; do
-	    echo 'Checking job '$JOBID
-	    if grep -q 'exit code' $WORKDIR/*$JOBID.out; then
-		NFAILEDJOBS=$(($NFAILEDJOBS+1))
+	for JOBID in "${ALLJOBIDS[@]}"; do
+	    echo "Checking job $JOBID"
+	    if grep -q 'exit code' "$WORKDIR"/*"$JOBID".out; then
+		NFAILEDJOBS=$((NFAILEDJOBS+1))
 	    fi
 	done
     fi
@@ -703,14 +703,14 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     #Now deploy.
     if [ $DEPLOY == 1 ]; then
 	if [ $NFAILEDJOBS -gt 0 ]; then
-	    read -p "$NFAILEDJOBS of the calibration tasks failed, do you want to quit here (y/n)"
+	    read -r -p "$NFAILEDJOBS of the calibration tasks failed, do you want to quit here (y/n)"
 	    if [ "$REPLY" != "y" ];then
 		exit 1
 	    fi
 	fi
         for JUNGFRAU in $DETNAMES; do
 	    #this is also where -t should be used, just as for the validity range
-            CMD=`echo jungfrau_deploy_constants -D -d $JUNGFRAU -e $EXP -r $RUN`
+            CMD="jungfrau_deploy_constants -D -d $JUNGFRAU -e $EXP -r $RUN"
             if [ $VALSTR != 'xxx' ]; then
 	       # this does not work before ana-.....	
                #CMD=$CMD' -t '$VALSTR'-end'
@@ -720,67 +720,67 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
 	        CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/'
             fi   
 
-            echo $CMD
+            echo "$cmd"
             $CMD
         done
     fi
 
-    ls -l /reg/d/psdm/${EXP:0:3}/$EXP/calib/J*/*/pedestals/*$RUN*data
-    echo -------------------- END JUNGFRAU PEDESTALS at $(date +"%T") ----------------------------
+    ls -l /reg/d/psdm/"$EXP:0:3}"/"$EXP"/calib/J*/*/pedestals/*"$RUN"*data
+    echo "-------------------- END JUNGFRAU PEDESTALS at $(date +'%T') ----------------------------"
 fi
 
 ####
 # epix10k related stuff. Different executable w/ different options. Ack.
 ###
 #check if epix10k detectors are present
-HAVE_EPIX10K=`grep Epix10ka /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
+HAVE_EPIX10K=$(grep -c Epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME")
 if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 ) && ( $WANT_UXI -eq 0 ) ]]; then
-    echo -------------------- START EPIX10K PEDESTALS at $(date +"%T") ----------------------------
-    DETNAMES=`grep Epix10ka /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $2}' | paste -d " " -s`
+    echo "-------------------- START EPIX10K PEDESTALS at $(date +'%T') ----------------------------"
+    DETNAMES=$(grep Epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $2}' | paste -d " " -s)
     if [[ $RUNLOCAL -ne 1 ]]; then
         JOBIDS=()
         NJOBS=0
     fi
     for EPIX10K in $DETNAMES; do
-	deploy_geometry $EPIX10K
+	deploy_geometry "$EPIX10K"
     done
     for EPIX10K in $DETNAMES; do
-        echo Epix10ka name for $EXP is: $EPIX10K
+        echo "Epix10ka name for $EXP is: $EPIX10K"
         ##run all at once - do not use
 	#Do not use workdir as you'd need to run the full charge injection run there for this to work
 	#revisit when we run into permission problems.
 
 	for calibcycle in {0..4}; do
             if [[ $HOSTNAME =~ "drp-srcf" ]]; then
-		CMD=`echo epix10ka_pedestals_calibration -d $EPIX10K -e $EXP -r $RUN -c $calibcycle -x /cds/data/drpsrcf/$HUTCH/$EXP/xtc/:live:stream=0-79 -L INFO`
+		CMD="epix10ka_pedestals_calibration -d $EPIX10K -e $EXP -r $RUN -c $calibcycle -x /cds/data/drpsrcf/$HUTCH/$EXP/xtc/:live:stream=0-79 -L INFO"
 	    else 
-		CMD=`echo epix10ka_pedestals_calibration -d $EPIX10K -e $EXP -r $RUN -c $calibcycle -L INFO`
+		CMD="epix10ka_pedestals_calibration -d $EPIX10K -e $EXP -r $RUN -c $calibcycle -L INFO"
 	    fi
-    	    echo ---------------EPIX10K PEDESTALS FOR CYCLE $calibcycle --------------------
+   	    echo "---------------EPIX10K PEDESTALS FOR CYCLE $calibcycle --------------------"
             if [[ $RUNLOCAL != 1 ]]; then
                 tmpScript=$(mktemp -p $WORKDIR epix10ka_pedestals_tmpXXXXX.sh)
                 #trap "rm -f $tmpScript" EXIT
-                chmod u+x $tmpScript
-                printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda1/manage/bin/psconda.sh\n' > $tmpScript
-                printf '%s\n' "${CMD}" >> $tmpScript
-                ep10kaCmd=`echo sbatch --exclusive -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript`
-                echo 'run in queue: ' $ep10kaCmd
-                SUBMISSION=`$ep10kaCmd`
-                echo $SUBMISSION
-                THISJOBID=`echo $SUBMISSION | awk {'print $4'}`
-                JOBIDS+=( $THISJOBID )
-                NJOBS=$(($NJOBS+1))
+                chmod u+x "$tmpScript"
+                printf '#!/bin/bash\nsource /cds/sw/ds/ana/conda1/manage/bin/psconda.sh\n' > "$tmpScript"
+                printf '%s\n' "${CMD}" >> "$tmpScript"
+                ep10kaCmd="sbatch --exclusive -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
+                echo "run in queue: $ep10kaCmd"
+                SUBMISSION=$($ep10kaCmd)
+                echo "$SUBMISSION"
+                THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
+                JOBIDS+=( "$THISJOBID" )
+                NJOBS=$((NJOBS+1))
             else            
-                echo $CMD
+                echo "$CMD"
                 $CMD
             fi
         done
-	ALLJOBIDS=${JOBIDS[@]}
+	ALLJOBIDS=("${JOBIDS[@]}")
     done
     if [[ $RUNLOCAL != 1 ]]; then
 	echo 'Wait for 1 minute before checking jobs:'
         sleep 60
-        echo Running $NJOBS jobs are PIDS: ${JOBIDS[@]}
+	echo Running $NJOBS jobs are PIDS: "${JOBIDS[@]}"
         until check_running_jobs; do
                 echo 'Checking again in 10s'
                 sleep 10
@@ -790,21 +790,21 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
         # currently, the epix10k jobs print DONE at the end. 
 # Second check necessary as jobs can fail without printing an exit code to the logfile
 	NFAILEDJOBS=0
-	for JOBID in ${ALLJOBIDS[@]}; do
-	    echo 'Checking job '$JOBID
-	    if grep -q 'exit code' $WORKDIR/*$JOBID.out; then
-		NFAILEDJOBS=$(($NFAILEDJOBS+1))
-	    elif ! grep -q 'DONE' $WORKDIR/*$JOBID.out; then
-		NFAILEDJOBS=$(($NFAILEDJOBS+1))
+	for JOBID in "${ALLJOBIDS[@]}"; do
+	    echo "Checking job $JOBID"
+	    if grep -q 'exit code' "$WORKDIR"/*"$JOBID".out; then
+		NFAILEDJOBS=$((NFAILEDJOBS+1))
+	    elif ! grep -q 'DONE' "$WORKDIR"/*"$JOBID".out; then
+		NFAILEDJOBS=$((NFAILEDJOBS+1))
 	    fi
 	done
 	
     fi
 
-    echo ---------------EPIX10K PEDESTALS CALCULATED NOW DEPLOY     --------------------
+    echo "---------------EPIX10K PEDESTALS CALCULATED NOW DEPLOY     --------------------"
     if [ $DEPLOY == 1 ]; then
 	if [ $NFAILEDJOBS -gt 0 ]; then
-	    read -p "$NFAILEDJOBS of the calibration tasks failed, do you want to continue anyways (y/n)?"
+	    read -r -p "$NFAILEDJOBS of the calibration tasks failed, do you want to continue anyways (y/n)?"
 	    if [ "$REPLY" != "y" ];then
 		exit 1
 	    fi
@@ -812,7 +812,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
 
 
         for EPIX10K in $DETNAMES; do
-            CMD=`echo epix10ka_deploy_constants -D -d $EPIX10K -e $EXP -r $RUN -L INFO`
+            CMD="epix10ka_deploy_constants -D -d $EPIX10K -e $EXP -r $RUN -L INFO"
 	    echo 'setting validity....' $VALSTR
             if [ $VALSTR != 'xxx' ]; then
                 CMD=$CMD' -t '$VALSTR
@@ -820,22 +820,22 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
             if [[ $HOSTNAME =~ "drp-srcf" ]]; then
                 CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/:stream=0-79'
 	    fi
-            echo $CMD
+            echo "$CMD"
             $CMD
         done
         if [[ $RUNLOCAL != 1 ]]; then
     	    echo 'Print Information about batch jobs'
 	    JOBIDSTR=''
-    	    for JOBID in ${ALLJOBIDS[@]}; do
+    	    for JOBID in "${ALLJOBIDS[@]}"; do
 		if [[ $JOBIDSTR != '' ]]; then 
  		    JOBIDSTR=$JOBIDSTR','
 		fi
 		JOBIDSTR=$JOBIDSTR$JOBID
 	    done
-	    sacct -j $JOBIDSTR --format=JobID,AveCPU,AveVMSize,CPUTime,Start,End,Elapsed
+	    sacct -j "$JOBIDSTR" --format=JobID,AveCPU,AveVMSize,CPUTime,Start,End,Elapsed
         fi
     fi
-    echo -------------------- STOP EPIX10K PEDESTALS at $(date +"%T") ----------------------------
+    echo "-------------------- STOP EPIX10K PEDESTALS at $(date +'%T') ----------------------------"
 fi
 
 ###########
@@ -843,35 +843,35 @@ fi
 ###########
 
 #check if detectors are present    
-HAVE_EPIX=`grep Epix100 /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-HAVE_CSPAD=`grep Cspad /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-HAVE_ZYLA=`grep Zyla /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-HAVE_UXI=`grep -i Uxi /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-HAVE_ISTAR=`grep iStar /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-HAVE_OPAL=`grep Opal /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
-HAVE_RAYONIX=`grep Rayonix /tmp/detnames_$EXP\_$CREATE_TIME | wc -l`
+HAVE_EPIX=$(grep -c Epix100 /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_CSPAD=$(grep -c Cspad /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_ZYLA=$(grep -c Zyla /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_UXI=$(grep -c -i Uxi /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_ISTAR=$(grep -c iStar /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_OPAL=$(grep -c Opal /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_RAYONIX=$(grep -c Rayonix /tmp/detnames_"$EXP"_"$CREATE_TIME")
 
 #not like this: calculation
-let SPECIFIED_CUTS=MYNOISESIGMIN+MYNOISESIGMAX+MYADUMIN+MYADUMAX
+(( SPECIFIED_CUTS=MYNOISESIGMIN+MYNOISESIGMAX+MYADUMIN+MYADUMAX ))
 
 DETS=''
 #always make pedestals if detectors are present in data
 if [[ ( $HAVE_CSPAD -ge 1) ]]; then
-    DETS=`echo $DETS ' CSPAD,CSPAD2x2'`
+    DETS="$DETS CSPAD,CSPAD2x2"
 
-    DETNAMES=`grep Cspad /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
+    DETNAMES=$(grep Cspad /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
     for CSPAD in $DETNAMES; do
-	deploy_geometry $CSPAD
+	deploy_geometry "$CSPAD"
     done
 fi
 if [[ ( $HAVE_EPIX -ge 1) ]]; then
-    DETS=`echo $DETS ' Epix100a'`
+    DETS="$DETS Epix100a"
 fi
 
 #add Zyla only on request
 if [[ ( $HAVE_ZYLA -ge 1 ) && ( $WANT_ZYLA -ge 1 ) ]]; then
     if [ $SPECIFIED_CUTS -eq -4 ]; then
-	DETS=`echo $DETS' Zyla'`
+	DETS="$DETS Zyla"
     else
 	DETS='Zyla'
     fi
@@ -879,7 +879,7 @@ fi
 #add iStar only on request
 if [[ ( $HAVE_ISTAR -ge 1 ) && ( $WANT_ZYLA -ge 1 ) ]]; then
     if [ $SPECIFIED_CUTS -eq -4 ]; then
-	DETS=`echo $DETS' iStar'`
+	DETS="$DETS iStar"
     else
 	DETS='iStar'
     fi
@@ -888,7 +888,7 @@ fi
 #add Opal only on request
 if [[ ( $HAVE_OPAL -ge 1 ) && ( $WANT_OPAL -ge 1 ) ]]; then
     if [ $SPECIFIED_CUTS -eq -4 ]; then
-	DETS=`echo $DETS' Opal1000,Opal2000,Opal4000,Opal8000'`
+	DETS="$DETS Opal1000,Opal2000,Opal4000,Opal8000"
     else
 	DETS='Opal1000,Opal2000,Opal4000,Opal8000'
     fi
@@ -897,7 +897,7 @@ fi
 #add uxi only on request
 if [[ ( $HAVE_UXI -ge 1 ) && ( $WANT_UXI -ge 1 ) ]]; then
     if [ $SPECIFIED_CUTS -eq -4 ]; then
-	DETS=`echo $DETS' uxi'`
+	DETS="$DETS uxi"
     else
 	DETS='uxi'
     fi
@@ -906,15 +906,15 @@ fi
 #add Rayonix only on request
 if [[ ( $HAVE_RAYONIX -ge 1 ) && ( $WANT_RAYONIX -ge 1 ) ]]; then
     if [ $SPECIFIED_CUTS -eq -4 ]; then
-	DETS=`echo $DETS' Rayonix'`
+	DETS="$DETS Rayonix"
     else
 	DETS='Rayonix'	
     fi
     ARG=$ARG' --zeropeds'
     
-    DETNAMES=`grep Rayonix /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
+    DETNAMES=$(grep Rayonix /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
     for RAYONIX in $DETNAMES; do
-	deploy_geometry $RAYONIX
+	deploy_geometry "$RAYONIX"
     done
 fi
 
@@ -923,13 +923,13 @@ if [[ ( $DETS == '' ) ]]; then
     S="$((T2/1000000000))"
     MIN="$((S/60))"
     SEC="$((S-MIN*60))"
-    echo XXXX NO epix100/cspad/opal/... IN RUN $RUN - END MAKEPEDS at $(date +"%T") after  $MIN.$SEC XXXXXXXXXXXXXXXXX
+    echo "XXXX NO epix100/cspad/opal/... IN RUN $RUN - END MAKEPEDS at $(date +'%T') after  $MIN.$SEC XXXXXXXXXXXXXXXXX"
     exit
 fi
 
-echo 'now calling calibrun from host ' $HOSTNAME ' from directory '
-echo 'in: ' `pwd` ' running: ' `which calibrun` ' on ' `hostname`
-echo 'for the following detectors: ' $DETS
+echo "now calling calibrun from host $HOSTNAME from directory "
+echo "in: $(pwd) running: $(which calibrun) on $(hostname)"
+echo "for the following detectors: $DETS"
 
 for MYDET in $DETS; do
     #set thresholds for the detector in question
@@ -946,21 +946,21 @@ for MYDET in $DETS; do
         LOCARG=$LOCARG' -v '$VALSTR'-end'
     fi
 
-    echo -------------------- START CALIBRUN at $(date +"%T") for detector $MYDET----------------------------
+    echo "-------------------- START CALIBRUN at $(date +'%T') for detector $MYDET----------------------------"
     source /reg/g/psdm/etc/psconda.sh
     if [[ $HOSTNAME =~ "drp-srcf" ]]; then
-    	cmd=`echo calibrun -r $RUN  -d $MYDET -P -e $EXP -x /cds/data/drpsrcf/$HUTCH/$EXP/xtc/ $LOCARG`
-    	echo $cmd
+    	cmd="calibrun -r $RUN  -d $MYDET -P -e $EXP -x /cds/data/drpsrcf/$HUTCH/$EXP/xtc/ $LOCARG"
+    	echo "$cmd"
     	$cmd
     else
-    	cmd=`echo calibrun -r $RUN  -d $MYDET -P -e $EXP -m 10 $LOCARG`
-    	echo $cmd
+    	cmd="calibrun -r $RUN  -d $MYDET -P -e $EXP -m 10 $LOCARG"
+    	echo "$cmd"
     	$cmd
     fi
-    echo -------------------- END CALIBRUN at $(date +"%T") for detector $MYDET----------------------------
+    echo "-------------------- END CALIBRUN at $(date +'%T') for detector $MYDET----------------------------"
 done
-rm /tmp/detnames_$EXP\_$CREATE_TIME
+rm /tmp/detnames_"$EXP"_"$CREATE_TIME"
 T2="$(($(date +%s%N)-T))"
 S="$((T2/1000000000))"
 M="$((T2/1000000))"
-echo xxxxxxxxxxxxxxxxxxxx END MAKEPEDS at $(date +"%T") after  '$S'.'$M' XXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo "xxxxxxxxxxxxxxxxxxxx END MAKEPEDS at $(date +'%T') after  $S.$M XXXXXXXXXXXXXXXXXXXXXXXXXXXX"

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -162,7 +162,7 @@ deploy_geometry()
     GEODIR=`dirname $GEOPATH`
     if [ ! -d $GEODIR ]; then
 	echo No geometry file found, deploying.
-	geometry_deploy_constants -e $EXP -r $RUN -d $1 -D -c ./calib
+	geometry_deploy_constants -e $EXP -r $RUN -d $1 -D
 	echo Geometry deployed.
 	if [ "$2" != "" ]; then
 	    echo Running additional command:
@@ -616,7 +616,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     DETNAMES=`grep Jungfrau /tmp/detnames_$EXP\_$CREATE_TIME | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s`
     for JUNGFRAU in $DETNAMES; do
 	deploy_geometry $JUNGFRAU "jungfrau_gain_constants -d exp=${EXP}:run=${RUN} -D"
-    fi
+    done
 
     DSNAME='exp='$EXP':run='$RUN':smd:stream=0-79'
     if [ -v OLD_JUNGFRAU ]; then
@@ -743,7 +743,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
     fi
     for EPIX10K in $DETNAMES; do
 	deploy_geometry $EPIX10K
-    fi
+    done
     for EPIX10K in $DETNAMES; do
         echo Epix10ka name for $EXP is: $EPIX10K
         ##run all at once - do not use

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -534,6 +534,7 @@ if [[ $LCLS2 -gt 0 ]]; then
                 done
 	        ALLJOBIDS=("${JOBIDS[@]}")
             fi
+   	    NFAILEDJOBS=0
             if [[ $RUNLOCAL != 1 ]]; then
 	        echo 'Wait for 1 minute before checking jobs:'
                 sleep 60
@@ -546,7 +547,6 @@ if [[ $LCLS2 -gt 0 ]]; then
                 # and now check that none of the jobs have existed with an error code:
                 # currently, the epix10k jobs print DONE at the end. 
                 # Second check necessary as jobs can fail without printing an exit code to the logfile
-   	        NFAILEDJOBS=0
 	        for JOBID in "${ALLJOBIDS[@]}"; do
 	            echo "Checking job $JOBID"
 	            if grep -q 'exit code' "$WORKDIR"/*"$JOBID".out; then
@@ -630,7 +630,14 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     fi   
 
     #default arguments.
-    JFARG=' -d '$DSNAME' -n '$NUMEVT
+    JFARG=$JFARG' -d '$DSNAME
+    if [ $CALIBCODE -ne 0 ]; then
+        if [ $NUMEVT -le 1000 ]; then
+	    NUMEVT=100000
+        fi
+        JFARG=$JFARG' -c '$CALIBCODE
+    fi
+    JFARG=$JFARG' -n '$NUMEVT
     if [[ $DEPLOY == 1 ]]; then
         JFARG=$JFARG' -u '
     fi
@@ -654,8 +661,10 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
    	for calibcycle in {0..2}; do
             if [ -v OLD_JUNGFRAU ]; then
                 CMDC=$CMD
-            else
+            elif  [ $CALIBCODE -eq 0 ]; then
                 CMDC=$CMD' --stepnum '$calibcycle
+	    else
+                CMDC=$CMD
 	    fi
             if [[ $RUNLOCAL != 1 ]]; then
                 tmpScript=$(mktemp -p $WORKDIR jungfrau_multi_tmpXXXXX.sh)
@@ -677,10 +686,14 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
             if [ -v OLD_JUNGFRAU ]; then
        	        break
 	    fi
+            if [ $CALIBCODE -ne 0 ]; then
+		break
+	    fi
         done
 	ALLJOBIDS=("${JOBIDS[@]}")
     done
 
+    NFAILEDJOBS=0
     if [[ $RUNLOCAL != 1 ]]; then
 	echo 'Wait for 1/2 minutes before checking jobs:'
         sleep 30
@@ -691,7 +704,6 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
             done
         echo 'All jobs finished'
 	# and now check that none of the jobs have existed with an error code:
-	NFAILEDJOBS=0
 	for JOBID in "${ALLJOBIDS[@]}"; do
 	    echo "Checking job $JOBID"
 	    if grep -q 'exit code' "$WORKDIR"/*"$JOBID".out; then
@@ -725,7 +737,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
         done
     fi
 
-    ls -l /reg/d/psdm/"$EXP:0:3}"/"$EXP"/calib/J*/*/pedestals/*"$RUN"*data
+    ls -l /reg/d/psdm/"${EXP:0:3}"/"$EXP"/calib/J*/*/pedestals/*"$RUN"*data
     echo "-------------------- END JUNGFRAU PEDESTALS at $(date +'%T') ----------------------------"
 fi
 


### PR DESCRIPTION
## Description
    - Moved the makepeds-specific flags to the top of the help, just so I could see that this matches makepeds_psana.
    - Created a hutch-specific configuration file /reg/g/pcds/pyps/config/$HUTCH/makepeds.cfg, which contains the ADUMAX, ADUMIN, NOISESIGMAX, and NOISESIGMIN settings for each class of detector.  For now, this only exists in xpp.
    - Removed the -g geometry flag.  Instead, added a bash function "deploy_geometry" that will see if the geometry directory exists already, and if not call the geometry_deploy_constants script to deploy the geometry automatically.  This is also given an optional command that will be run as well if we need to deploy geometry.
    - Call deploy_geometry for cspad, epix10k, jungfrau, and rayonix detectors.  In the event of a jungfrau, also call jungfrau_gain_constants.

## Motivation and Context
See https://jira.slac.stanford.edu/browse/LCLSECSD-1004.

## How Has This Been Tested?
I'm sorry, I don't understand the question.

## Where Has This Been Documented?
It hasn't been documented yet.

