### PR TITLE
MAINT: remove glx env var, no longer needed and causing issues

### DIFF
--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -55,13 +55,5 @@ source "${TOKEN_DIR}/typhos.sh"
 # The same was done with PyDM and this fixes Designer and friends.
 if [ -n "${SSH_CONNECTION}" ]; then
   export QT_QUICK_BACKEND="software"
-  # Check for errors in the opengl rendering
-  # Manually fall back to mesa library if we know there is a problem
-  if [ -x "$(command -v glxinfo)" ] && [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
-    # Expecting either a segfault or exit code 1 if there is a problem
-    if ! { glxinfo -B; } > /dev/null 2>&1; then
-      export __GLX_VENDOR_LIBRARY_NAME="mesa"
-    fi
-  fi
 fi
 

--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -2,7 +2,7 @@
 usage()
 {
 cat << EOF
-usage: source $0 
+usage: source $0
 
 Source this to activate the latest version a pcds conda environment.
 EOF
@@ -56,4 +56,3 @@ source "${TOKEN_DIR}/typhos.sh"
 if [ -n "${SSH_CONNECTION}" ]; then
   export QT_QUICK_BACKEND="software"
 fi
-

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -127,13 +127,5 @@ source "${TOKEN_DIR}/typhos.sh"
 # The same was done with PyDM and this fixes Designer and friends.
 if [ -n "${SSH_CONNECTION}" ]; then
   export QT_QUICK_BACKEND="software"
-  # Check for errors in the opengl rendering
-  # Manually fall back to mesa library if we know there is a problem
-  if [ -x "$(command -v glxinfo)" ] && [ -z "${__GLX_VENDOR_LIBRARY_NAME}" ]; then
-    # Expecting either a segfault or exit code 1 if there is a problem
-    if ! { glxinfo -B; } > /dev/null 2>&1; then
-      export __GLX_VENDOR_LIBRARY_NAME="mesa"
-    fi
-  fi
 fi
 

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -128,4 +128,3 @@ source "${TOKEN_DIR}/typhos.sh"
 if [ -n "${SSH_CONNECTION}" ]; then
   export QT_QUICK_BACKEND="software"
 fi
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove opengl-related environment variable from the conda startup scripts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
At LCLS, this was a temporary workaround that is causing a new issue.
- This variable is causing https://jira.slac.stanford.edu/browse/ECS-5700
- This variable was originally a workaround for https://jira.slac.stanford.edu/browse/ECS-1867, see https://jira.slac.stanford.edu/browse/ECS-1878, https://github.com/pcdshub/engineering_tools/pull/132, https://github.com/pcdshub/engineering_tools/pull/133
- Interactively, my applications no longer crash without this variable set: previously, even simply starting `pydm` would break everything.
- Now, sometimes I get a new OpenGL warning but no crashes.

In general, forcing the renderer settings in the conda environment sourceable led to a very confusing bug. This should have been handled (and seemingly has been handled) by adjusting the server settings.

I'm not sure why this variable is causing crashes now, but I am sure that I don't want to be in charge of messing with these sorts of settings in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only, as me

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only here and on Jira in https://jira.slac.stanford.edu/browse/ECS-5700
<!--
## Screenshots (if appropriate):
-->
