### PR TITLE
FIX: pcds_conda, dev_conda: only set mesa if renderer is failing

### DIFF
--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -53,11 +53,35 @@ source "${TOKEN_DIR}/typhos.sh"
 # Revert to Software Raster when SSH to avoid issues with QtQuick.
 # The same was done with PyDM and this fixes Designer and friends.
 if [ -n "${SSH_CONNECTION}" ]; then
+  echo "SSH Session"
 	export QT_QUICK_BACKEND="software"
-  # On operator consoles over ssh for most users, opengl crashes unless this is set.
-  # This tells the GLX extension to use software rendering by way of the mesa library.
-  if [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
-    export __GLX_VENDOR_LIBRARY_NAME="mesa"
+  # Check for errors in the renderer
+  # Manually fall back to mesa library if renderer doesn't work
+  if [ -x "$(command -v glxinfo)" ] && [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
+    echo "Check for graphics errors"
+    GLX_OUTPUT="$(glxinfo -B 2>&1)"
+    if [ "${?}" -ne "0" ]; then
+      echo "Graphics error found"
+      export ERROR="1"
+    else
+      GLX_ERRORS="$(echo "${GLX_OUTPUT}" | grep -i "^error")"
+      if [ -n "${GLX_ERRORS}" ]; then
+        echo "Graphics warning found"
+        export ERROR="1"
+      else
+        echo "No errors"
+        export ERROR="0"
+      fi
+    fi
+    if [ "${ERROR}" -eq "1" ]; then
+      echo "Manual ovveride of GLX renderer"
+      export __GLX_VENDOR_LIBRARY_NAME="mesa"
+    else
+      echo "Use automatic renderer"
+    fi
+  else
+    echo "Cannot check for graphics errors"
   fi
+else
+  echo "Not an SSH session"
 fi
-

--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -53,35 +53,14 @@ source "${TOKEN_DIR}/typhos.sh"
 # Revert to Software Raster when SSH to avoid issues with QtQuick.
 # The same was done with PyDM and this fixes Designer and friends.
 if [ -n "${SSH_CONNECTION}" ]; then
-  echo "SSH Session"
-	export QT_QUICK_BACKEND="software"
-  # Check for errors in the renderer
-  # Manually fall back to mesa library if renderer doesn't work
+  export QT_QUICK_BACKEND="software"
+  # Check for errors in the opengl rendering
+  # Manually fall back to mesa library if we know there is a problem
   if [ -x "$(command -v glxinfo)" ] && [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
-    echo "Check for graphics errors"
-    GLX_OUTPUT="$(glxinfo -B 2>&1)"
-    if [ "${?}" -ne "0" ]; then
-      echo "Graphics error found"
-      export ERROR="1"
-    else
-      GLX_ERRORS="$(echo "${GLX_OUTPUT}" | grep -i "^error")"
-      if [ -n "${GLX_ERRORS}" ]; then
-        echo "Graphics warning found"
-        export ERROR="1"
-      else
-        echo "No errors"
-        export ERROR="0"
-      fi
-    fi
-    if [ "${ERROR}" -eq "1" ]; then
-      echo "Manual ovveride of GLX renderer"
+    # Expecting either a segfault or exit code 1 if there is a problem
+    if ! { glxinfo -B; } > /dev/null 2>&1; then
       export __GLX_VENDOR_LIBRARY_NAME="mesa"
-    else
-      echo "Use automatic renderer"
     fi
-  else
-    echo "Cannot check for graphics errors"
   fi
-else
-  echo "Not an SSH session"
 fi
+

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -127,35 +127,14 @@ source "${TOKEN_DIR}/typhos.sh"
 # Revert to Software Raster when SSH to avoid issues with QtQuick.
 # The same was done with PyDM and this fixes Designer and friends.
 if [ -n "${SSH_CONNECTION}" ]; then
-  echo "SSH Session"
-	export QT_QUICK_BACKEND="software"
-  # Check for errors in the renderer
-  # Manually fall back to mesa library if renderer doesn't work
+  export QT_QUICK_BACKEND="software"
+  # Check for errors in the opengl rendering
+  # Manually fall back to mesa library if we know there is a problem
   if [ -x "$(command -v glxinfo)" ] && [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
-    echo "Check for graphics errors"
-    GLX_OUTPUT="$(glxinfo -B 2>&1)"
-    if [ "${?}" -ne "0" ]; then
-      echo "Graphics error found"
-      export ERROR="1"
-    else
-      GLX_ERRORS="$(echo "${GLX_OUTPUT}" | grep -i "^error")"
-      if [ -n "${GLX_ERRORS}" ]; then
-        echo "Graphics warning found"
-        export ERROR="1"
-      else
-        echo "No errors"
-        export ERROR="0"
-      fi
-    fi
-    if [ "${ERROR}" -eq "1" ]; then
-      echo "Manual ovveride of GLX renderer"
+    # Expecting either a segfault or exit code 1 if there is a problem
+    if ! { glxinfo -B; } > /dev/null 2>&1; then
       export __GLX_VENDOR_LIBRARY_NAME="mesa"
-    else
-      echo "Use automatic renderer"
     fi
-  else
-    echo "Cannot check for graphics errors"
   fi
-else
-  echo "Not an SSH session"
 fi
+

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -127,10 +127,35 @@ source "${TOKEN_DIR}/typhos.sh"
 # Revert to Software Raster when SSH to avoid issues with QtQuick.
 # The same was done with PyDM and this fixes Designer and friends.
 if [ -n "${SSH_CONNECTION}" ]; then
+  echo "SSH Session"
 	export QT_QUICK_BACKEND="software"
-  # On operator consoles over ssh for most users, opengl crashes unless this is set.
-  # This tells the GLX extension to use software rendering by way of the mesa library.
-  if [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
-    export __GLX_VENDOR_LIBRARY_NAME="mesa"
+  # Check for errors in the renderer
+  # Manually fall back to mesa library if renderer doesn't work
+  if [ -x "$(command -v glxinfo)" ] && [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
+    echo "Check for graphics errors"
+    GLX_OUTPUT="$(glxinfo -B 2>&1)"
+    if [ "${?}" -ne "0" ]; then
+      echo "Graphics error found"
+      export ERROR="1"
+    else
+      GLX_ERRORS="$(echo "${GLX_OUTPUT}" | grep -i "^error")"
+      if [ -n "${GLX_ERRORS}" ]; then
+        echo "Graphics warning found"
+        export ERROR="1"
+      else
+        echo "No errors"
+        export ERROR="0"
+      fi
+    fi
+    if [ "${ERROR}" -eq "1" ]; then
+      echo "Manual ovveride of GLX renderer"
+      export __GLX_VENDOR_LIBRARY_NAME="mesa"
+    else
+      echo "Use automatic renderer"
+    fi
+  else
+    echo "Cannot check for graphics errors"
   fi
+else
+  echo "Not an SSH session"
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Check if the server has a problem before switching the renderer library.
This is WIP because it is messy and littered with echo and I'm not sure if it's even fully right.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting the `__GLX_VENDOR_LIBRARY_NAME` didn't work for all consoles.
For many cases it actually created a problem rather than solving it.

Only do it if we definitely fail without it.

That is, when:
- glxinfo has a nonzero exit code (usually 0 is success, 1 is errors, 139 is segfault)
- glxinfo has a 0 exit code but shows errors in the text (TODO: does this actually happen or is it a remnant of an older version of the script?)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Heavily interactively.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
