### PR TITLE
Enh/dss check

### DIFF
--- a/scripts/ami_offline_psana
+++ b/scripts/ami_offline_psana
@@ -18,8 +18,8 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-USER=`whoami`
-ARGSTR='-Z '
+USER=$(whoami)
+ARGSTR='-Z'
 
 while getopts "u:e:ntR" OPTION
 do
@@ -40,13 +40,13 @@ do
 	esac
 done
 
-if [ -z $EXP ]; then
-    echo getting the experiment $EXP
-    HUTCH=`get_hutch_name`
-    if [ $HUTCH == 'unknown_hutch' ]; then
-	printf 'please enter an experiment name '; read $EXP
+if [ -z "$EXP" ]; then
+    echo getting the experiment "$EXP"
+    HUTCH=$(get_hutch_name)
+    if [ "$HUTCH" == 'unknown_hutch' ]; then
+	read -p 'please enter an experiment name: ' EXP
     else
-	EXP=`get_curr_exp`
+	EXP=$(get_curr_exp)
     fi
 fi
 HUTCH=${EXP:0:3}
@@ -56,7 +56,7 @@ if [ -z $REBIN ]; then
 fi
 
 jet_hutches="xpp xcs mec"
-if [ `echo $jet_hutches | grep $HUTCH | wc -l` -gt 0 ]; then
+if echo "$jet_hutches" | grep -iw "$HUTCH" > /dev/null; then
     ARGSTR=$ARGSTR' -C mono,jet'
 fi
 
@@ -66,16 +66,16 @@ if [[ $HUTCH == 'cxi' ]]; then
 fi
 
 #get executable
-ami_base_path=`grep ami_base_path /reg/g/pcds/dist/pds/$HUTCH/scripts/$CNF | grep -v '#' | grep -v 'ami_base_path+' | tail -n 1 | awk 'BEGIN { FS = "=" }; { print $2}' | sed s/\'//g`
-ami_path=$ami_base_path`grep ami_path /reg/g/pcds/dist/pds/$HUTCH/scripts/$CNF | grep -v 'ami_path+' | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+//g | sed s/\'//g`
+ami_base_path=$(grep ami_base_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNF" | grep -v '#' | grep -v 'ami_base_path+' | tail -n 1 | awk 'BEGIN { FS = "=" }; { print $2}' | sed s/\'//g)
+ami_path=$ami_base_path$(grep ami_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNF" | grep -v 'ami_path+' | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+//g | sed s/\'//g)
 
 if [ ! -f  $ami_path/offline_ami ]; then
-    echo 'could not find offline_ami executable in $ami_path'
+    echo "could not find offline_ami executable in ""$ami_path"
     exit
 fi
 
 #plugin_path & plugin string.
-pp=`grep plugin_path /reg/g/pcds/dist/pds/$HUTCH/scripts/$CNF | grep ami_base | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+//g | sed s/\'//g`
+pp=$(grep plugin_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNF" | grep ami_base | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+//g | sed s/\'//g)
 plugin_path=$ami_base_path$pp
 plugin_str=$plugin_path'/libtimetooldbd.so'
 
@@ -85,55 +85,45 @@ fi
 #ARGSTR=$ARGSTR -X /reg/neh/operator/$HUTCH\opr/experiments
 
 #check hostname - different path for recorder node.
-if [ ${HOSTNAME:0:5} == 'psana' ]; then
-    XTCDIR=/reg/d/psdm/$HUTCH/$EXP/xtc
-    HAVE_RUNS=`find $XTCDIR/*r* | wc -l `
-    if [ $HAVE_RUNS == 0 ]; then
-	echo 'did not find any xtc files in /reg/d/psdm/'$HUTCH'/'$EXP', will exit'
+if [ "${HOSTNAME:0:5}" == 'psana' ]; then
+    XTCDIR=/reg/d/psdm/$HUTCH/$EXP/xtc/
+    HAVE_RUNS=$(find "$XTCDIR"/*r* | wc -l)
+    if [ "$HAVE_RUNS" == 0 ]; then
+	echo 'did not find any xtc files in /reg/d/psdm/'"$HUTCH"'/'"$EXP"', will exit'
 	exit
     fi 
-elif [ ${HOSTNAME:0:5} == 'drp' ]; then
-    XTCDIR=/cds/data/drpsrcf/$HUTCH/$EXP/xtc
-    HAVE_RUNS=`find $XTCDIR/*r* | wc -l `
-    if [ $HAVE_RUNS == 0 ]; then
-	echo 'did not find any xtc files in /cds/data/drpsrcf/'$HUTCH'/'$EXP', will exit'
+elif [ "${HOSTNAME:0:3}" == 'drp' ]; then
+    XTCDIR=/cds/data/drpsrcf/$HUTCH/$EXP/xtc/
+    HAVE_RUNS=$(find "$XTCDIR"/*r* | wc -l)
+    if [ "$HAVE_RUNS" == 0 ]; then
+	echo 'did not find any xtc files in /cds/data/drpsrcf/'"$HUTCH"'/'"$EXP"', will exit'
 	exit
     fi 
-elif  [ ${HOSTNAME:8:3} == 'rec' ]; then
-    #EXPID=`get_info --setExp $EXP --experimentNumber`
+elif  [ "${HOSTNAME:8:3}" == 'rec' ]; then
     XTCDIR=/u2/REC/daq/xtc/
-elif  [ ${HOSTNAME:8:3} == 'dss' ]; then
-    EXPID=`get_info --setExp $EXP --experimentNumber`
-    XTCDIR=/u2/pcds/pds/$HUTCH/e$EXPID    
+elif  [ "${HOSTNAME:8:3}" == 'dss' ]; then
+    EXPID=$(get_info --setExp "$EXP" --experimentNumber)
+    XTCDIR=/u2/pcds/pds/"$HUTCH"/e"$EXPID"/  
 else
     echo 'Please ssh to a psana, recorder or dss node to see data'
     exit
 fi
 
 #change to temporary directory where we'll need the favorites file (&maybe
-if [ ! -d /tmp/ami_offline_$USER ] ; then
-    mkdir /tmp/ami_offline_$USER
+if [ ! -d /tmp/ami_offline_"$USER" ] ; then
+    mkdir /tmp/ami_offline_"$USER"
 fi
 
-ln -sf /reg/neh/operator/$HUTCHopr/.ami_favorites ~/.
-##not sure this is necessry anymore....
-#if [ x$TTINFDIR != 'x' ]; then
-#    pwd
-#    echo 'will use the timetool plugin w/ '$TTINF' as input file'
-#    echo LD_LIBRAY_PATH: $LD_LIBRARY_PATH
-#    cp $TTINFDIR/timetool.input ~/.
-#    cp $TTINFDIR/timetool.ref.* ~/.
-#else
-#    rm timetool.input
-#fi
+ln -sf /reg/neh/operator/"$HUTCH"opr/.ami_favorites ~/.
 
 #not sure this is necessary either.
 source /reg/g/pcds/setup/pathmunge.sh
-ldpathmunge /reg/g/pcds/dist/pds/$HUTCH/ami-current/build/ami/lib/x86_64-linux-opt
+ldpathmunge /reg/g/pcds/dist/pds/"$HUTCH"/ami-current/build/ami/lib/x86_64-linux-opt
 
-LD_LIBRARY_PATH=/reg/g/pcds/dist/pds/$HUTCH/current/build/pds/lib/x86_64-linux/:/reg/g/pcds/dist/pds/xpp/current/build/pdsdata/lib/x86_64-linux/:/reg/g/pcds/dist/pds/xpp/current/build/pdsalg/lib/x86_64-linux/:/reg/g/pcds/dist/pds/xpp/current/build/pdsapp/lib/x86_64-linux/:$LD_LIBRARY_PATH
+LD_LIBRARY_PATH=/reg/g/pcds/dist/pds/"$HUTCH"/current/build/pds/lib/x86_64-linux/:/reg/g/pcds/dist/pds/xpp/current/build/pdsdata/lib/x86_64-linux/:/reg/g/pcds/dist/pds/xpp/current/build/pdsalg/lib/x86_64-linux/:/reg/g/pcds/dist/pds/xpp/current/build/pdsapp/lib/x86_64-linux/:$LD_LIBRARY_PATH
 
+#ARGSTR='-p '$XTCDIR $ARGSTR
 echo '----------------------------------------------'
-echo $ami_path/offline_ami -p $XTCDIR  $ARGSTR
+echo "$ami_path"/offline_ami $ARGSTR -p $XTCDIR 
 echo '----------------------------------------------'
-$ami_path/offline_ami -p $XTCDIR $ARGSTR
+$ami_path/offline_ami $ARGSTR -p $XTCDIR 

--- a/scripts/checkcnf
+++ b/scripts/checkcnf
@@ -13,20 +13,30 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-HUTCH=`get_info --gethutch`
-NOTRUNNING='Not running'
+HUTCH=$(get_info --gethutch)
 
-if  [[ ($HUTCH == 'tmo') || ($HUTCH == 'rix') ]]; then
-    source /reg/g/pcds/dist/pds/$HUTCH/scripts/setup_env.sh
+LCLS2_HUTCHES="rix, tmo, ued"
+if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+    source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'
 else
-    PROCMGR='/reg/g/pcds/dist/pds/current/tools/procmgr/procmgr'
+    PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 fi
 
-STATUS=`$PROCMGR status /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf control_gui`
-ISOK=`echo $STATUS | grep platform | wc -l`
+CNFEXT=.cnf
+CNFFILE="$HUTCH"$CNFEXT
+if [ "$HOSTNAME" == 'cxi-daq' ]; then
+    PEXT=_0
+    CNFFILE="$HUTCH"$PEXT$CNFEXT
+elif [ "$HOSTNAME" == 'cxi-monitor' ]; then
+    PEXT=_1
+    CNFFILE="$HUTCH"$PEXT$CNFEXT
+fi
+
+STATUS=$($PROCMGR status /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" control_gui)
+ISOK=$(echo "$STATUS" | grep -c platform)
 if [[ $ISOK == 0 ]]; then
-    echo The cnf file for $HUTCH can be parsed
+    echo The cnf file for "$HUTCH" can be parsed
 else
-    echo WARNING: the cnf file for $HUTCH cannot parsed!
+    echo WARNING: the cnf file for "$HUTCH" cannot parsed!
 fi

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -6,6 +6,7 @@ usage: $0 options
 
 OPTIONS:
 -w sort windows after start
+-d dss-test setup
 -p select partition (same as used last)
 -s silent (do not email jana)
 -c enable core files
@@ -28,7 +29,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 CORESIZE=0
-while getopts "m:pwsc" OPTION
+while getopts "m:pwscd" OPTION
 do
     case $OPTION in
 	p)
@@ -46,6 +47,9 @@ do
  	c) 
  	    CORESIZE=2000000000 
  	    ;;
+ 	d) 
+ 	    DSSTEST=1
+ 	    ;;
 	?)
 	    usage
 	    exit 1
@@ -54,62 +58,74 @@ do
 	esac
 done
 
-if [[ `whoami` != *'opr'* ]]; then
+if [[ $(whoami) != *'opr'* ]]; then
     echo "Please run the DAQ from the operator account!"
     exit
+fi
+
+HUTCH=$(get_info --gethutch)
+CNFEXT=.cnf
+CNFFILE=$HUTCH$CNFEXT
+if [ "$HOSTNAME" == 'cxi-daq' ]; then
+    PEXT=_0
+    CNFFILE=$HUTCH$PEXT$CNFEXT
+elif [ "$HOSTNAME" == 'cxi-monitor' ]; then
+    PEXT=_1
+    CNFFILE=$HUTCH$PEXT$CNFEXT
+fi
+
+if [[ "$DSSTEST" == 1 ]]; then
+    CNFFILE=dss.cnf
 fi
 
 #clean the enviroment before sourcing any conda env.
 unset PYTHONPATH
 unset LD_LIBRARY_PATH
 
-CNFEXT=.cnf
-if [[ $AIMHOST == 'cxi-daq' ]]; then
-    CNFEXT=_0.cnf
-elif [[ $AIMHOST == 'cxi-monitor' ]]; then
-    CNFEXT=_1.cnf
-fi
-
-HUTCH=`get_hutch_name`
-
 #go to hutches DAQ scripts directory (puts pid file in consistent location)
-cd /reg/g/pcds/dist/pds/$HUTCH/scripts/
+cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
 DAQNETWORK='fez'
 LCLS2_HUTCHES="rix, tmo, ued"
-if echo $LCLS2_HUTCHES | grep -iw $HUTCH > /dev/null; then
-    source /reg/g/pcds/dist/pds/$HUTCH/scripts/setup_env.sh
+if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+    source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'
     DAQNETWORK='drp'
 else
     PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 fi
 
-IS_DAQ_HOST=`netconfig search $AIMHOST-$DAQNETWORK --brief | grep $DAQNETWORK | wc -l`
-if [ $IS_DAQ_HOST == 0 ]; then
-    HOSTS=`netconfig search $HUTCH-*-$DAQNETWORK --brief | sed s/-$DAQNETWORK//g`
+IS_DAQ_HOST=$(netconfig search "$AIMHOST"-$DAQNETWORK --brief | grep -c $DAQNETWORK)
+if [ "$IS_DAQ_HOST" == 0 ]; then
+    HOSTS=$(netconfig search "$HUTCH"-*-$DAQNETWORK --brief | sed s/-$DAQNETWORK//g)
     WORKINGHOSTS=''
     #make sure at least cds is up.
     for HOST in $HOSTS; do
-	ping -w 2 $HOST >/dev/null 2>&1
+	ping -w 2 "$HOST" >/dev/null 2>&1
 	if [[ $? == 0 ]]; then
 	    WORKINGHOSTS=$WORKINGHOSTS' '$HOST
 	fi
     done
-    echo $AIMHOST does not have $DAQNETWORK, please choose one of the following machines to run the DAQ: $WORKINGHOSTS
+    echo "$AIMHOST" does not have "$DAQNETWORK", please choose one of the following machines to run the DAQ: "$WORKINGHOSTS"
     echo "restartdaq -m <machine_with_$DAQNETWORK>"
     exit
 fi
 
-DAQHOST=`wheredaq`
-if [[ $DAQHOST != *$NOTRUNNING* ]]; then
-    echo stop the DAQ on $DAQHOST from $HOSTNAME
+if [[ $DSSTEST == 1 ]]; then
+    DAQHOST=$(wheredaq -d)
+else
+    DAQHOST=$(wheredaq)
+fi
+
+PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE | awk '{print $NF}' | sed s/\'//g)
+if [[ "$DAQHOST" != *$NOTRUNNING* ]]; then
+    echo stop the DAQ on "$DAQHOST" from "$HOSTNAME"
     T="$(date +%s%N)"
     $PROCMGR stop \
-	/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT 
+	/reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE 
 
-    PLATFORM=`grep 'if not platform' /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT | awk '{print $NF}' | sed s/\'//g`
-    if [ -f /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM$CNFEXT.running ]; then
+
+    if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
 	echo 'the DAQ did not stop properly, exit now and try again or call Silke or the DAQ phone'
 	exit
     fi
@@ -118,14 +134,13 @@ if [[ $DAQHOST != *$NOTRUNNING* ]]; then
     M="$((T2/1000000))"
     echo 'it took '$S'.'$M' for stopping the DAQ'
 else
-    PLATFORM=`grep 'if not platform' /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT | awk '{print $NF}' | sed s/\'//g`
-    if [ -f /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM$CNFEXT.running ]; then
-	echo while DAQ reports to not run, will stop the DAQ on $DAQHOST from $HOSTNAME to clear the p$PLATFORM$CNFEXT.running file
+    if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
+	echo while DAQ reports to not run, will stop the DAQ on "$DAQHOST" from "$HOSTNAME" to clear the p"$PLATFORM"$CNFEXT.running file
 	T="$(date +%s%N)"
 	$PROCMGR stop \
-	    /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT 
+	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE 
 
-        if [ -f /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM$CNFEXT.running ]; then
+        if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
             echo 'the DAQ did not stop properly, exit now and try again follow the escalation procedure'
             exit
         fi
@@ -138,23 +153,30 @@ fi
 
 #start DAQ on AIMHOST
 T="$(date +%s%N)"
-echo start DAQ on $AIMHOST
-if [ $HOSTNAME == $AIMHOST ]; then
+echo start DAQ on "$AIMHOST"
+if [ "$HOSTNAME" == "$AIMHOST" ]; then
     $PROCMGR start \
-        /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT -c $CORESIZE -o /reg/g/pcds/pds/$HUTCH/logfiles
+        /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE -c $CORESIZE -o /reg/g/pcds/pds/"$HUTCH"/logfiles
 else
-    ssh -Y $AIMHOST restartdaq
+    ssh -Y "$AIMHOST" restartdaq
 fi
 
-DAQHOST=`wheredaq`
-if [[ $DAQHOST == *$NOTRUNNING* ]]; then
+if [[ $DSSTEST == 1 ]]; then
+    DAQHOST=$(wheredaq -d)
+    echo 'checked dss-node test DAQ....'
+    echo "$DAQHOST"
+else
+    DAQHOST=$(wheredaq)
+fi
+
+if [[ "$DAQHOST" == *$NOTRUNNING* ]]; then
     echo 'We tried restarting the DAQ, but wheredaq says its still off!'
-    if [[ $DAQHOST != $AIMHOST ]]; then
-	echo 'We tried to run the DAQ on another host: target '$AIMHOST' from '$HOSTNAME
+    #I cannot remember what this statement was supposed to do.
+    if [[ "$DAQHOST" != "$AIMHOST" ]]; then
+	echo 'We tried to run the DAQ on another host: target '"$AIMHOST"' from '"$HOSTNAME"
     fi
     exit
 else
-    echo the DAQ is now running on $DAQHOST
     T2="$(($(date +%s%N)-T))"
     S="$((T2/1000000000))"
     M="$((T2/1000000))"
@@ -162,14 +184,14 @@ else
 fi
 
 if [ ${#DOWIN} != 0 ] ||  [ ${#SELPART} != 0 ]; then
-    if  [ $HUTCH  == 'xpp' ] || [ $HUTCH  == 'xcs' ]; then
+    if  [ "$HUTCH"  == 'xpp' ] || [ "$HUTCH"  == 'xcs' ]; then
 	if  [ ! -f /usr/bin/xdotool ]; then
 	    echo 'xdotool not installed, ask IT to do so'
 	    DOWIN=0
 	    SELPART=0
 	fi
     fi
-    if [ ! /reg/neh/operator/$HUTCH\opr/bin/$HUTCH\_cleanup_windows_daq ]; then
+    if [ -f /reg/neh/operator/"$HUTCH"\opr/bin/"$HUTCH"\_cleanup_windows_daq ]; then
 	if [ ${#DOWIN} != 0 ]; then
 	    echo 'This instrument does not have standard locations for DAQ windows setup'
 	fi
@@ -179,35 +201,35 @@ fi
 
 if [ ${#DOWIN} != 0 ]; then    
     T="$(date +%s%N)"
-    if [ $HUTCH == 'xpp' ]; then
-	test=`xdotool search --sync --onlyvisible --name 'ProcStat'` 
+    if [ "$HUTCH" == 'xpp' ]; then
+	test=$(xdotool search --sync --onlyvisible --name 'ProcStat')
     fi
-    if [ $HUTCH == 'xcs' ]; then
+    if [ "$HUTCH" == 'xcs' ]; then
 	sleep 2
     fi
-    echo 'resorting the windows now using: /reg/neh/operator/'$HUTCH'opr/bin/'$HUTCH'_cleanup_windows_daq'
-    /reg/neh/operator/$HUTCH\opr/bin/$HUTCH\_cleanup_windows_daq
+    echo 'resorting the windows now using: /reg/neh/operator/'"$HUTCH"'opr/bin/'"$HUTCH"'_cleanup_windows_daq'
+    /reg/neh/operator/"$HUTCH"\opr/bin/"$HUTCH"\_cleanup_windows_daq
     Tdinter="$(($(date +%s%N)-T))"
     Sinter="$((Tdinter/1000000000))"
     Minter="$((Tdinter/1000000))"
-    echo 'and '$Sinter'.'$Minter' extra seconds for windows'
+    echo 'and '"$Sinter"'.'"$Minter"' extra seconds for windows'
 fi
 
 if [ ${#SELPART} != 0 ]; then    
-    DAQC=`xdotool search  --onlyvisible --name 'DAQ Control'`
+    DAQC=$(xdotool search  --onlyvisible --name 'DAQ Control')
     #echo $DAQC
-    xdotool mousemove --sync --window $DAQC 80 230
-    xdotool windowfocus $DAQC
+    xdotool mousemove --sync --window "$DAQC" 80 230
+    xdotool windowfocus "$DAQC"
     xdotool click 1 
     
-    PARTSEL=`xdotool search  --onlyvisible --sync --name 'Partition Selection'`
-    YLOW=`xdotool search --name 'Partition Selection' getwindowgeometry %@ | grep Geometry | awk '{print $2}' | sed s/x/" "/g | awk '{print $2}'`
+    PARTSEL=$(xdotool search  --onlyvisible --sync --name 'Partition Selection')
+    YLOW=$(xdotool search --name 'Partition Selection' getwindowgeometry %@ | grep Geometry | awk '{print $2}' | sed s/x/" "/g | awk '{print $2}')
         #echo $PARTSEL
-    xdotool mousemove --sync --window $PARTSEL 80 $(($YLOW-28)) 
+    xdotool mousemove --sync --window "$PARTSEL" 80 $(("$YLOW"-28)) 
     xdotool click 1 
 fi
 
-if [ ${SILENT} == 0 ];then
+if [ "$SILENT" == 0 ];then
     /reg/g/pcds/dist/pds/scripts/txtjana.sh
     printf 'email jana that we restarted the DAQ\n'
 fi

--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -13,13 +13,20 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-HUTCH=`get_info --gethutch`
-DAQHOST=`wheredaq`
+HUTCH=$(get_info --gethutch)
+DAQHOST=$(wheredaq)
 CNFEXT=.cnf
-if [ $HOSTNAME == 'cxi-daq' ]; then
-    CNFEXT=_0.cnf
-elif [ $HOSTNAME == 'cxi-monitor' ]; then
-    CNFEXT=_1.cnf
+CNFFILE=$HUTCH$CNFEXT
+if [ "$HOSTNAME" == 'cxi-daq' ]; then
+    PEXT=_0
+    CNFFILE=$HUTCH$PEXT$CNFEXT
+elif [ "$HOSTNAME" == 'cxi-monitor' ]; then
+    PEXT=_1
+    CNFFILE=$HUTCH$PEXT$CNFEXT
+fi
+
+if [[ ($1 == "--dss") || ($1 == "-d") ]]; then
+	CNFFILE=dss.cnf
 fi
 
 #clean the enviroment before sourcing any conda env.
@@ -28,23 +35,22 @@ unset LD_LIBRARY_PATH
 
 #go to hutches DAQ scripts directory 
 #(puts pid file in consistent location - necessary for stopping for LCLS-II DAQ)
-cd /reg/g/pcds/dist/pds/$HUTCH/scripts/
+cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
 LCLS2_HUTCHES="rix, tmo, ued"
-if echo $LCLS2_HUTCHES | grep -iw $HUTCH > /dev/null; then
-    source /reg/g/pcds/dist/pds/$HUTCH/scripts/setup_env.sh
+if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+    source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'
 else
-    PROCMGR='/reg/g/pcds/dist/pds/tools/procmgr/procmgr'
+    PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 fi
 
-if [[ $DAQHOST != 'DAQ is not running' ]]; then
+PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" | awk '{print $NF}' | sed s/\'//g)
+if [[ "$DAQHOST" != 'DAQ is not running' ]]; then
     T="$(date +%s%N)"
-    echo stop the DAQ from $HOSTNAME
-    $PROCMGR stop /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT 
-
-    PLATFORM=`grep 'if not platform' /reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH$CNFEXT | awk '{print $NF}' | sed s/\'//g`
-    if [ -f /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM$CNFEXT.running ]; then
+    echo stop the DAQ from "$HOSTNAME"
+    $PROCMGR stop /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE    
+    if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM""$CNFEXT".running ]; then
 	echo 'the DAQ did not stop properly, exit now and try again or call your POC or the DAQ phone'
 	exit
     fi

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -23,7 +23,7 @@ $DAQ_RELEASE/tools/scanning/take_pedestals -p $station -r
 
 elogMessage="DARK"
 source pcds_conda
-export PYTHONPATH=/reg/g/pcds/pyps/apps/hutch-python/common/dev/elog:${PYTHONPATH}
+#export PYTHONPATH=/reg/g/pcds/pyps/apps/hutch-python/common/dev/elog:${PYTHONPATH}
 PYCMD=LogBookPost.py
 
 EXP=`get_curr_exp`

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -13,24 +13,31 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-HUTCH=`get_info --gethutch`
+HUTCH=$(get_info --gethutch)
 CNFEXT=.cnf
-PLATFORM=0
-if [ $HOSTNAME == 'cxi-monitor' ]; then
-    PLATFORM=1
-elif [ $HUTCH == 'rix' ]; then
-    PLATFORM=2
+if [ "$HOSTNAME" == 'cxi-daq' ]; then
+    CNFEXT=_0.cnf
+elif [ "$HOSTNAME" == 'cxi-monitor' ]; then
+    CNFEXT=_1.cnf
 fi
 
-if [[ ! -f /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM.cnf.running ]]; then
-    if [ $HOSTNAME == 'cxi-daq' ]; then
-	echo 'Main DAQ cxi_0 is not running on '$HOSTNAME
-    elif [ $HOSTNAME == 'cxi-monitor' ]; then
-	echo 'Secondary DAQ cxi_1 is not running on '$HOSTNAME
+if [[ ($1 == "--dss") || ($1 == "-d") ]]; then
+    CNFFILE=dss.cnf
+else
+    CNFFILE=$HUTCH$CNFEXT
+fi
+
+PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" | awk '{print $NF}' | sed s/\'//g)
+
+if [[ ! -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running ]]; then
+    if [ "$HOSTNAME" == 'cxi-daq' ]; then
+	echo 'Main DAQ cxi_0 is not running on '"$HOSTNAME"
+    elif [ "$HOSTNAME" == 'cxi-monitor' ]; then
+	echo 'Secondary DAQ cxi_1 is not running on '"$HOSTNAME"
     else
-	echo 'DAQ is not running in '$HUTCH
+	echo 'DAQ is not running in '"$HUTCH"
     fi
 else
-    DAQ_HOST=`grep "'HOST'" /reg/g/pcds/dist/pds/$HUTCH/scripts/p$PLATFORM.cnf.running | awk {'print $3'} | sed s/\'//g`
-    echo 'DAQ is running on '$DAQ_HOST
+    DAQ_HOST=$(grep "'HOST'" /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running | awk {'print $3'} | sed s/\'//g)
+    echo 'DAQ is running on '"$DAQ_HOST"
 fi


### PR DESCRIPTION
## Description
Adding a "dss-check" mode which will run a barebones DAQ recording to the <hutch>daq18 experiment. 

## Motivation and Context
I wanted to make a full checkout of the DSS nodes simpler for the (IT) staff involved. As I made edits, I also ran spellcheck and implemented a fair number of the suggestioins.

## How Has This Been Tested?
Tested new scripts from local checkout in XCS.

## Where Has This Been Documented?
No real documentation as these are changes to pre-existing scripts. The new option is not for general use and instructions will be written.
