### PR TITLE
Bug/makepeds epix100

### DIFF
--- a/scripts/checkcnf
+++ b/scripts/checkcnf
@@ -4,7 +4,8 @@ usage()
 cat << EOF
 usage: $0
 
-Discover what host is running the daq in the current hutch, if any.
+Check if an LCLS1 cnf file can be parsed
+
 EOF
 }
 

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -162,8 +162,15 @@ deploy_geometry()
     GEODIR=$(dirname "$GEOPATH")
     if [ ! -d "$GEODIR" ]; then
 	echo No geometry file found, deploying.
-	geometry_deploy_constants -e "$EXP" -r "$RUN" -d "$1" -D
-	echo Geometry deployed.
+
+	CMD=geometry_deploy_constants -e "$EXP" -r "$RUN" -d "$1" -D
+        if [[ $HOSTNAME =~ "drp-srcf" ]]; then
+            CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/:stream=0-79'
+	fi
+
+	echo calling $CMD
+	$CMD
+	echo Geometry now deployed.
 	if [ "$2" != "" ]; then
 	    echo Running additional command:
 	    echo "$2"
@@ -180,8 +187,13 @@ deploy_gain()
     GAINDIR=$(dirname "$GAINPATH")
     if [ ! -d "$GAINDIR" ]; then
 	echo No gain file file found, deploying.
-	echo Calling: deploy_constants -e "$EXP" -r "$RUN" -d "$1" -C gain -D
-	deploy_constants -e "$EXP" -r "$RUN" -d "$1" -C gain -D
+	CMD=deploy_constants -e "$EXP" -r "$RUN" -d "$1" -C gain -D
+        if [[ $HOSTNAME =~ "drp-srcf" ]]; then
+            CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/:stream=0-79'
+	fi
+
+	echo calling $CMD
+	$CMD
 	echo Gain file deployed.
     fi
 }

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -158,12 +158,12 @@ get_config()
 # Args: Detector ID, Additional command to run.
 deploy_geometry()
 {
-    GEOPATH=$(calibfile path -e "$EXP" -s "$1" -t geometry | awk '{print $2;}' -)
+    GEOPATH=$(calibfile path -e "$EXP" -s "$1" -t geometry | awk 'END{print $NF}' -)
     GEODIR=$(dirname "$GEOPATH")
     if [ ! -d "$GEODIR" ]; then
 	echo No geometry file found, deploying.
 
-	CMD=geometry_deploy_constants -e "$EXP" -r "$RUN" -d "$1" -D
+	CMD='geometry_deploy_constants -e '$EXP' -r '$RUN' -d '$1' -D'
         if [[ $HOSTNAME =~ "drp-srcf" ]]; then
             CMD=$CMD' -x /cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/:stream=0-79'
 	fi


### PR DESCRIPTION
## Description
add xtc-path for geometry deploy & epix100 gain file to make them also work on the DRPSRCF FFB
also fix usage text for checkcnf.

## Motivation and Context
geometries could not deployed from jobs run against the FFB.

## How Has This Been Tested?
Running the command. 