### PR TITLE
motor-expert-screen checks for smaract-specific pvs so it works…

### DIFF
--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -96,17 +96,20 @@ elif [ "${rtyp}" == 'motor' ]; then
     caget "$PREFIX:PN" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         /reg/g/pcds/package/epics/3.14//modules/pcds_motion/${OLD_VERSION}/launch-motor.sh "$PREFIX" > /dev/null 2>&1 &
-    elif [[ $PREFIX == *"MCS2"* ]]; then # smaracts have "motor" rtyp, so we catch them with the PREFIX
-        enc=$(caget $PREFIX.UEIP)
-        if [[ $enc == *"Yes"* ]]; then
-            edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &
-        else
-            edm -x -eolc -m "MOTOR=$PREFIX" mcs2_openloop.edl > /dev/null 2>&1 &
-        fi
     else
-        cd /reg/neh/home/klg/epics/ioc/common/aerotech/current/motorScreens
-        #cd /reg/neh/home4/mcbrowne/trunk2/ioc/common/aerotech/current/motorScreens
-        edm -x -eolc -m "MOTOR=${PREFIX}" ens_main.edl >& /dev/null &
+	caget "$PREFIX:LSCO_RBV" > /dev/null 2>&1
+	if [[ $? -eq 0 || $PREFIX == *"MCS2"* ]]; then # smaracts have "motor" rtyp, so we catch them with the PREFIX or with smaract specific pvs
+            enc=$(caget $PREFIX.UEIP)
+            if [[ $enc == *"Yes"* ]]; then
+		edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &
+            else
+		edm -x -eolc -m "MOTOR=$PREFIX" mcs2_openloop.edl > /dev/null 2>&1 &
+            fi
+	else
+            cd /reg/neh/home/klg/epics/ioc/common/aerotech/current/motorScreens
+            #cd /reg/neh/home4/mcbrowne/trunk2/ioc/common/aerotech/current/motorScreens
+            edm -x -eolc -m "MOTOR=${PREFIX}" ens_main.edl >& /dev/null &
+	fi
     fi
 else
     edm -x -eolc -m "MOTOR=$PREFIX" ims_main.edl > /dev/null 2>&1 &

--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -97,8 +97,8 @@ elif [ "${rtyp}" == 'motor' ]; then
     if [ $? -eq 0 ]; then
         /reg/g/pcds/package/epics/3.14//modules/pcds_motion/${OLD_VERSION}/launch-motor.sh "$PREFIX" > /dev/null 2>&1 &
     else
-	caget "$PREFIX:LSCO_RBV" > /dev/null 2>&1
-	if [[ $? -eq 0 || $PREFIX == *"MCS2"* ]]; then # smaracts have "motor" rtyp, so we catch them with the PREFIX or with smaract specific pvs
+	# smaracts have "motor" rtyp, so we catch them with the PREFIX or with smaract specific pvs
+	if [[ $PREFIX == *"MCS2"* || $(caget "$PREFIX:PTYPE_RBV" > /dev/null 2>&1) -eq 0 ]]; then
             enc=$(caget $PREFIX.UEIP)
             if [[ $enc == *"Yes"* ]]; then
 		edm -x -eolc -m "MOTOR=$PREFIX" mcs2_main.edl > /dev/null 2>&1 &


### PR DESCRIPTION
… with aliases without MCS2 in their prefix

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Logic to select which edm screen to use now checks if LSCO_RBV pv is present, which is a smaract specific pv. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some smaract axes have aliases without MCS2 in their prefix, so before they would use the default aerotech edm screen when launched from motor-expert-screen instead of a smaract screen.
https://jira.slac.stanford.edu/browse/ECS-4401

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Launching motor-expert-screen with a smaract alias pv without mcs2 in its prefix and a smaract pv with mcs2 in its prefix and ensuring it uses a smaract screen instead of an aerotech screen.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
A comment in the code has been updated

<!--
## Screenshots (if appropriate):
-->
