### PR TITLE
Cater to restricted experiments

### DIFF
--- a/scripts/detector_totals.py
+++ b/scripts/detector_totals.py
@@ -154,7 +154,10 @@ if __name__ == '__main__':
         try:
             daq_counts[experiment] = getDAQDetectorTotals(experiment)
         except:
-            logger.exception("Exception getting  DAQ detector counts for %s. Note; this may be expected ( for example, restricted experiments ) ", experiment)
+            logger.exception("Exception getting  DAQ detector counts"
+                             " for %s. Note; this may be expected "
+                             "( for example, restricted experiments ) ", 
+                            experiment)
 
     det_counts = OrderedDict()
     for experiment, detectors in daq_counts.items():

--- a/scripts/detector_totals.py
+++ b/scripts/detector_totals.py
@@ -26,8 +26,9 @@ def getDAQDetectorTotals(experiment):
 
     resp = requests.get(
         f"{lgbkprefix}/{experiment}/ws/run_table_sources",
-        headers=krbheaders).json()
-    rps = resp["value"].get("DAQ", [])
+        headers=krbheaders)
+    resp.raise_for_status()
+    rps = resp.json()["value"].get("DAQ", [])
     daqdets = map(lambda x: x["source"].replace("params.", ""),
                   filter(lambda x: x["label"].startswith("DAQ Detectors/"),
                          rps))
@@ -150,7 +151,10 @@ if __name__ == '__main__':
     daq_counts = OrderedDict()
     for experiment in experiments:
         logger.debug("Getting DAQ detector counts for %s", experiment)
-        daq_counts[experiment] = getDAQDetectorTotals(experiment)
+        try:
+            daq_counts[experiment] = getDAQDetectorTotals(experiment)
+        except:
+            logger.exception("Exception getting  DAQ detector counts for %s. Note; this may be expected ( for example, restricted experiments ) ", experiment)
 
     det_counts = OrderedDict()
     for experiment, detectors in daq_counts.items():


### PR DESCRIPTION
With run 21, we introduced the notion of restricted experiments; that is, experiments for which most LCLS staff do not have permission. We get a permission denied exception when getting run table data from these experiments. We should just try/catch the exception, log it as expected and move on.