### PR TITLE
Remove non-s3df pedestal processing

### DIFF
--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -191,24 +191,21 @@ else
     if [[ $USER =~ "opr" ]]; then
         printf "Please enter user name (cannot run as from operator account): \n"; read USER
     fi
-    if [[ $S3DF == 1 ]]; then
-        echo calling on SDF system: makepeds_psana $@
-        # We need to change paths here as the S3DF filesytem is completely independent
-        if [ -v SDFDIR  ]; then
-            DIR=$SDFDIR
-        else
-            DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`
-        fi
-        echo ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
-        ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
+    echo calling on SDF system: makepeds_psana $@
+    # We need to change paths here as the S3DF filesytem is completely independent
+    if [ -v SDFDIR  ]; then
+        DIR=$SDFDIR
+    else
+        DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`
     fi
+    echo ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
+    ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
 fi
 
 if [[ $HOSTNAME =~ "sdf" ]]; then
     source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
 else
     source pcds_conda
-fi
 elog_par_post --file pedestal -e "$EXP" -r $RUN
 
 #if this is a default pedestal run, then do not post as this is handled in takepeds

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -206,6 +206,8 @@ if [[ $HOSTNAME =~ "sdf" ]]; then
     source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
 else
     source pcds_conda
+fi
+
 elog_par_post --file pedestal -e "$EXP" -r $RUN
 
 #if this is a default pedestal run, then do not post as this is handled in takepeds

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -358,13 +358,8 @@ if [ $RUN == 0 ]; then
     fi
 fi
 
-PCDSDIR='/reg/g/pcds/'
-SIT_ENV_DIR="/cds/sw/ds/ana/"
-S3DF="sdf"
-if [[ $HOSTNAME =~ "sdf" ]]; then
-    PCDSDIR='/sdf/group/lcls/ds/tools/'
-    SIT_ENV_DIR="/sdf/group/lcls/ds/ana/sw"
-fi
+PCDSDIR='/sdf/group/lcls/ds/tools/'
+SIT_ENV_DIR="/sdf/group/lcls/ds/ana/sw"
 
 if [ $EXP == 'xxx' ]; then
     echo 'no experiment passed!!!'
@@ -409,22 +404,15 @@ ARG=' -n '$NUMEVT' -Z 1000000 -U 1000000 -z 1000000 -u 1000000 '
 # find xtc directory
 # look for xtc w/o in progress if not using live mode. TOBEIMPLEMENTED
 ###########
-XTCDIR=/reg/d/psdm/"$HUTCH"/"$EXP"/xtc
 RUNSTR=$(printf '%04d' $RUN)
 RUNSTR=$EXP-r$RUNSTR*.xtc
-if [[ $HOSTNAME =~ "sdf" ]]; then
-    XTCDIR=/sdf/data/lcls/ds/"$HUTCH"/"$EXP"/xtc
-    # If inprogress files use FFB location
-    if compgen -G "$XTCDIR/$RUNSTR.inprogress" > /dev/null; then
-        XTCDIR=/sdf/data/lcls/drpsrcf/ffb/"$HUTCH"/"$EXP"/xtc
-    # If no corresponding xtc files use FFB location
-    elif ! compgen -G "$XTCDIR/$RUNSTR" > /dev/null; then
-        XTCDIR=/sdf/data/lcls/drpsrcf/ffb/"$HUTCH"/"$EXP"/xtc
-    fi
-
-
-elif [[ $HOSTNAME =~ "drp-srcf" ]]; then
-    XTCDIR=/cds/data/drpsrcf/${HUTCH}/$EXP/xtc
+XTCDIR=/sdf/data/lcls/ds/"$HUTCH"/"$EXP"/xtc
+# If inprogress files use FFB location
+if compgen -G "$XTCDIR/$RUNSTR.inprogress" > /dev/null; then
+    XTCDIR=/sdf/data/lcls/drpsrcf/ffb/"$HUTCH"/"$EXP"/xtc
+# If no corresponding xtc files use FFB location
+elif ! compgen -G "$XTCDIR/$RUNSTR" > /dev/null; then
+    XTCDIR=/sdf/data/lcls/drpsrcf/ffb/"$HUTCH"/"$EXP"/xtc
 fi
 
 echo "Use XTC files from  $XTCDIR."
@@ -438,12 +426,7 @@ if [ $CALIBDIR != 'xxx' ]; then
     JFARG=' -C '$CALIBDIR
 else
     JFARG=''
-    CALIBDIR=/reg/d/psdm/${HUTCH}/$EXP/calib/
-    if [[ $HOSTNAME =~ "drp-srcf" ]]; then
-        CALIBDIR=/cds/data/drpsrcf/${HUTCH}/$EXP/calib/
-    elif [[ $HOSTNAME =~ "sdf" ]]; then
-        CALIBDIR=/sdf/data/lcls/ds/${HUTCH}/$EXP/calib/
-    fi
+    CALIBDIR=/sdf/data/lcls/ds/${HUTCH}/$EXP/calib/
     if [[ $LCLS2 -gt 0 ]]; then
         CALIBDIR=${CALIBDIR/calib/scratch}
     fi
@@ -517,13 +500,7 @@ fi
 CREATE_TIME=$(date '+%m_%d_%Y_%H:%M:%S')
 printf -v RUNSTR "%04g" "$RUN"
 
-if [[ $HOSTNAME =~ "sdf" ]]; then
-    echo check detectors at SDF: 
-elif [[ $HOSTNAME =~ "drp-srcf" ]]; then
-    echo check FFB files: 
-else
-    echo Process offline files in psana: 
-fi
+echo Check detectors: 
 
 ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc*
 if [[ $LCLS2 -gt 0 ]]; then
@@ -685,17 +662,13 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     DETNAMES=$(grep Jungfrau /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
 
     DSNAME='exp='$EXP':run='$RUN':smd:stream=0-79'
-    if [ -v OLD_JUNGFRAU ]; then
-    #get the dataset name
-    (( RUN1=RUN+1 ))
-    (( RUN2=RUN+2 ))
-    DSNAME="exp=$EXP:run=$RUN,$RUN1,$RUN2:smd:stream=0-79"
+    if [ -v OLD_JUNGFRAU ]; then # Do we need to keep the old JF stuff?
+        #get the dataset name
+        (( RUN1=RUN+1 ))
+        (( RUN2=RUN+2 ))
+        DSNAME="exp=$EXP:run=$RUN,$RUN1,$RUN2:smd:stream=0-79"
     fi
-    if [[ $HOSTNAME =~ "drp-srcf" ]]; then
-    DSNAME=$DSNAME':dir=/cds/data/drpsrcf/'$HUTCH'/'$EXP'/xtc/'
-    elif [[ $HOSTNAME =~ "sdf" ]]; then
     DSNAME=$DSNAME':dir='$XTCDIR
-    fi   
 
     #default arguments.
     JFARG=$JFARG' -d '$DSNAME


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makepeds should only run on S3DF now.

## Motivation and Context
Clean up old system processing

## How Has This Been Tested?
Run from an xpp exp with Jungfrau det

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
