### PR TITLE
ENH: Added check for Beckhoff axis

### DIFF
--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -1,5 +1,3 @@
-isbeckhoff=false
-
 #!/bin/bash
 
 OLD_VERSION='R2.5.0'

--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -31,10 +31,21 @@ export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/commo
 source /reg/g/pcds/setup/pathmunge.sh
 ldpathmunge /usr/local/lib
 
+# Check to see if this is a Beckhoff axis
+#   caget will return exit code 0 if :PLC:nErrorId_RBV exists, 
+#   we set isbeckhoff based on this.
+isbeckhoff=false
+caget "${PREFIX}:PLC:nErrorId_RBV" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    isbeckhoff=true
+fi
+
 # Choose title so we can move the right window.
 # If this script hangs later, titles probably changed.
 rtyp=`caget -t $PREFIX.RTYP` > /dev/null 2>&1
-if [ "${rtyp}" == 'xps8p' ]; then
+if [ ${isbeckhoff} == true ]; then
+    title="Typhos Suite - ${PREFIX}"
+elif [ "${rtyp}" == 'xps8p' ]; then
     title='Newport XPS Positioner'
 elif [ "${rtyp}" == 'ims' ]; then
     title='IMS Motor Control -- Main'
@@ -49,7 +60,6 @@ else
     fi
 fi
 
-
 # xdotool is used to move the new window to the mouse location
 # if xdotool is not installed, the move window commands will skip
 
@@ -57,7 +67,9 @@ fi
 oldwins=`xdotool search --onlyvisible --maxdepth 2 --all --name "$title" 2> /dev/null`
 
 # Open new window
-if [ "${rtyp}" == 'xps8p' ]; then
+if [ ${isbeckhoff} == true ]; then
+    motor-typhos ${PREFIX} > /dev/null 2>&1 &
+elif [ "${rtyp}" == 'xps8p' ]; then
     # If we have a Newport motor, we need to parse the PV to get the macro
     # substitutions for the edm screen
     base=`echo $PREFIX | cut -d':' -f 1,2,3`

--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -1,3 +1,5 @@
+isbeckhoff=false
+
 #!/bin/bash
 
 OLD_VERSION='R2.5.0'
@@ -31,26 +33,27 @@ export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/commo
 source /reg/g/pcds/setup/pathmunge.sh
 ldpathmunge /usr/local/lib
 
-# Check to see if this is a Beckhoff axis
-#   caget will return exit code 0 if :PLC:nErrorId_RBV exists, 
-#   we set isbeckhoff based on this.
+# bool used to to deterime if a motor with .rtyp == 'motor' is a Beckhoff axis.
 isbeckhoff=false
-caget "${PREFIX}:PLC:nErrorId_RBV" > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    isbeckhoff=true
-fi
 
 # Choose title so we can move the right window.
 # If this script hangs later, titles probably changed.
 rtyp=`caget -t $PREFIX.RTYP` > /dev/null 2>&1
-if [ ${isbeckhoff} == true ]; then
-    title="Typhos Suite - ${PREFIX}"
-elif [ "${rtyp}" == 'xps8p' ]; then
+if [ "${rtyp}" == 'xps8p' ]; then
     title='Newport XPS Positioner'
 elif [ "${rtyp}" == 'ims' ]; then
     title='IMS Motor Control -- Main'
 elif [ "${rtyp}" == 'motor' ]; then
-    title='Aerotech motor'
+    # Check to see if this is a Beckhoff axis
+    #   caget will return exit code 0 if :PLC:nErrorId_RBV exists,
+    #   we set isbeckhoff based on this.
+    caget "${PREFIX}:PLC:nErrorId_RBV" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        title="Typhos Suite - ${PREFIX}"
+        isbeckhoff=true;
+    else
+        title='Aerotech motor'
+    fi
 else
     caget "$PREFIX.PN" > /dev/null 2>&1
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a check for Beckhoff motors and launch the typhos motor screen. 
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, Beckhoff motors defaulted to the Aerotech edm screen.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested the script by calling IMS motors and PLC motors. Ensured that the typhos window title iscorrectly defined so the repositioning works as intended.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
Added comments where the check is performed.
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
