### PR TITLE
FIX: pydev_env was not showing dev typhos templates

### DIFF
--- a/scripts/pydev_env
+++ b/scripts/pydev_env
@@ -18,3 +18,5 @@ source pcds_conda
 PYDEV="${HOME}/pydev"
 export PATH="${PYDEV}/bin:${PATH}"
 export PYTHONPATH="${PYDEV}:${PYTHONPATH}"
+# The following is set by pcds_conda and needs to be undone for dev typhos to pick your templates
+unset PYDM_DISPLAYS_PATH


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Unset the long `PYDM_DISPLAYS_PATH` from `pcds_conda` in the `pydev_env` setup

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The path here was masking personal dev env screens with the production screens, preventing testing of dev typhos templates when using `pydev_env`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes later

<!--
## Screenshots (if appropriate):
-->
