### PR TITLE
Fix/makeped jf fraclm

### DIFF
--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -198,7 +198,6 @@ deploy_gain()
     fi
 }
 
-
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -319,9 +318,9 @@ do
 done
 set -- "${POSITIONAL[@]}"
 
-
 T="$(date +%s%N)"
-echo "XXXXXXXXXXXXXXXXX START MAKEPEDS DEV at $(date +'%T') on $HOSTNAME XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+echo "XXXXXXXXXXXXXXXXX START MAKEPEDS at $(date +'%T') on $HOSTNAME XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
 
 RUN=${RUN:=0}
 EXP=${EXP:='xxx'}
@@ -665,7 +664,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     #specify parameters for status bits in pixel mask
     get_config "Jungfrau"
 
-    JFARG=$JFARG' --int_lo='$ADUMIN' --int_hi='$ADUMAX' --rms_lo='$NOISESIGMIN' --rms_hi='$NOISESIGMAX
+    JFARG=$JFARG' --int_lo='$ADUMIN' --int_hi='$ADUMAX' --rms_lo='$NOISESIGMIN' --rms_hi='$NOISESIGMAX' --fraclm='$FRACLM
 
     echo "-------------------- START JUNGFRAU PEDESTALS at $(date +'%T') ----------------------------"
 

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -32,7 +32,7 @@ HUTCH=${EXP:0:3}
 echo $PYCMD -i "${HUTCH^^}" -u `whoami` -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"
 $PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"&
 
-echo 'please call: makepeds -u <userID> -r '`get_lastRun`
+echo 'please call: makepeds -r '`get_lastRun`' -u <userID>'
 echo 'for gainswitching detectors we recommend: makepeds -u <userID> -q <ffb-queue-assigned-in-elog> -r '`get_lastRun`
 #echo 'we need to use the offline data to process pedestals right now, make sure files have moved, otherwise a very silent failure might happen'
 #echo 'please call: makepeds -u <userID> -e '`get_curr_exp`' -r '`get_lastRun`' -q psfehhiprioq'


### PR DESCRIPTION
## Description
Adding a parameter for the jungfrau pedestal status to makepeds(_psana)

## Motivation and Context
the default in the current release ana-4.0.47-py3 flags about half the jungfrau1M pixels as bad....bad means that 1 event in a run has a very low or high pedestal value.

## How Has This Been Tested?
Running & checking the status...
