### PR TITLE
DEV: disabling serverstat off and cycle for drp nodes

### DIFF
--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -138,7 +138,7 @@ if  [[ $NAME == *rec* ]]; then
 fi
 
 if [[ "${NAME,,}" == *drp* ]] && ([[ $CMD == "off" ]] || [[ $CMD == "cycle" ]]); then
-    printf "serverStat $CMD is not supported on the DRP nodes as the underlying psipmi power off or psipmi power cycle commands will disable the ipmi card. Instead, use the web interface as described on:\n\nhttps://confluence.slac.stanford.edu/display/PSDMInternal/Debugging+DAQ#DebuggingDAQ-IPMI\n"
+    printf "serverStat $CMD is not supported for DRP nodes as the underlying psipmi power off or psipmi power cycle commands will disable the ipmi card. Instead, use the web interface as described on:\n\nhttps://confluence.slac.stanford.edu/display/PSDMInternal/Debugging+DAQ#DebuggingDAQ-IPMI\n"
     exit 1
 fi
 

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -138,7 +138,7 @@ if  [[ $NAME == *rec* ]]; then
 fi
 
 if [[ "${NAME,,}" == *drp* ]] && ([[ $CMD == "off" ]] || [[ $CMD == "cycle" ]]); then
-    printf "The off and cycle serverStat commands are unavailable on DRP nodes. Do not use psipmi power off or psipmi power cycle directly on DRP nodes as this will disable the ipmi card. Instead, use the web interface as described on:\n\nhttps://confluence.slac.stanford.edu/display/PSDMInternal/Debugging+DAQ#DebuggingDAQ-IPMI\n"
+    printf "serverStat $CMD is not supported on the DRP nodes as the underlying psipmi power off or psipmi power cycle commands will disable the ipmi card. Instead, use the web interface as described on:\n\nhttps://confluence.slac.stanford.edu/display/PSDMInternal/Debugging+DAQ#DebuggingDAQ-IPMI\n"
     exit 1
 fi
 

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -137,6 +137,11 @@ if  [[ $NAME == *rec* ]]; then
     fi
 fi
 
+if [[ "${NAME,,}" == *drp* ]] && ([[ $CMD == "off" ]] || [[ $CMD == "cycle" ]]); then
+    printf "The off and cycle serverStat commands are unavailable on DRP nodes. Do not use psipmi power off or psipmi power cycle directly on DRP nodes as this will disable the ipmi card. Instead, use the web interface as described on:\n\nhttps://confluence.slac.stanford.edu/display/PSDMInternal/Debugging+DAQ#DebuggingDAQ-IPMI\n"
+    exit 0
+fi
+
 #check if this is a DAQ device
 if [[ $ISSRV -lt 1 ]] && [[ $HUTCH != 'unknown_hutch' ]]; then
     if [[ $HUTCH == 'cxi' ]]; then # only supporting primary daq for now

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -139,7 +139,7 @@ fi
 
 if [[ "${NAME,,}" == *drp* ]] && ([[ $CMD == "off" ]] || [[ $CMD == "cycle" ]]); then
     printf "The off and cycle serverStat commands are unavailable on DRP nodes. Do not use psipmi power off or psipmi power cycle directly on DRP nodes as this will disable the ipmi card. Instead, use the web interface as described on:\n\nhttps://confluence.slac.stanford.edu/display/PSDMInternal/Debugging+DAQ#DebuggingDAQ-IPMI\n"
-    exit 0
+    exit 1
 fi
 
 #check if this is a DAQ device


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Trying to turn off or power cycle a drp node (a server with drp in its hostname) will instead point you to a confluence page explaining how to do this through the ipmi web interface and exit because using serverStat/psipmi sometimes causes the ipmi interfaces to stop working until they are manually restarted whereas the web interface works as exptected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5126

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Code will print out a message, but I did not update the serverStat readme description because I thought this would be too specific to mention. 

<!--
## Screenshots (if appropriate):
-->
