### PR TITLE
Add in new script for resuming PVs in the archiver.

### DIFF
--- a/scripts/archive-resume
+++ b/scripts/archive-resume
@@ -1,0 +1,24 @@
+#!/bin/bash
+usage()
+{
+cat << EOF
+usage: $0 <PV>
+
+Resume archiving of a PV in the archiver, e.g. $0 GDET:FEE1:241:ENRC
+EOF
+}
+
+if [[ -z $1 ]]; then
+    usage
+    exit 1
+fi
+    
+if [[ ($1 == "--help") || ($1 == "-h") ]]; then
+    usage
+    exit 0
+fi
+
+result=$(curl -s "http://pscaa01.slac.stanford.edu:17665/mgmt/bpl/resumeArchivingPV?pv=$1")
+echo
+echo $result | cut -d'{' -f2 | cut -d '}' -f1 | tr ',' '\n'
+echo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds in a script for resuming PVs in the archiver from the command line. 

## Motivation and Context
TMO found a PV that was paused in the archiver and the people online at the time did not know how to fix it. The _did_ know how to check the status using `archive-status`, so I thought perhaps a similar bash tool would be helpful in the future. 

https://slac.slack.com/archives/CUC9NLU8H/p1712197816806739

## How Has This Been Tested?
Tested live using a PV in the FTL. Paused the pv manually from the archiver web interface. 

![image](https://github.com/pcdshub/engineering_tools/assets/29102919/9735bca7-c5d7-41ea-beb2-37f7e2e1b1ad)

