### PR TITLE
ENH: Add check for SmarAct encoder

### DIFF
--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -97,7 +97,12 @@ elif [ "${rtyp}" == 'motor' ]; then
     if [ $? -eq 0 ]; then
         /reg/g/pcds/package/epics/3.14//modules/pcds_motion/${OLD_VERSION}/launch-motor.sh "$PREFIX" > /dev/null 2>&1 &
     elif [[ $PREFIX == *"MCS2"* ]]; then # smaracts have "motor" rtyp, so we catch them with the PREFIX
-        edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &
+        enc=$(caget $PREFIX.UEIP)
+        if [[ $enc == *"Yes"* ]]; then
+            edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &
+        else
+            edm -x -eolc -m "MOTOR=$PREFIX" mcs2_openloop.edl > /dev/null 2>&1 &
+        fi
     else
         cd /reg/neh/home/klg/epics/ioc/common/aerotech/current/motorScreens
         #cd /reg/neh/home4/mcbrowne/trunk2/ioc/common/aerotech/current/motorScreens


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a check in motor-expert-screen to see if the stage is encoded, and bring up the correct screen.

## Motivation and Context
This script is heavily used by the beamline scientists, and they need to have access to the right PVs. 

## How Has This Been Tested?
Tested interactively with a stage. 
