### PR TITLE
clean up psana / ffb stuff from makepeds

### DIFF
--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -193,7 +193,8 @@ else
     if [[ $S3DF == 1 ]]; then
         echo calling on SDF system: makepeds_psana $@
         #we need to change paths here as directories are completely independent
-        if [ -v $SDFDIR  ]; then
+        if [ -v SDFDIR  ]; then
+            echo "SDFDIR: $SDFDIR"
             DIR=$SDFDIR
         else
             DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -15,8 +15,6 @@ OPTIONS:
                user (needs to be able to log into the psananeh/feh)
         -p|--post <text>  
                add <text> to elog post
-        -F|--ffb
-                run job on FFB system
         -t|--test
                 do not deploy pedestals (epix10k only)
         -r|--run         
@@ -68,126 +66,104 @@ POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
         key="$1"
-	case $key in
-		-h|--help)x
-			usage
-			exit
-			;;
-		-p|--post)
-		        ELOGTEXT="$2"
-			shift
-			shift
-			;;
-           	-D|--xtcav_dark)
+        case $key in
+                -h|--help)x
+                        usage
+                        exit
+                        ;;
+                -p|--post)
+                        ELOGTEXT="$2"
+                        shift
+                        shift
+                        ;;
+                -D|--xtcav_dark)
                         POSITIONAL+=("$1")
-	                elogMessage="DARK for XTCAV"
-			shift
-			;;
-           	-L|--xtcav_lasingoff)
+                        elogMessage="DARK for XTCAV"
+                        shift
+                        ;;
+                -L|--xtcav_lasingoff)
                         POSITIONAL+=" $1"
-	                elogMessage="Lasing off for XTCAV"
-			shift
-			;;
-           	-i|--interactive)
+                        elogMessage="Lasing off for XTCAV"
+                        shift
+                        ;;
+                -i|--interactive)
                         POSITIONAL+=("$1")
-	                elogMessage="start calibman GUI"
-			shift
-			;;
-           	-U|--uxi)
+                        elogMessage="start calibman GUI"
+                        shift
+                        ;;
+                -U|--uxi)
                         POSITIONAL+=("$1")
-	                elogMessage="DARK for Uxi"
-			shift
-			;;
-           	-Z|--zyla)
+                        elogMessage="DARK for Uxi"
+                        shift
+                        ;;
+                -Z|--zyla)
                         POSITIONAL+=("$1")
-	                elogMessage="DARK for Zyla"
-			shift
-			;;
-           	-O|--opal)
+                        elogMessage="DARK for Zyla"
+                        shift
+                        ;;
+                -O|--opal)
                         POSITIONAL+=("$1")
-	                elogMessage="DARK for opal"
-			shift
-			;;
-           	-R|--rayonix)
+                        elogMessage="DARK for opal"
+                        shift
+                        ;;
+                -R|--rayonix)
                         POSITIONAL+=("$1")
-	                elogMessage="DARK for Rayonix"
-			shift
-			;;
-           	-j|--jungfrau3)
+                        elogMessage="DARK for Rayonix"
+                        shift
+                        ;;
+                -j|--jungfrau3)
                         POSITIONAL+=("$1")
-	                elogMessage="DARK for jungfrau, also next two runs."
-			shift
-			;;
-           	-u|--user)
-		        USER="$2"
-			shift
-			shift
-			;;
-           	-r|--run)
-		        RUN="$2"
+                        elogMessage="DARK for jungfrau, also next two runs."
+                        shift
+                        ;;
+                -u|--user)
+                        USER="$2"
+                        shift
+                        shift
+                        ;;
+                -r|--run)
+                        RUN="$2"
                         POSITIONAL+=("--run $2")
-			shift
-			shift
-			;;
-           	-e|--experiment)
-		        EXP="$2"
+                        shift
+                        shift
+                        ;;
+                -e|--experiment)
+                        EXP="$2"
                         POSITIONAL+=("--experiment $2")
-			shift
-			shift
-			;;
-           	-F|--ffb)
-		        FFB=1
-			shift
-			;;
-           	-q|--queue)
-		        QUEUE="$2"
+                        shift
+                        shift
+                        ;;
+                -q|--queue)
+                        QUEUE="$2"
                         POSITIONAL+=("--queue $2")
-			shift
-			shift
-			;;
-                 *)
+                        shift
+                        shift
+                        ;;
+                        *)
                         POSITIONAL+=("$1")
-			shift
-			;;
-	esac
+                        shift
+                        ;;
+        esac
 done
 set -- "${POSITIONAL[@]}"
-	
+
 ELOGTEXT=${ELOGTEXT:=""}
 RUN=${RUN:=0}
 EXP=${EXP:='xxx'}
-FFB=${FFB:=0}
 QUEUE=${QUEUE:='xxx'}
 INTERACTIVE=${INTERACTIVE:=0}
 
-FFBQUEUES=('anaq' 'ffbh1q' 'ffbl1q' 'ffbh2q' 'ffbl2q' 'ffbh3q' 'ffbl3q' 'ffbgpuq')
-ANAQUEUES=('psanagpuq' 'psanaq')
 SDFQUEUES=('milano' 'roma')
-for FFBQUEUE in ${FFBQUEUES[@]}; do
-    if [[ $QUEUE == $FFBQUEUE ]]; then 
-	FFB=1
-	break
-    fi
-done
-
-for ANAQUEUE in ${ANAQUEUES[@]}; do
-    if [[ $QUEUE == $ANAQUEUE ]]; then 
-	FFB=0
-	break
-    fi
-done
-
 for SDFQUEUE in ${SDFQUEUES[@]}; do
     if [[ $QUEUE == $SDFQUEUE ]]; then 
-	FFB=2
-	break
+	S3DF=1
     fi
 done
 
 
 if [[ $RUN == 0 ]]; then
     if [[ $INTERACTIVE == 0 ]]; then
-	printf "Please enter a run number: \n"; read RUN
+        printf "Please enter a run number: \n"; read RUN
         set -- "$@" '--run ' $RUN
     fi
 fi
@@ -200,28 +176,20 @@ else
     HUTCH=${EXP:0:3}
 fi
 
-if [[ $HOSTNAME =~ "psana" ]] || [[ $HOSTNAME =~ "drp-srcf" ]] || [[ $HOSTNAME =~ "sdf" ]]; then
+if [[ $HOSTNAME =~ "sdf" ]]; then
     #echo $DIR/makepeds_psana $@
     $DIR/makepeds_psana $@
 else
     if [[ $USER =~ "opr" ]]; then
         printf "Please enter user name (cannot run as from operator account): \n"; read USER
     fi
-
-    if [[ $FFB == 1 ]]; then
-        echo calling on FFB system: makepeds_psana $@
-        echo ssh -Y $USER@psffb "$DIR/makepeds_psana $@"
-        ssh -Y $USER@psffb "$DIR/makepeds_psana $@"
-    elif [[ $FFB == 2 ]]; then
+    
+    if [[ SDF == 1 ]]; then
         echo calling on SDF system: makepeds_psana $@
         #we need to change paths here as directories are completely independent
         DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`
         echo ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
         ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
-    else
-        echo calling on offline system: makepeds_psana $@
-        echo ssh -Y $USER@psana "$DIR/makepeds_psana $@"
-        ssh -Y $USER@psana "$DIR/makepeds_psana $@"
     fi
 fi
 

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -192,9 +192,8 @@ else
     fi
     if [[ $S3DF == 1 ]]; then
         echo calling on SDF system: makepeds_psana $@
-        #we need to change paths here as directories are completely independent
+        # We need to change paths here as the S3DF filesytem is completely independent
         if [ -v SDFDIR  ]; then
-            echo "SDFDIR: $SDFDIR"
             DIR=$SDFDIR
         else
             DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -166,7 +166,6 @@ for SDFQUEUE in ${SDFQUEUES[@]}; do
 	S3DF=1
     fi
 done
-echo "S3DF: $S3DF"
 
 if [[ $RUN == 0 ]]; then
     if [[ $INTERACTIVE == 0 ]]; then

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -12,7 +12,7 @@ Make a pedestal file for offline use
 
 OPTIONS:
         -u|--user        
-               user (needs to be able to log into the psananeh/feh)
+               user (needs to be able to log into the s3df)
         -p|--post <text>  
                add <text> to elog post
         -t|--test
@@ -57,6 +57,8 @@ OPTIONS:
                 give path for alternative calibdir
         -b|--nbunch
                 number of bunches for the laseroff XTCAV calculations
+        --sdfdir
+                Directory where engineering tool in on S3DF. For development work only.
 EOF
 }
 
@@ -65,84 +67,89 @@ elogMessage="DARK"
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
-        key="$1"
-        case $key in
-                -h|--help)x
-                        usage
-                        exit
-                        ;;
-                -p|--post)
-                        ELOGTEXT="$2"
-                        shift
-                        shift
-                        ;;
-                -D|--xtcav_dark)
-                        POSITIONAL+=("$1")
-                        elogMessage="DARK for XTCAV"
-                        shift
-                        ;;
-                -L|--xtcav_lasingoff)
-                        POSITIONAL+=" $1"
-                        elogMessage="Lasing off for XTCAV"
-                        shift
-                        ;;
-                -i|--interactive)
-                        POSITIONAL+=("$1")
-                        elogMessage="start calibman GUI"
-                        shift
-                        ;;
-                -U|--uxi)
-                        POSITIONAL+=("$1")
-                        elogMessage="DARK for Uxi"
-                        shift
-                        ;;
-                -Z|--zyla)
-                        POSITIONAL+=("$1")
-                        elogMessage="DARK for Zyla"
-                        shift
-                        ;;
-                -O|--opal)
-                        POSITIONAL+=("$1")
-                        elogMessage="DARK for opal"
-                        shift
-                        ;;
-                -R|--rayonix)
-                        POSITIONAL+=("$1")
-                        elogMessage="DARK for Rayonix"
-                        shift
-                        ;;
-                -j|--jungfrau3)
-                        POSITIONAL+=("$1")
-                        elogMessage="DARK for jungfrau, also next two runs."
-                        shift
-                        ;;
-                -u|--user)
-                        USER="$2"
-                        shift
-                        shift
-                        ;;
-                -r|--run)
-                        RUN="$2"
-                        POSITIONAL+=("--run $2")
-                        shift
-                        shift
-                        ;;
-                -e|--experiment)
-                        EXP="$2"
-                        POSITIONAL+=("--experiment $2")
-                        shift
-                        shift
-                        ;;
-                -q|--queue)
-                        QUEUE="$2"
-                        POSITIONAL+=("--queue $2")
-                        shift
-                        shift
-                        ;;
-                        *)
-                        POSITIONAL+=("$1")
-                        shift
-                        ;;
+    key="$1"
+    case $key in
+        -h|--help)x
+            usage
+            exit
+            ;;
+        -p|--post)
+            ELOGTEXT="$2"
+            shift
+            shift
+            ;;
+        -D|--xtcav_dark)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for XTCAV"
+            shift
+            ;;
+        -L|--xtcav_lasingoff)
+            POSITIONAL+=" $1"
+            elogMessage="Lasing off for XTCAV"
+            shift
+            ;;
+        -i|--interactive)
+            POSITIONAL+=("$1")
+            elogMessage="start calibman GUI"
+            shift
+            ;;
+        -U|--uxi)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for Uxi"
+            shift
+            ;;
+        -Z|--zyla)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for Zyla"
+            shift
+            ;;
+        -O|--opal)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for opal"
+            shift
+            ;;
+        -R|--rayonix)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for Rayonix"
+            shift
+            ;;
+        -j|--jungfrau3)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for jungfrau, also next two runs."
+            shift
+            ;;
+        -u|--user)
+            USER="$2"
+            shift
+            shift
+            ;;
+        -r|--run)
+            RUN="$2"
+            POSITIONAL+=("--run $2")
+            shift
+            shift
+            ;;
+        -e|--experiment)
+            EXP="$2"
+            POSITIONAL+=("--experiment $2")
+            shift
+            shift
+            ;;
+        -q|--queue)
+            QUEUE="$2"
+            POSITIONAL+=("--queue $2")
+            shift
+            shift
+            ;;
+        --sdfdir)
+            SDFDIR="$2"
+            shift
+            shift
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
         esac
 done
 set -- "${POSITIONAL[@]}"
@@ -159,7 +166,7 @@ for SDFQUEUE in ${SDFQUEUES[@]}; do
 	S3DF=1
     fi
 done
-
+echo "S3DF: $S3DF"
 
 if [[ $RUN == 0 ]]; then
     if [[ $INTERACTIVE == 0 ]]; then
@@ -183,11 +190,14 @@ else
     if [[ $USER =~ "opr" ]]; then
         printf "Please enter user name (cannot run as from operator account): \n"; read USER
     fi
-    
-    if [[ SDF == 1 ]]; then
+    if [[ $S3DF == 1 ]]; then
         echo calling on SDF system: makepeds_psana $@
         #we need to change paths here as directories are completely independent
-        DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`
+        if [ -v $SDFDIR  ]; then
+            DIR=$SDFDIR
+        else
+            DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`
+        fi
         echo ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
         ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
     fi

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -32,7 +32,7 @@ echo $PYCMD -i "${HUTCH^^}" -u `whoami` -e "$EXP"  -t DARK  -r $RUN -m "$elogMes
 $PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"&
 
 echo 'please call: makepeds -r '`get_lastRun`' -u <userID>'
-echo 'for gainswitching detectors we recommend: makepeds -u <userID> -q <ffb-queue-assigned-in-elog> -r '`get_lastRun`
+echo 'for gain-switching detectors we recommend: makepeds -u <userID> -q milano -r '`get_lastRun`
 #echo 'we need to use the offline data to process pedestals right now, make sure files have moved, otherwise a very silent failure might happen'
 #echo 'please call: makepeds -u <userID> -e '`get_curr_exp`' -r '`get_lastRun`' -q psfehhiprioq'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description


## Motivation and Context
As we are now using the S3DF, takepeds and makepeds should only run from there, or the calib files won't be written to the right place. Removing old psana and ffb from it ensures that there won't be accidental run of makepeds on the wrong systems. Should older pedestal be reprocessed, one should run from a previous release of engineering_tools


## How Has This Been Tested?
Full workflow tested with the Jungfrau from xpp-control

## Where Has This Been Documented?
Self documented with docstring
