### PR TITLE
ENH/Add SmarAct MSC2 to motor-expert-screen

### DIFF
--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -25,7 +25,7 @@ PREFIX=`echo $1 | cut -d . -f 1`
 source /reg/g/pcds/setup/epicsenv-3.14.12.sh
 export PCDS_EDMS=/reg/g/pcds/package/epics/3.14/screens/edm
 #export EDMDATAFILES=.:${PCDS_EDMS}/xps8:${PCDS_EDMS}/ims  # normal EDMDATAFILES line
-export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens
+export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/reg/g/pcds/epics/ioc/common/smaract/R1.0.10/motorScreens
 
 # this ldpathmunge gives access to xdotool for xpp-control, xpp-daq
 source /reg/g/pcds/setup/pathmunge.sh
@@ -48,6 +48,7 @@ else
         title='IMS Motor Control'
     fi
 fi
+
 
 # xdotool is used to move the new window to the mouse location
 # if xdotool is not installed, the move window commands will skip
@@ -80,6 +81,8 @@ elif [ "${rtyp}" == 'motor' ]; then
     caget "$PREFIX:PN" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         /reg/g/pcds/package/epics/3.14//modules/pcds_motion/${OLD_VERSION}/launch-motor.sh "$PREFIX" > /dev/null 2>&1 &
+    elif [[ $PREFIX == *"MCS2"* ]]; then # smaracts have motor prefix, so we catch them with the PREFIX
+        edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &
     else
         cd /reg/neh/home/klg/epics/ioc/common/aerotech/current/motorScreens
         #cd /reg/neh/home4/mcbrowne/trunk2/ioc/common/aerotech/current/motorScreens

--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -25,7 +25,7 @@ PREFIX=`echo $1 | cut -d . -f 1`
 source /reg/g/pcds/setup/epicsenv-3.14.12.sh
 export PCDS_EDMS=/reg/g/pcds/package/epics/3.14/screens/edm
 #export EDMDATAFILES=.:${PCDS_EDMS}/xps8:${PCDS_EDMS}/ims  # normal EDMDATAFILES line
-export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/reg/g/pcds/epics/ioc/common/smaract/R1.0.11/motorScreens
+export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/cds/group/pcds/epics/ioc/common/smaract/R1.0.11/motorScreens:/cds/group/pcds/epics/ioc/common/mmc/R1.0.6/mmcScreens
 
 # this ldpathmunge gives access to xdotool for xpp-control, xpp-daq
 source /reg/g/pcds/setup/pathmunge.sh
@@ -77,6 +77,8 @@ if [ "${rtyp}" == 'xps8p' ]; then
         ext=0000
     fi
     edm -x -eolc -m "CNAME=${base}_${ext},POS=$PREFIX" XPS8_Positioner.edl > /dev/null 2>&1 &
+elif [ "${rtyp}" == 'mmca' ]; then # MMC-100 axis
+    edm -x -eolc -m "MOTOR=$PREFIX" mmc_main.edl > /dev/null 2>&1 &
 elif [ "${rtyp}" == 'motor' ]; then
     caget "$PREFIX:PN" > /dev/null 2>&1
     if [ $? -eq 0 ]; then

--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -25,7 +25,7 @@ PREFIX=`echo $1 | cut -d . -f 1`
 source /reg/g/pcds/setup/epicsenv-3.14.12.sh
 export PCDS_EDMS=/reg/g/pcds/package/epics/3.14/screens/edm
 #export EDMDATAFILES=.:${PCDS_EDMS}/xps8:${PCDS_EDMS}/ims  # normal EDMDATAFILES line
-export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/reg/g/pcds/epics/ioc/common/smaract/R1.0.10/motorScreens
+export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/reg/g/pcds/epics/ioc/common/smaract/R1.0.11/motorScreens
 
 # this ldpathmunge gives access to xdotool for xpp-control, xpp-daq
 source /reg/g/pcds/setup/pathmunge.sh

--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -81,7 +81,7 @@ elif [ "${rtyp}" == 'motor' ]; then
     caget "$PREFIX:PN" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         /reg/g/pcds/package/epics/3.14//modules/pcds_motion/${OLD_VERSION}/launch-motor.sh "$PREFIX" > /dev/null 2>&1 &
-    elif [[ $PREFIX == *"MCS2"* ]]; then # smaracts have motor prefix, so we catch them with the PREFIX
+    elif [[ $PREFIX == *"MCS2"* ]]; then # smaracts have "motor" rtyp, so we catch them with the PREFIX
         edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &
     else
         cd /reg/neh/home/klg/epics/ioc/common/aerotech/current/motorScreens


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add the right expert screen for SmarAct stages

## Motivation and Context
Have the expert screen script open the right screen for SmarAct

## How Has This Been Tested?
Tested with some axis of the LIB SmarAct IOC at XPP.

## Where Has This Been Documented?
Docstring in the script

<!--
## Screenshots (if appropriate):
-->
