### PR TITLE
feat(set_gem_timing): allowing operators to switch between HXR-GEM SC and NC timing with a one line script

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,5 +623,11 @@ Optional arguments:<br/>
     </td>
 </tr>
 
+<tr>
+    <td> set_gem_timing</td>
+    <td> 
+    Usage: set_gem_timing [SC or NC]
+    </td>
+</tr>
 
 </table>

--- a/scripts/set_gem_timing
+++ b/scripts/set_gem_timing
@@ -9,7 +9,7 @@ IOC_PATH=0
 
 # User input validation
 if [[ -n $1 ]]; then # if the user passed at least one arg
-  if [[ $1 != $NC_STRING ]] && [[ $1 != $SC_STRING ]]; then #validate argument is either SC or NC
+  if [[ $1 != "$NC_STRING" ]] && [[ $1 != "$SC_STRING" ]]; then #validate argument is either SC or NC
     echo "Error. Argument must be either: [NC or SC]"
     exit 1
   else
@@ -26,7 +26,7 @@ if [[ -n $2 ]]; then
 fi
 
 #get caget and caput
-source /cds/group/pcds/setup/epicsenv-cur.sh #Note: (josh) we should only source the actual executables we are using, this is heavy handed. Should be considered suboptimal, but should keep us consitent with the rest of the stack
+source /cds/group/pcds/setup/epicsenv-cur.sh #Note: (josh) we should only source the actual executables we are using, this is heavy handed. shellcheck does not love this; however if this path doesnt exist we have bigger problems
 #get imgr
 IMGR_CMD_PATH="/reg/g/pcds/engineering_tools/latest-released/scripts/imgr"
 
@@ -35,7 +35,7 @@ OP_MODE=$(caget KFE:CAM:TPR:02:MODE | awk '{print $2}')
 SET_MODE_CMD="caput KFE:CAM:TPR:02:MODE $1"
 
 echo "Current OP_MODE is: $OP_MODE"
-if [[ $OP_MODE = $1 ]]; then
+if [[ $OP_MODE = "$1" ]]; then
   echo "Already in requested mode: $OP_MODE exitting with NOP"
   exit 1
 else
@@ -44,7 +44,7 @@ else
 fi
 
 # only now discern which mode we want to put it in, TODO(josh): theres some more bashy way of string unwrapping todo this....
-if [[ $1 = $NC_STRING ]]; then
+if [[ $1 = "$NC_STRING" ]]; then
   IOC_PATH=$IOC_PATH_NC
 else
   IOC_PATH=$IOC_PATH_SC
@@ -52,7 +52,7 @@ fi
 
 SET_IOC_PATH_CMD="${IMGR_CMD_PATH} ioc-lfe-gasdet-daq --upgrade $IOC_PATH"
 CURR_IOC_PATH=$(${IMGR_CMD_PATH} ioc-lfe-gasdet-daq --info | awk 'FNR == 4 {print $3}') #Warning: make sure your release of imgr supports --info 
-if [[ CURR_IOC_PATH = IOC_PATH ]]; then
+if [[ $CURR_IOC_PATH = "$IOC_PATH" ]]; then
   echo "Current IOC path is: $CURR_IOC_PATH which is equiavlent to requested IOC path for the requested switch to $1, not invoking imgr"
 else
   echo "Actuating ioc-lfe-gasdet-daq IOC software change from $CURR_IOC_PATH to: $IOC_PATH"

--- a/scripts/set_gem_timing
+++ b/scripts/set_gem_timing
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+NC_STRING="NC"
+SC_STRING="SC"
+# TODO:(josh) reflect on hardcoded releases
+IOC_PATH_NC="ioc/fee/GasDetDAQ/R4.0.22"
+IOC_PATH_SC="ioc/fee/GasDetDAQ/R4.0.22-NOTS"
+IOC_PATH=0
+
+# User input validation
+if [[ -n $1 ]]; then # if the user passed at least one arg
+  if [[ $1 != $NC_STRING ]] && [[ $1 != $SC_STRING ]]; then #validate argument is either SC or NC
+    echo "Error. Argument must be either: [NC or SC]"
+    exit 1
+  else
+    echo "User passed argument of: $1"
+  fi
+else
+  echo "Error. Must pass at least one argument"
+  exit 1
+fi
+
+if [[ -n $2 ]]; then
+  echo "Warning. Must pass strictly one argument, additional arg: $2 is ignored"
+  exit 1
+fi
+
+# check current operational state
+OP_MODE=$(caget KFE:CAM:TPR:02:MODE | awk '{print $2}')
+SET_MODE_CMD="caput KFE:CAM:TPR:02:MODE $1"
+
+echo "Current OP_MODE is: $OP_MODE"
+if [[ $OP_MODE = $1 ]]; then
+  echo "Already in requested mode: $OP_MODE exitting with NOP"
+  exit 1
+else
+  echo "Actuating requested timing change, caputing $1 to KFE:CAM:TPR:02:MODE"
+  $SET_MODE_CMD
+fi
+
+# only now discern which mode we want to put it in, TODO(josh): theres some more bashy way of string unwrapping todo this....
+if [[ $1 = $NC_STRING ]]; then
+  IOC_PATH=$IOC_PATH_NC
+else
+  IOC_PATH=$IOC_PATH_SC
+fi
+
+SET_IOC_PATH_CMD="imgr ioc-lfe-gasdet-daq --upgrade $IOC_PATH"
+CURR_IOC_PATH=$(imgr ioc-lfe-gasdet-daq --info | awk 'FNR == 4 {print $3}') #Warning: make sure your release of imgr supports --info 
+if [[ CURR_IOC_PATH = IOC_PATH ]]; then
+  echo "Current IOC path is: $CURR_IOC_PATH which is equiavlent to requested IOC path for the requested switch to $1, not invoking imgr"
+else
+  echo "Actuating ioc-lfe-gasdet-daq IOC software change from $CURR_IOC_PATH to: $IOC_PATH"
+  $SET_IOC_PATH_CMD
+fi
+
+exit 0

--- a/scripts/set_gem_timing
+++ b/scripts/set_gem_timing
@@ -25,6 +25,11 @@ if [[ -n $2 ]]; then
   exit 1
 fi
 
+#get caget and caput
+source /cds/group/pcds/setup/epicsenv-cur.sh #Note: (josh) we should only source the actual executables we are using, this is heavy handed. Should be considered suboptimal, but should keep us consitent with the rest of the stack
+#get imgr
+IMGR_CMD_PATH="/reg/g/pcds/engineering_tools/latest-released/scripts/imgr"
+
 # check current operational state
 OP_MODE=$(caget KFE:CAM:TPR:02:MODE | awk '{print $2}')
 SET_MODE_CMD="caput KFE:CAM:TPR:02:MODE $1"
@@ -45,8 +50,8 @@ else
   IOC_PATH=$IOC_PATH_SC
 fi
 
-SET_IOC_PATH_CMD="imgr ioc-lfe-gasdet-daq --upgrade $IOC_PATH"
-CURR_IOC_PATH=$(imgr ioc-lfe-gasdet-daq --info | awk 'FNR == 4 {print $3}') #Warning: make sure your release of imgr supports --info 
+SET_IOC_PATH_CMD="${IMGR_CMD_PATH} ioc-lfe-gasdet-daq --upgrade $IOC_PATH"
+CURR_IOC_PATH=$(${IMGR_CMD_PATH} ioc-lfe-gasdet-daq --info | awk 'FNR == 4 {print $3}') #Warning: make sure your release of imgr supports --info 
 if [[ CURR_IOC_PATH = IOC_PATH ]]; then
   echo "Current IOC path is: $CURR_IOC_PATH which is equiavlent to requested IOC path for the requested switch to $1, not invoking imgr"
 else


### PR DESCRIPTION
Adding what should be a temporary hack script but may be somewhat long lived to provide a one line mechanism for operators to switch the timing paradigm on the HXR-GEM. This script:
- Sets PV: `KFE:CAM:TPR:02:MODE` to either SC or NC
- Invokes `imgr` to set the GEMs IOC version to the correct version for the corresponding timing paradigm

Invokation once sourced is of form: `set_gem_timing [scheme]` 
Schemes besides `NC` and `SC` will be rejected.

Associated PR: https://github.com/pcdshub/IocManager/pull/9

## Description
The `set_gem_timing` bash script critically:
- Sets PV: `KFE:CAM:TPR:02:MODE` to either SC or NC
- Invokes `imgr` to set the GEMs IOC version to the correct version for the corresponding timing paradigm

### Argument and State Parsing
- Input validates that only 1 argument is supplied and that argument is either `SC` or `NC`
- Will fail if `KFE:CAM:TPR:02:MODE` is already in whatever mode is trying to be actuated
- Will fail if `imgr --info` determines that the requested software is already on the device


## Motivation and Context
Ticket [ECS-3765](https://jira.slac.stanford.edu/browse/ECS-3765) requests a script to switch timing of the HXR-GEMs for the NC and SC timing schemas.

For the SC timing schema the crate that contains the HXR-GEM cannot be upgraded (or is prohibitively expensive to upgrade) which means the non SLAC EVR cannot receive / decode LCLS2 timing pulses.

To circumvent this Silke hardwired the LCLS2 timing signal from the IM2K0 to the HXR-GEM enabling LCLS2 timing to be passed to the L, hard x-ray, side of things. This means that as long as the hack exists and we want to collect SC (LCLSII) data on the HXR-GEM we need to toggle the IOC software to be the one that ignores timing and triggers when the IM2K0 camera triggers and we need a mechanism to toggle it back when we want to send NC beam to the HXR-GEM and get the additional information (timestamps) provided by actually going through the EVR on the crate.

This toggle can be accomplished [manually](https://confluence.slac.stanford.edu/pages/viewpage.action?spaceKey=PCDS&title=LCLS+II+Timing+Switchover+for+GEMs):

- From machine in the CA network: caput KFE:CAM:TPR:02:MODE X where X == NC or SC
  - I have heard but not confirmed this sets a bunch of PVs to predetermined values
- Switch the running software via imgr
  - ioc/fee/GasDetDAQ/R4.0.22 <- for NC
  - ioc/fee/GasDetDAQ/R4.0.22-NOTS <- SC

This script aims to deprecate both manual mechanisms GUI and CLI in switching between timing paradigms in favor of a one line command. This command can be plumbed into a button if desired.

## How Has This Been Tested?
- Josh has used it to switch timing paradigms for ACR for the evening shift on 9/6 and both shifts on 9/7.

## TODO:
- [x] this has all been from Josh's user account 
  - [x] check permissioning works as intended on operator account
  - [x] determine if sourcing should be handled by operator or this script
- [x] Upgrade the imgr instance for the lfe hutch to contain changes made in https://github.com/pcdshub/IocManager/pull/9
- [x] I would like to remove the absolute filepaths; but I would like to do it in a way thats principic to the rest of our system, someone will likely have to show me how we do it here

## Where Has This Been Documented?
* https://confluence.slac.stanford.edu/display/PCDS/IocManager+R2-5-0
