### PR TITLE
ENH: set the default pydm protocol to ca, the most-used protocol

### DIFF
--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -38,6 +38,7 @@ EPICS_ROOT="/cds/group/pcds/epics-dev"
 export PYTHONPATH="${APPS_ROOT}/dev/pythonpath"
 export PYQTDESIGNERPATH="${CONDA_ROOT}/dev_designer_plugins/:${PYQTDESIGNERPATH}"
 export PYDM_CONFIRM_QUIT=0
+export PYDM_DEFAULT_PROTOCOL=ca
 export PYDM_DESIGNER_ONLINE=1
 export PYDM_DISPLAYS_PATH="${PCDSDEVICES_DEV_UI}:${EPICS_ROOT}/screens/pydm:${EPICS_ROOT}"
 export PYDM_STYLESHEET="${EPICS_ROOT}/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss"

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -110,6 +110,7 @@ TYPHOS_PROD_DEVICES_UI="${SITE_PACKAGES}/typhos/ui/devices"
 EPICS_ROOT="/cds/group/pcds/epics-dev"
 
 export PYDM_CONFIRM_QUIT=0
+export PYDM_DEFAULT_PROTOCOL=ca
 export PYDM_DESIGNER_ONLINE=1
 export PYDM_DISPLAYS_PATH="${PCDSDEVICES_PROD_UI}:${TYPHOS_PROD_DEVICES_UI}:${PCDSDEVICES_DEV_UI}:${EPICS_ROOT}/screens/pydm:${EPICS_ROOT}"
 export PYDM_STYLESHEET="${EPICS_ROOT}/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
PyDM has an environment variable, `PYDM_DEFAULT_PROTOCOL`, that allows you to set a default protocol to use.
This PR sets the default protocol to `ca` (channel access (EPICS)), which is the most used protocol, allowing us to omit it when building out our screens. This also makes the conversion from edm to pydm smoother.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When setting up a pydm channel, you're expected to provide a protocol in the form of a pseudo-url:
```
ca://MY:PVNAME
```

If, instead, you just use:
```
MY:PVNAME
```
You'll get the following error:
```
Channel MY:PVNAME did not specify a valid protocol and no default protocol is defined. This channel will receive no data. To specify a default protocol, set the PYDM_DEFAULT_PROTOCOL environment variable.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Setting this environment variable helped @patoppermann 's screen load properly (converted from edm)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a
<!--
## Screenshots (if appropriate):
-->
