### PR TITLE
Enh/makepeds jf4m epix100

### DIFF
--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -173,6 +173,20 @@ deploy_geometry()
     fi
 }
 
+# Args: Detector ID, Additional command to run.
+deploy_gain()
+{
+    GAINPATH=$(calibfile path -e "$EXP" -s "$1" -t pixel_gain | awk '{print $2;}' -)
+    GAINDIR=$(dirname "$GAINPATH")
+    if [ ! -d "$GAINDIR" ]; then
+	echo No gain file file found, deploying.
+	echo Calling: deploy_constants -e "$EXP" -r "$RUN" -d "$1" -C gain -D
+	deploy_constants -e "$EXP" -r "$RUN" -d "$1" -C gain -D
+	echo Gain file deployed.
+    fi
+}
+
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -873,8 +887,17 @@ if [[ ( $HAVE_CSPAD -ge 1) ]]; then
 	deploy_geometry "$CSPAD"
     done
 fi
+
 if [[ ( $HAVE_EPIX -ge 1) ]]; then
     DETS="$DETS Epix100a"
+
+    DETNAMES=$(grep Epix100a /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
+    for EPIX100 in $DETNAMES; do
+        echo DEBUG call gain for "$EPIX100"
+	deploy_gain "$EPIX100"
+    done
+    #DEBUG.....
+    exit
 fi
 
 #add Zyla only on request

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -423,7 +423,7 @@ fi
 
 if [ $CALIBCODE -ne 0 ]; then
     if [ $NUMEVT -le 1000 ]; then
-	NUMEVT=10000
+	NUMEVT=1000000
     fi
     ARG=$ARG' -f '$CALIBCODE
 fi
@@ -632,14 +632,11 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     #default arguments.
     JFARG=$JFARG' -d '$DSNAME
     if [ $CALIBCODE -ne 0 ]; then
-        if [ $NUMEVT -le 1000 ]; then
-	    NUMEVT=100000
-        fi
-        JFARG=$JFARG' -c '$CALIBCODE
+        JFARG=$JFARG' -c '$CALIBCODE' --evstep '$NUMEVT
     fi
-    JFARG=$JFARG' -n '$NUMEVT
+    JFARG=$JFARG' --events '$NUMEVT
     if [[ $DEPLOY == 1 ]]; then
-        JFARG=$JFARG' -u '
+        JFARG=$JFARG' --upload '
     fi
 
     #specify parameters for status bits in pixel mask
@@ -680,7 +677,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
                 JOBIDS+=( "$THISJOBID" )
                 NJOBS=$((NJOBS+1))
 	    else
-                echo "$cmd"C
+                echo "$CMDC"
                 $CMDC
             fi
             if [ -v OLD_JUNGFRAU ]; then

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -32,7 +32,8 @@ HUTCH=${EXP:0:3}
 echo $PYCMD -i "${HUTCH^^}" -u `whoami` -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"
 $PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"&
 
-echo 'please call: makepeds -u <userID> [-F -q <queue>] -r '`get_lastRun`
+echo 'please call: makepeds -u <userID> -r '`get_lastRun`
+echo 'for gainswitching detectors we recommend: makepeds -u <userID> -q <ffb-queue-assigned-in-elog> -r '`get_lastRun`
 #echo 'we need to use the offline data to process pedestals right now, make sure files have moved, otherwise a very silent failure might happen'
 #echo 'please call: makepeds -u <userID> -e '`get_curr_exp`' -r '`get_lastRun`' -q psfehhiprioq'
 


### PR DESCRIPTION
Add gain-file deployment for epix100 
somewhat better makeup's-command suggestion for takepeds

## Motivation and Context
the detector group would like all detectors to report their values in ADUs and the chosen solution relies on deployment of Gail-files in the calib-directory

## How Has This Been Tested?
Tested on xppx40719 and xpplz0620 (gain files removed later).