### PR TITLE
fix(set_gem_timing): updated logic to reflect application layer concers: do not exit the program if PV and IOC software are out of sync

### DIFF
--- a/scripts/set_gem_timing
+++ b/scripts/set_gem_timing
@@ -21,7 +21,7 @@ else
 fi
 
 if [[ -n $2 ]]; then
-  echo "Warning. Must pass strictly one argument, additional arg: $2 is ignored"
+  echo "Error. Must pass strictly one argument, at least one additional arg: $2, please run again with exclusively [NC or SC] as argument"
   exit 1
 fi
 
@@ -36,8 +36,7 @@ SET_MODE_CMD="caput KFE:CAM:TPR:02:MODE $1"
 
 echo "Current OP_MODE is: $OP_MODE"
 if [[ $OP_MODE = "$1" ]]; then
-  echo "Already in requested mode: $OP_MODE exitting with NOP"
-  exit 1
+  echo "Warning. Already in requested mode: $OP_MODE" #Note: (josh) we are opting to consider this not error worthy
 else
   echo "Actuating requested timing change, caputing $1 to KFE:CAM:TPR:02:MODE"
   $SET_MODE_CMD


### PR DESCRIPTION
## Description
Addressing the valid concern in the set_gem_timing script that we want to guard against the edge case where PV: `KFE:CAM:TPR:02:MODE` is inconsistent with IOC software path.

For reference here is the intended pairing:
|KFE:CAM:TPR:02:MODE Value | IOC Software Path|
| -------- | ------- |
| SC | `ioc/fee/GasDetDAQ/R4.0.22-NOTS`    |
| NC | `ioc/fee/GasDetDAQ/R4.0.22`     |

Critical functional change is that if an operator tries to run `set_gem_timing` into a mode in which the PV: `KFE:CAM:TPR:02:MODE` already is in it **will not** terminate the program.

## Motivation and Context
https://github.com/pcdshub/engineering_tools/pull/163#discussion_r1320381287

## How Has This Been Tested?
- [ ] publish update and ask operators to use tool

## Where Has This Been Documented?
Code comment and output of command
