### PR TITLE
fix takepeds for elog script

### DIFF
--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -23,8 +23,7 @@ $DAQ_RELEASE/tools/scanning/take_pedestals -p $station -r
 
 elogMessage="DARK"
 source pcds_conda
-#export PYTHONPATH=/reg/g/pcds/pyps/apps/hutch-python/common/dev/elog:${PYTHONPATH}
-PYCMD=LogBookPost.py
+PYCMD=LogBookPost
 
 EXP=`get_curr_exp`
 RUN=`get_lastRun`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
remove the .py extension on the elog script call, as per the recent changes to pcds_conda
