### PR TITLE
[ENH] Additional `makepeds` reporting and exclusion of recorder data stream

### DIFF
--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -62,6 +62,20 @@ check_running_jobs()
     REMJOBIDS=()
     for JOBID in "${JOBIDS[@]}"; do
         if  squeue | grep -q "$JOBID"; then
+            JOBSTATUS=`squeue | grep "${JOBID}" | awk '{print $5}'`
+            if [[ $JOBSTATUS == "R" ]]; then
+                echo "${JOBID} is RUNNING"
+            elif [[ "${JOBSTATUS}" == "PD" ]]; then
+                echo "${JOBID} is PENDING"
+            elif [[ "${JOBSTATUS}" == "CG" ]]; then
+                echo "${JOBID} is COMPLETING"
+            elif [[ "${JOBSTATUS}" == "PR" ]]; then
+                echo "${JOBID} has been PREEMPTED!"
+            elif [[ "${JOBSTATUS}" == "F" ]]; then
+                echo "${JOBID} has FAILED!"
+            else
+                echo "${JOBID} is STOPPED or SUSPENDED"
+            fi
             REMJOBIDS+=( "$JOBID" )
             NJOBS=$((NJOBS+1))
         fi
@@ -1037,7 +1051,7 @@ for MYDET in $DETS; do
 
     echo "-------------------- START CALIBRUN at $(date +'%T') for detector $MYDET----------------------------"
     source $SIT_ENV_DIR/manage/bin/psconda.sh
-    cmd="calibrun -r $RUN  -d $MYDET -P -e $EXP -x :dir=$XTCDIR $LOCARG"
+    cmd="calibrun -r $RUN  -d $MYDET -P -e $EXP -x :dir=$XTCDIR:stream=0-79 $LOCARG"
     echo "$cmd"
     $cmd
     echo "-------------------- END CALIBRUN at $(date +'%T') for detector $MYDET----------------------------"

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -56,6 +56,14 @@ OPTIONS:
 EOF
 }
 
+check_for_submit_error()
+{
+    if [[ $? != 0 ]]; then
+        echo "Submission failed. Does the user have permission to submit with experiment account?"
+        exit 1
+    fi
+}
+
 check_running_jobs()
 {
     declare -A SLURM_STAT_MSG=( ["R"]="is RUNNING."
@@ -103,6 +111,7 @@ xtcav_dark()
        xtcavCmd="sbatch --exclusive  --account lcls:$EXP -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
        echo "run in queue: $xtcavCmd"
        SUBMISSION=$($xtcavCmd)
+       check_for_submit_error
        echo "$SUBMISSION"
        THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
        JOBIDS+=( "$THISJOBID" )
@@ -137,6 +146,7 @@ xtcav_lasOff()
        xtcavCmd="sbatch --exclusive  --account lcls:$EXP -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
        echo "run in queue: $xtcavCmd"
        SUBMISSION=$($xtcavCmd)
+       check_for_submit_error
        echo "$SUBMISSION"
        THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
        JOBIDS+=( "$THISJOBID" )
@@ -610,6 +620,7 @@ if [[ $LCLS2 -gt 0 ]]; then
                         fi
                         echo "run in queue: $ep10kaCmd"
                         SUBMISSION=$($ep10kaCmd)
+                        check_for_submit_error
                         echo "$SUBMISSION"
                         THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
                         JOBIDS+=( "$THISJOBID" )
@@ -760,6 +771,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
                 fi
                 echo "run in queue: $jfCmd"        
                 SUBMISSION=$($jfCmd)
+                check_for_submit_error
                 echo "$SUBMISSION"
                 THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
                 JOBIDS+=( "$THISJOBID" )
@@ -864,6 +876,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
                 fi
                 echo "run in queue: $ep10kaCmd"
                 SUBMISSION=$($ep10kaCmd)
+                check_for_submit_error
                 echo "$SUBMISSION"
                 THISJOBID=$(echo "$SUBMISSION" | awk '{print $4}')
                 JOBIDS+=( "$THISJOBID" )

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -56,6 +56,20 @@ OPTIONS:
 EOF
 }
 
+cancel_jobs_ctrl_c()
+{
+    echo "Canceling all SLURM Jobs"
+    echo "------------------------"
+    for JOBID in "${JOBIDS[@]}"; do
+        echo "Canceling ${JOBID}"
+        scancel "${JOBID}"
+    done
+    echo "Exiting makepeds"
+    exit 130
+}
+
+trap cancel_jobs_ctrl_c SIGINT
+
 check_for_submit_error()
 {
     if [[ $? != 0 ]]; then

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -58,14 +58,14 @@ EOF
 
 check_running_jobs()
 {
-    declare -A SLURM_STAT_MSG = ( ["R"]="is RUNNING."
-                                  ["PD"]="is PENDING."
-                                  ["CG"]="is COMPLETING."
-                                  ["CD"]="has COMPLETED."
-                                  ["PR"]="was PREEMPTED!"
-                                  ["F"]="has FAILED!"
-                                  ["S"]="was SUSPENDED!"
-                                  ["ST"]="was STOPPED!" )
+    declare -A SLURM_STAT_MSG=( ["R"]="is RUNNING."
+                                ["PD"]="is PENDING."
+                                ["CG"]="is COMPLETING."
+                                ["CD"]="has COMPLETED."
+                                ["PR"]="was PREEMPTED!"
+                                ["F"]="has FAILED!"
+                                ["S"]="was SUSPENDED!"
+                                ["ST"]="was STOPPED!" )
     NJOBS=0
     REMJOBIDS=()
     for JOBID in "${JOBIDS[@]}"; do

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -58,23 +58,23 @@ EOF
 
 check_running_jobs()
 {
+    declare -A SLURM_STAT_MSG = ( ["R"]="is RUNNING."
+                                  ["PD"]="is PENDING."
+                                  ["CG"]="is COMPLETING."
+                                  ["CD"]="has COMPLETED."
+                                  ["PR"]="was PREEMPTED!"
+                                  ["F"]="has FAILED!"
+                                  ["S"]="was SUSPENDED!"
+                                  ["ST"]="was STOPPED!" )
     NJOBS=0
     REMJOBIDS=()
     for JOBID in "${JOBIDS[@]}"; do
         if  squeue | grep -q "$JOBID"; then
-            JOBSTATUS=`squeue | grep "${JOBID}" | awk '{print $5}'`
-            if [[ $JOBSTATUS == "R" ]]; then
-                echo "${JOBID} is RUNNING"
-            elif [[ "${JOBSTATUS}" == "PD" ]]; then
-                echo "${JOBID} is PENDING"
-            elif [[ "${JOBSTATUS}" == "CG" ]]; then
-                echo "${JOBID} is COMPLETING"
-            elif [[ "${JOBSTATUS}" == "PR" ]]; then
-                echo "${JOBID} has been PREEMPTED!"
-            elif [[ "${JOBSTATUS}" == "F" ]]; then
-                echo "${JOBID} has FAILED!"
+            JOBSTATUS=$(squeue | grep "${JOBID}" | awk '{print $5}')
+            if [ "${SLURM_STAT_MSG[$JOBSTATUS]}" ]; then
+                echo "${JOBID} ${SLURM_STAT_MSG[$JOBSTATUS]}"
             else
-                echo "${JOBID} is STOPPED or SUSPENDED"
+                echo "${JOBID} has unknown status ${JOBSTATUS}!"
             fi
             REMJOBIDS+=( "$JOBID" )
             NJOBS=$((NJOBS+1))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Currently, `makepeds` waits until jobs complete, checking every 10 seconds, but does not indicate the job status (pending/running/etc). This PR provides feedback on the status of those submitted jobs so a decision can be made as to whether it's just a matter of waiting patiently or requesting additional resources (etc.).
- Currently, most portions of `makepeds` exclude the recorder datastream; however, the `calibrun` portion does not. This PR excludes the recorder data stream from this latter part as well.
- `Ctrl-c` can now be used to cancel all SLURM jobs. This allows early exit if jobs are stuck pending and a new strategy is needed.
- Exits `makepeds` early if `sbatch` fails and provides a hint to a common cause (account doesn't have permission on experiment).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Provides additional information to make decisions about compute resources. Resolves [[ECS-3879]](https://jira.slac.stanford.edu/browse/ECS-3879?filter=-1)
- Helps to improve the efficiency of `makepeds` by only considering events with usable detector information. Resolves [[ECS-3770]](https://jira.slac.stanford.edu/browse/ECS-3770)
- Provide a way to easily cancel jobs when a new strategy is needed.
- `makepeds` reports a lot of information and failures of `sbatch` can sometimes be missed. Early exit with a message can help catch this problem faster.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on experiment `xcsl1004821` run `258`.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- NA

## Screenshots (if appropriate):

![image](https://github.com/pcdshub/engineering_tools/assets/18701604/0915d3ea-d8cc-406a-80b2-eca050c612d7)
![Captura desde 2023-09-26 14-02-22](https://github.com/pcdshub/engineering_tools/assets/18701604/4a93412b-3bbf-41c4-a472-fee2b00bf486)
