### PR TITLE
Bare repo script

### DIFF
--- a/scripts/new_bare_repo
+++ b/scripts/new_bare_repo
@@ -37,6 +37,8 @@ then
     git-bare-repo /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
     git remote add origin /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
     git push -u origin master
-else
-    echo "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/ does not exist"
+elif [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ]
+    echo "The directory /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/ does not exist!"
+elif [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ]
+    echo "There already exists a bare repo for this device!"
 fi

--- a/scripts/new_bare_repo
+++ b/scripts/new_bare_repo
@@ -15,20 +15,25 @@ You also might need to run kinit and aklog before hand!
 EOF
 }
 
-if [ $# -lt 1 ]; then
+if [[ ($1 == "--help") || ($1 == "-h") ]]; then
+   usage
+   exit 0
+
+elif [ $# -lt 2 ]; then
    echo 'Need to specify the hutch and name of the proposed bare repo' >&2
    usage
    exit 1
 
-elif [[ ($1 == "--help") || ($1 == "-h") ]]; then
-   usage
-   exit 0
 fi
 
 HUTCH=$1
 REPO=$2
+CWD=$(PWD)
 
-if [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ] && [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ]
+Check if current working directory is 
+
+
+if [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ] && [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ] && [${CWD} == *${REPO}* ]
 then
     git init
     cp /cds/sw/tools/bin/eco_tools/gitignore.template .gitignore
@@ -39,6 +44,8 @@ then
     git push -u origin master
 elif [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ]
     echo "The directory /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/ does not exist!"
+    exit 1
 elif [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ]
     echo "There already exists a bare repo for this device!"
+    exit 1
 fi

--- a/scripts/new_bare_repo
+++ b/scripts/new_bare_repo
@@ -1,0 +1,42 @@
+#!/bin/bash
+usage()
+{
+cat << EOF
+usage: new_bare_repo <hutch> <repo name>
+
+Script for automating the tedious process of integrating an existing IOC into our git bare repo scheme
+Run in the top level of your IOC
+
+Ex. new_bare_repo rix new_device
+(Creates a new bare repo in /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/rix/ named "new_device.git")
+
+You also might need to run kinit and aklog before hand!
+
+EOF
+}
+
+if [ $# -lt 1 ]; then
+   echo 'Need to specify the hutch and name of the proposed bare repo' >&2
+   usage
+   exit 1
+
+elif [[ ($1 == "--help") || ($1 == "-h") ]]; then
+   usage
+   exit 0
+fi
+
+HUTCH=$1
+REPO=$2
+
+if [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ] && [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ]
+then
+    git init
+    cp /cds/sw/tools/bin/eco_tools/gitignore.template .gitignore
+    git add *.cfg Makefile .gitignore
+    git commit -m "Initial commit"
+    git-bare-repo /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
+    git remote add origin /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
+    git push -u origin master
+else
+    echo "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/ does not exist"
+fi

--- a/scripts/new_bare_repo
+++ b/scripts/new_bare_repo
@@ -28,22 +28,23 @@ fi
 
 HUTCH=$1
 REPO=$2
-CWD=$(PWD)
+CWD=$PWD
 
-
-if [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ] && [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ] && [${CWD} == *${REPO}* ]
-then
-    git init
-    cp /cds/sw/tools/bin/eco_tools/gitignore.template .gitignore
-    git add *.cfg Makefile .gitignore
-    git commit -m "Initial commit"
-    git-bare-repo /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
-    git remote add origin /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
-    git push -u origin master
-elif [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ]
+set -e
+if [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ]
     echo "The directory /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/ does not exist!"
     exit 1
 elif [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ]
     echo "There already exists a bare repo for this device!"
     exit 1
+elif [ ${CWD} != *${REPO}* ]
+    echo "Current working directory does not contain the name of the planned repo, check that you are running this script in the right place"
+    exit 1
+else
+    git init
+    cp -u /cds/sw/tools/bin/eco_tools/gitignore.template .gitignore
+    git add *.cfg Makefile .gitignore
+    git commit -m "Initial commit"
+    git-bare-repo /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
+    git remote add origin /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git
 fi

--- a/scripts/new_bare_repo
+++ b/scripts/new_bare_repo
@@ -30,8 +30,6 @@ HUTCH=$1
 REPO=$2
 CWD=$(PWD)
 
-Check if current working directory is 
-
 
 if [ -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/" ] && [ ! -d "/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/${HUTCH}/${REPO}.git" ] && [${CWD} == *${REPO}* ]
 then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There are a lot of IOCs that are not properly version controlled since we moved from svn to git. Often, I run into IOCs that do not have a hutch specific bare repo setup, so I made this script to help facilitate the process of creating that bare repo and the subsequent steps afterwards.

<!--- Describe your changes in detail -->
This script: 

1. Initializes the local repository
2. Checks in the .cfg file, Makefile and .gitignore
3. Creates the bare repo in the proper location using eco_tools git-bare-repo script
4. Sets this newly created bare repo as the remote origin and sets it as the upstream

## Motivation and Context
As mentioned above

## How Has This Been Tested?
This has been tested once with the Smarpod IOC, which I had yet to create a hutch bare repo for. Worked perfectly. 

## Where Has This Been Documented?
Code includes simple explanations for how to use the script.

If this script is redundant, or could be useful in another script or repository, feel free to shoot this down.
