### PR TITLE
MAINT: cleaner handling of latest conda and dev conda

### DIFF
--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -28,8 +28,8 @@ source "${BASE_ENV}/etc/profile.d/conda.sh"
 
 # Activate base env first so things like conda build are available
 conda activate
-# Default to dev pcds release
-conda activate dev
+# Default to latest pcds release as the base
+conda activate "$(cat "${BASE_ENV}/latest_env")"
 
 PCDSDEVICES_DEV_UI="${APPS_ROOT}/dev/pcdsdevices/pcdsdevices/ui"
 

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -65,9 +65,7 @@ if [[ -z "${PCDS_CONDA_VER}" ]]; then
   # If env var unset, then default to latest
   BASE_ENV="${CONDA_ROOT}/py39"
   PYTHON_VER="3.9"
-  PCDS_CONDA_VER="$(command ls "${BASE_ENV}/envs" | command grep pcds- | command tail -1)"
-  SERIES="pcds"
-  VER_NUM="$(echo "${PCDS_CONDA_VER}" | cut -d - -f 2)"
+  PCDS_CONDA_VER="$(cat "${BASE_ENV}/latest_env")"
 else
   # Figure out which base to use
   if [[ -z "${PCDS_CONDA_VER##*-*}" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- For `dev_conda`, use the latest tag as a base instead of an arbitrary outdated `dev` environment. This gives us a better chance of dev always being up-to-date and stable.
- For `pcds_conda` and `dev_conda`, find the latest tag via config file instead of automatically.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The outdated `dev` environment is causing issues because the base packages are so far behind and it's not possible to update it safely in-place.
The dynamically picked `pcds_conda` environment path causes issues (closes #136)
Now, we will be able to test and vet the fully installed environment before dropping people into it by default.

I've placed the config file for this inside of the conda environment itself. This keeps it one level hidden from accidental changes and allows a different config seamlessly when we boost to the next version of Python.

See `/cds/group/pcds/pyps/conda/py39/latest_env`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A, should be transparent to users.
<!--
## Screenshots (if appropriate):
-->
