### PR TITLE
(re)add hutch autodiscovery

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -266,14 +266,13 @@ fi
 
 verify-hutch "$hutch"
 if [ $? == 1 ]; then
-    echo 'No hutch or invalid hutch name passed. Trying to guess hutch.'
     hutch=$(get_info --gethutch)
     if [ "$hutch" == unknown_hutch ]; then
-        echo 'unknown hutch, specify using -H option with a valid hutch name.'
+        echo 'Unknown hutch, specify using -H option with a valid hutch name.'
         usage
         exit 1
     fi
-    echo "Picked $hutch."
+    echo "Launching camViewer for  $hutch."
 fi
 
 EXE="/reg/g/pcds/pyps/config/$hutch/camviewer/run_viewer.csh"

--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -273,6 +273,7 @@ if [ $? == 1 ]; then
         usage
         exit 1
     fi
+    echo "Picked $hutch."
 fi
 
 EXE="/reg/g/pcds/pyps/config/$hutch/camviewer/run_viewer.csh"

--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -272,7 +272,7 @@ if [ $? == 1 ]; then
         usage
         exit 1
     fi
-    echo "Launching camViewer for  $hutch."
+    echo "Launching camViewer for $hutch."
 fi
 
 EXE="/reg/g/pcds/pyps/config/$hutch/camviewer/run_viewer.csh"

--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -264,7 +264,6 @@ if [ $# -ge 1 ]; then
     exit 1
 fi
 
-verify-hutch "$hutch"
 if ! verify-hutch "$hutch"; then
     hutch=$(get_info --gethutch)
     if [ "$hutch" == unknown_hutch ]; then

--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -265,7 +265,15 @@ if [ $# -ge 1 ]; then
 fi
 
 verify-hutch "$hutch"
-
+if [ $? == 1 ]; then
+    echo 'No hutch or invalid hutch name passed. Trying to guess hutch.'
+    hutch=$(get_info --gethutch)
+    if [ "$hutch" == unknown_hutch ]; then
+        echo 'unknown hutch, specify using -H option with a valid hutch name.'
+        usage
+        exit 1
+    fi
+fi
 
 EXE="/reg/g/pcds/pyps/config/$hutch/camviewer/run_viewer.csh"
 PVLIST="/reg/g/pcds/pyps/config/$hutch/camviewer.cfg"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fix hutch auto-discovery in camViewer

## Motivation and Context
The auto-discoevry had been accidentaly removed in the previous PR on this script

## How Has This Been Tested?
Tested as xppopr on xpp-control for the following commands:
camViewer
camViewer -H xpp
camViewer -H xll

