### PR TITLE
MNT Temporarily modify `restartdaq` and `get_info` to allow TXI to run from TMO/RIX machines

### DIFF
--- a/scripts/get_info.py
+++ b/scripts/get_info.py
@@ -3,6 +3,7 @@ import logging
 import os
 import socket
 import sys
+import getpass
 
 import requests
 
@@ -71,12 +72,20 @@ else:
     for ihutch in hutches:  # use the IP address to match the host to a hutch by subnet
         if subnet in hutch_subnets.get(ihutch):
             hutch = ihutch.upper()
+            if hutch in "TMO" or hutch in "RIX":
+                user = getpass.getuser()
+                if user[:3].upper() == "TXI":
+                    hutch = "TXI"
             foundHutch = True
             break
     if not foundHutch:
         for ihutch in hutches:
             if hostname.find(ihutch) >= 0:
                 hutch = ihutch.upper()
+                if hutch in "TMO" or hutch in "RIX":
+                    user = getpass.getuser()
+                    if user[:3].upper() == "TXI":
+                        hutch = "TXI"
                 foundHutch = True
                 break
     if not foundHutch:

--- a/scripts/get_info.py
+++ b/scripts/get_info.py
@@ -72,7 +72,7 @@ else:
     for ihutch in hutches:  # use the IP address to match the host to a hutch by subnet
         if subnet in hutch_subnets.get(ihutch):
             hutch = ihutch.upper()
-            if hutch in "TMO" or hutch in "RIX":
+            if hutch in ("TMO", "RIX"):
                 user = getpass.getuser()
                 if user[:3].upper() == "TXI":
                     hutch = "TXI"
@@ -82,7 +82,7 @@ else:
         for ihutch in hutches:
             if hostname.find(ihutch) >= 0:
                 hutch = ihutch.upper()
-                if hutch in "TMO" or hutch in "RIX":
+                if hutch in ("TMO", "RIX"):
                     user = getpass.getuser()
                     if user[:3].upper() == "TXI":
                         hutch = "TXI"

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -86,7 +86,7 @@ unset LD_LIBRARY_PATH
 cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
 DAQNETWORK='fez'
-LCLS2_HUTCHES="rix, tmo, ued"
+LCLS2_HUTCHES="rix, tmo, ued, txi"
 if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
     source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -41,13 +41,13 @@ do
 	s)
 	    SILENT=1
 	    ;;
-	m) 
+	m)
 	    AIMHOST=$OPTARG
 	    ;;
- 	c) 
- 	    CORESIZE=2000000000 
+ 	c)
+ 	    CORESIZE=2000000000
  	    ;;
- 	d) 
+ 	d)
  	    DSSTEST=1
  	    ;;
 	?)
@@ -122,7 +122,7 @@ if [[ "$DAQHOST" != *$NOTRUNNING* ]]; then
     echo stop the DAQ on "$DAQHOST" from "$HOSTNAME"
     T="$(date +%s%N)"
     $PROCMGR stop \
-	/reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE 
+	/reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE
 
 
     if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
@@ -138,7 +138,7 @@ else
 	echo while DAQ reports to not run, will stop the DAQ on "$DAQHOST" from "$HOSTNAME" to clear the p"$PLATFORM"$CNFEXT.running file
 	T="$(date +%s%N)"
 	$PROCMGR stop \
-	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE 
+	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE
 
         if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
             echo 'the DAQ did not stop properly, exit now and try again follow the escalation procedure'
@@ -199,7 +199,7 @@ if [ ${#DOWIN} != 0 ] ||  [ ${#SELPART} != 0 ]; then
     fi
 fi
 
-if [ ${#DOWIN} != 0 ]; then    
+if [ ${#DOWIN} != 0 ]; then
     T="$(date +%s%N)"
     if [ "$HUTCH" == 'xpp' ]; then
 	test=$(xdotool search --sync --onlyvisible --name 'ProcStat')
@@ -215,18 +215,18 @@ if [ ${#DOWIN} != 0 ]; then
     echo 'and '"$Sinter"'.'"$Minter"' extra seconds for windows'
 fi
 
-if [ ${#SELPART} != 0 ]; then    
+if [ ${#SELPART} != 0 ]; then
     DAQC=$(xdotool search  --onlyvisible --name 'DAQ Control')
     #echo $DAQC
     xdotool mousemove --sync --window "$DAQC" 80 230
     xdotool windowfocus "$DAQC"
-    xdotool click 1 
-    
+    xdotool click 1
+
     PARTSEL=$(xdotool search  --onlyvisible --sync --name 'Partition Selection')
     YLOW=$(xdotool search --name 'Partition Selection' getwindowgeometry %@ | grep Geometry | awk '{print $2}' | sed s/x/" "/g | awk '{print $2}')
         #echo $PARTSEL
-    xdotool mousemove --sync --window "$PARTSEL" 80 $(("$YLOW"-28)) 
-    xdotool click 1 
+    xdotool mousemove --sync --window "$PARTSEL" 80 $(("$YLOW"-28))
+    xdotool click 1
 fi
 
 if [ "$SILENT" == 0 ];then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- [x] Add `txi` to list of LCLS2 hutches in `restartdaq`
- [x] Modify `getinfo.py --gethutch` to check for username if determined hutch is `TMO` or `RIX`
  - Hutch is determined by matching to subnets/hostname but `txiopr` currently uses `tmo-daq` or `rix-daq` machine to run. Other scripts depend on `txi` being correctly returned as the hutch from this script.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- TXI is temporarily running from tmo/rix machines. We need a mechanism

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested through local copies of relevant scripts in `txiopr/scripts`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
Running local version (in `~txiopr/scripts`) of `restartdaq` as `txiopr`
![image](https://github.com/pcdshub/engineering_tools/assets/18701604/42fce421-68d5-430d-b2cc-bb36c89548c9)
