### PR TITLE
ENH: add ioc-deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,43 +328,43 @@ usage: grep_more_ioc [-h] [-d] patt hutch {print,search} <br/>
 
 <tr>
     <td>ioc-deploy</td>
-    <td>
-usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]<br/>
-                  [--ioc-dir IOC_DIR] [--github_org GITHUB_ORG]<br/>
-                  [--auto-confirm] [--dry-run] [--verbose]<br/>
-<br/>
+    <td><pre>
+usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]
+&nbsp;                 [--ioc-dir IOC_DIR] [--github_org GITHUB_ORG]
+&nbsp;                 [--auto-confirm] [--dry-run] [--verbose]
+&nbsp;
 ioc-deploy is a script for building and deploying ioc tags from github. It
 will create a shallow clone of your IOC in the standard release area at the
 correct path and "make" it.
-<br/>
-optional arguments:<br/>
-  -h, --help            show this help message and exit<br/>
-  --version             Show version number and exit.<br/>
-  --name NAME, -n NAME  The name of the repository to deploy. This is a<br/>
-                        required argument. If it does not exist on github,<br/>
-                        we'll also try prepending with 'ioc-common-'.<br/>
-  --release RELEASE, -r RELEASE<br/>
-                        The version of the IOC to deploy. This is a required<br/>
-                        argument.<br/>
-  --ioc-dir IOC_DIR, -i IOC_DIR<br/>
-                        The directory to deploy IOCs in. This defaults to<br/>
-                        $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if<br/>
-                        the environment variable is not set. With your current<br/>
-                        environment variables, this defaults to<br/>
-                        /reg/g/pcds/epics/ioc.<br/>
-  --github_org GITHUB_ORG, --org GITHUB_ORG<br/>
-                        The github org to deploy IOCs from. This defaults to<br/>
-                        $GITHUB_ORG, or pcdshub if the environment variable is<br/>
-                        not set. With your current environment variables, this<br/>
-                        defaults to pcdshub.<br/>
-  --auto-confirm, --confirm, --yes, -y<br/>
-                        Skip the confirmation promps, automatically saying yes<br/>
-                        to each one.<br/>
-  --dry-run             Do not deploy anything, just print what would have<br/>
-                        been done.<br/>
-  --verbose, -v, --debug<br/>
-                        Display additional debug information.
-    </td>
+&nbsp;
+optional arguments:
+&nbsp; -h, --help            show this help message and exit
+&nbsp; --version             Show version number and exit.
+&nbsp; --name NAME, -n NAME  The name of the repository to deploy. This is a
+&nbsp;                       required argument. If it does not exist on github,
+&nbsp;                       we'll also try prepending with 'ioc-common-'.
+&nbsp; --release RELEASE, -r RELEASE
+&nbsp;                       The version of the IOC to deploy. This is a required
+&nbsp;                       argument.
+&nbsp; --ioc-dir IOC_DIR, -i IOC_DIR
+&nbsp;                       The directory to deploy IOCs in. This defaults to
+&nbsp;                       $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
+&nbsp;                       the environment variable is not set. With your current
+&nbsp;                       environment variables, this defaults to
+&nbsp;                       /reg/g/pcds/epics/ioc.
+&nbsp; --github_org GITHUB_ORG, --org GITHUB_ORG
+&nbsp;                       The github org to deploy IOCs from. This defaults to
+&nbsp;                       $GITHUB_ORG, or pcdshub if the environment variable is
+&nbsp;                       not set. With your current environment variables, this
+&nbsp;                       defaults to pcdshub.
+&nbsp; --auto-confirm, --confirm, --yes, -y
+&nbsp;                       Skip the confirmation promps, automatically saying yes
+&nbsp;                       to each one.
+&nbsp; --dry-run             Do not deploy anything, just print what would have
+&nbsp;                       been done.
+&nbsp; --verbose, -v, --debug
+&nbsp;                       Display additional debug information.
+    </pre></td>
 </tr>
 
 <tr>

--- a/README.md
+++ b/README.md
@@ -327,6 +327,47 @@ usage: grep_more_ioc [-h] [-d] patt hutch {print,search} <br/>
 </tr>
 
 <tr>
+    <td>ioc-deploy</td>
+    <td>
+usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]
+                  [--ioc-dir IOC_DIR] [--github_org GITHUB_ORG]
+                  [--auto-confirm] [--dry-run] [--verbose]
+
+ioc-deploy is a script for building and deploying ioc tags from github. It
+will create a shallow clone of your IOC in the standard release area at the
+correct path and "make" it.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --version             Show version number and exit.
+  --name NAME, -n NAME  The name of the repository to deploy. This is a
+                        required argument. If it does not exist on github,
+                        we'll also try prepending with 'ioc-common-'.
+  --release RELEASE, -r RELEASE
+                        The version of the IOC to deploy. This is a required
+                        argument.
+  --ioc-dir IOC_DIR, -i IOC_DIR
+                        The directory to deploy IOCs in. This defaults to
+                        $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
+                        the environment variable is not set. With your current
+                        environment variables, this defaults to
+                        /reg/g/pcds/epics/ioc.
+  --github_org GITHUB_ORG, --org GITHUB_ORG
+                        The github org to deploy IOCs from. This defaults to
+                        $GITHUB_ORG, or pcdshub if the environment variable is
+                        not set. With your current environment variables, this
+                        defaults to pcdshub.
+  --auto-confirm, --confirm, --yes, -y
+                        Skip the confirmation promps, automatically saying yes
+                        to each one.
+  --dry-run             Do not deploy anything, just print what would have
+                        been done.
+  --verbose, -v, --debug
+                        Display additional debug information.
+    </td>
+</tr>
+
+<tr>
     <td>iocmanager</td>
     <td>
 iocmanager [hutch]<br/>

--- a/README.md
+++ b/README.md
@@ -335,7 +335,12 @@ usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]
 &nbsp;
 ioc-deploy is a script for building and deploying ioc tags from github. It
 will create a shallow clone of your IOC in the standard release area at the
-correct path and "make" it.
+correct path and "make" it. If the tag directory already exists, the script
+will exit. Example command: "ioc-deploy -n ioc-foo-bar -r R1.0.0" This will
+clone the repository to the default ioc directory and run make using the
+currently set EPICS environment variables. With default settings this will
+clone from https://github.com/pcdshub/ioc-foo-bar to
+/cds/group/pcds/epics/ioc/foo/bar/R1.0.0 then cd and make.
 &nbsp;
 optional arguments:
 &nbsp; -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -329,40 +329,40 @@ usage: grep_more_ioc [-h] [-d] patt hutch {print,search} <br/>
 <tr>
     <td>ioc-deploy</td>
     <td>
-usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]
-                  [--ioc-dir IOC_DIR] [--github_org GITHUB_ORG]
-                  [--auto-confirm] [--dry-run] [--verbose]
-
+usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]<br/>
+                  [--ioc-dir IOC_DIR] [--github_org GITHUB_ORG]<br/>
+                  [--auto-confirm] [--dry-run] [--verbose]<br/>
+<br/>
 ioc-deploy is a script for building and deploying ioc tags from github. It
 will create a shallow clone of your IOC in the standard release area at the
 correct path and "make" it.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --version             Show version number and exit.
-  --name NAME, -n NAME  The name of the repository to deploy. This is a
-                        required argument. If it does not exist on github,
-                        we'll also try prepending with 'ioc-common-'.
-  --release RELEASE, -r RELEASE
-                        The version of the IOC to deploy. This is a required
-                        argument.
-  --ioc-dir IOC_DIR, -i IOC_DIR
-                        The directory to deploy IOCs in. This defaults to
-                        $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
-                        the environment variable is not set. With your current
-                        environment variables, this defaults to
-                        /reg/g/pcds/epics/ioc.
-  --github_org GITHUB_ORG, --org GITHUB_ORG
-                        The github org to deploy IOCs from. This defaults to
-                        $GITHUB_ORG, or pcdshub if the environment variable is
-                        not set. With your current environment variables, this
-                        defaults to pcdshub.
-  --auto-confirm, --confirm, --yes, -y
-                        Skip the confirmation promps, automatically saying yes
-                        to each one.
-  --dry-run             Do not deploy anything, just print what would have
-                        been done.
-  --verbose, -v, --debug
+<br/>
+optional arguments:<br/>
+  -h, --help            show this help message and exit<br/>
+  --version             Show version number and exit.<br/>
+  --name NAME, -n NAME  The name of the repository to deploy. This is a<br/>
+                        required argument. If it does not exist on github,<br/>
+                        we'll also try prepending with 'ioc-common-'.<br/>
+  --release RELEASE, -r RELEASE<br/>
+                        The version of the IOC to deploy. This is a required<br/>
+                        argument.<br/>
+  --ioc-dir IOC_DIR, -i IOC_DIR<br/>
+                        The directory to deploy IOCs in. This defaults to<br/>
+                        $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if<br/>
+                        the environment variable is not set. With your current<br/>
+                        environment variables, this defaults to<br/>
+                        /reg/g/pcds/epics/ioc.<br/>
+  --github_org GITHUB_ORG, --org GITHUB_ORG<br/>
+                        The github org to deploy IOCs from. This defaults to<br/>
+                        $GITHUB_ORG, or pcdshub if the environment variable is<br/>
+                        not set. With your current environment variables, this<br/>
+                        defaults to pcdshub.<br/>
+  --auto-confirm, --confirm, --yes, -y<br/>
+                        Skip the confirmation promps, automatically saying yes<br/>
+                        to each one.<br/>
+  --dry-run             Do not deploy anything, just print what would have<br/>
+                        been done.<br/>
+  --verbose, -v, --debug<br/>
                         Display additional debug information.
     </td>
 </tr>

--- a/scripts/ioc-deploy
+++ b/scripts/ioc-deploy
@@ -1,0 +1,1 @@
+ioc_deploy.py

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -126,23 +126,23 @@ def main(args: CliArgs) -> int:
     deploy_dir = get_target_dir(name=upd_name, ioc_dir=args.ioc_dir, release=upd_rel)
 
     logger.info(f"Deploying {args.github_org}/{upd_name} at {upd_rel} to {deploy_dir}")
+    if Path(deploy_dir).exists():
+        raise RuntimeError(f"Deploy directory {deploy_dir} already exists! Aborting.")
     if not args.auto_confirm:
         user_text = input("Confirm release source and target? y/n\n")
         if not user_text.strip().lower().startswith("y"):
             return ReturnCode.NO_CONFIRM
-    if Path(deploy_dir).exists():
-        logger.info(f"{deploy_dir} exists, skip git clone step.")
-    else:
-        rval = clone_repo_tag(
-            name=upd_name,
-            github_org=args.github_org,
-            release=upd_rel,
-            deploy_dir=deploy_dir,
-            dry_run=args.dry_run,
-        )
-        if rval != ReturnCode.SUCCESS:
-            logger.error(f"Nonzero return value {rval} from git clone")
-            return rval
+    logger.info(f"Cloning IOC to {deploy_dir}")
+    rval = clone_repo_tag(
+        name=upd_name,
+        github_org=args.github_org,
+        release=upd_rel,
+        deploy_dir=deploy_dir,
+        dry_run=args.dry_run,
+    )
+    if rval != ReturnCode.SUCCESS:
+        logger.error(f"Nonzero return value {rval} from git clone")
+        return rval
 
     logger.info(f"Building IOC at {deploy_dir}")
     rval = make_in(deploy_dir=deploy_dir, dry_run=args.dry_run)

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -2,6 +2,20 @@
 """
 ioc-deploy is a script for building and deploying ioc tags from github.
 It will create a shallow clone of your IOC in the standard release area at the correct path and "make" it.
+If the tag directory already exists, the script will exit.
+
+Example command:
+"ioc-deploy -n ioc-foo-bar -r R1.0.0"
+
+This will clone the repository to the default ioc directory and run make
+using the currently set EPICS environment variables.
+
+With default settings this will clone
+
+from https://github.com/pcdshub/ioc-foo-bar
+to /cds/group/pcds/epics/ioc/foo/bar/R1.0.0
+
+then cd and make.
 """
 
 import argparse

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python3
+"""
+ioc-deploy is a script for building and deploying ioc tags from github.
+It will create a shallow clone of your IOC in the standard release area at the correct path and "make" it.
+"""
+
+import argparse
+import enum
+import logging
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+EPICS_SITE_TOP_DEFAULT = "/cds/group/pcds/epics"
+GITHUB_ORG_DEFAULT = "pcdshub"
+
+logger = logging.getLogger("ioc-deploy")
+
+
+if sys.version_info >= (3, 7, 0):
+    import dataclasses
+
+    @dataclasses.dataclass(frozen=True)
+    class CliArgs:
+        """
+        Argparse argument types for type checking.
+        """
+
+        name: str = ""
+        release: str = ""
+        ioc_dir: str = ""
+        github_org: str = ""
+        auto_confirm: bool = False
+        dry_run: bool = False
+        verbose: bool = False
+        version: bool = False
+else:
+    from types import SimpleNamespace as CliArgs
+
+
+def get_parser() -> argparse.ArgumentParser:
+    current_default_target = str(
+        Path(os.environ.get("EPICS_SITE_TOP", EPICS_SITE_TOP_DEFAULT)) / "ioc"
+    )
+    current_default_org = os.environ.get("GITHUB_ORG", GITHUB_ORG_DEFAULT)
+    parser = argparse.ArgumentParser(prog="ioc-deploy", description=__doc__)
+    parser.add_argument(
+        "--version", action="store_true", help="Show version number and exit."
+    )
+    parser.add_argument(
+        "--name",
+        "-n",
+        action="store",
+        default="",
+        help="The name of the repository to deploy. This is a required argument. If it does not exist on github, we'll also try prepending with 'ioc-common-'.",
+    )
+    parser.add_argument(
+        "--release",
+        "-r",
+        action="store",
+        default="",
+        help="The version of the IOC to deploy. This is a required argument.",
+    )
+    parser.add_argument(
+        "--ioc-dir",
+        "-i",
+        action="store",
+        default=current_default_target,
+        help=f"The directory to deploy IOCs in. This defaults to $EPICS_SITE_TOP/ioc, or {EPICS_SITE_TOP_DEFAULT}/ioc if the environment variable is not set. With your current environment variables, this defaults to {current_default_target}.",
+    )
+    parser.add_argument(
+        "--github_org",
+        "--org",
+        action="store",
+        default=current_default_org,
+        help=f"The github org to deploy IOCs from. This defaults to $GITHUB_ORG, or {GITHUB_ORG_DEFAULT} if the environment variable is not set. With your current environment variables, this defaults to {current_default_org}.",
+    )
+    parser.add_argument(
+        "--auto-confirm",
+        "--confirm",
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip the confirmation promps, automatically saying yes to each one.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not deploy anything, just print what would have been done.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        "--debug",
+        action="store_true",
+        help="Display additional debug information.",
+    )
+    return parser
+
+
+class ReturnCode(enum.IntEnum):
+    SUCCESS = 0
+    EXCEPTION = 1
+    NO_CONFIRM = 2
+
+
+def main(args: CliArgs) -> int:
+    """
+    All main steps of the script.
+
+    Will either return an int return code or raise.
+    """
+    if not (args.name and args.release):
+        raise ValueError(
+            "Must provide both --name and --release. Check ioc-deploy --help for usage."
+        )
+
+    logger.info("Running ioc-deploy: checking inputs")
+    upd_name = finalize_name(name=args.name, github_org=args.github_org)
+    upd_rel = finalize_tag(
+        name=upd_name, github_org=args.github_org, release=args.release
+    )
+    deploy_dir = get_target_dir(name=upd_name, ioc_dir=args.ioc_dir, release=upd_rel)
+
+    logger.info(f"Deploying {args.github_org}/{upd_name} at {upd_rel} to {deploy_dir}")
+    if not args.auto_confirm:
+        user_text = input("Confirm release source and target? y/n\n")
+        if not user_text.strip().lower().startswith("y"):
+            return ReturnCode.NO_CONFIRM
+    if Path(deploy_dir).exists():
+        logger.info(f"{deploy_dir} exists, skip git clone step.")
+    else:
+        rval = clone_repo_tag(
+            name=upd_name,
+            github_org=args.github_org,
+            release=upd_rel,
+            deploy_dir=deploy_dir,
+            dry_run=args.dry_run,
+        )
+        if rval != ReturnCode.SUCCESS:
+            logger.error(f"Nonzero return value {rval} from git clone")
+            return rval
+
+    logger.info(f"Building IOC at {deploy_dir}")
+    rval = make_in(deploy_dir=deploy_dir, dry_run=args.dry_run)
+    if rval != ReturnCode.SUCCESS:
+        logger.error(f"Nonzero return value {rval} from make")
+        return rval
+    return ReturnCode.SUCCESS
+
+
+def finalize_name(name: str, github_org: str) -> str:
+    """
+    Check if name is present in org and is well-formed.
+
+    If the name is present, return it.
+    If the name is not present and the correct name can be guessed, guess.
+    If the name is not present and cannot be guessed, raise.
+
+    A name is well-formed if it starts with "ioc", is hyphen-delimited,
+    and has at least three sections.
+
+    For example, "ioc-common-gigECam" is a well-formed name for the purposes
+    of an IOC deployment. "ads-ioc" and "pcdsdevices" are not.
+
+    However, "ads-ioc" will resolve to "ioc-common-ads-ioc".
+    Only common IOCs will be automatically discovered using this method.
+    """
+    split_name = name.split("-")
+    if len(split_name) < 3 or split_name[0] != "ioc":
+        new_name = f"ioc-common-{name}"
+        logger.warning(f"{name} is not an ioc name, trying {new_name}")
+        name = new_name
+    logger.debug(f"Checking for {name} in org {github_org}")
+    try:
+        resp = urllib.request.urlopen(f"https://github.com/{github_org}/{name}")
+        if resp.code == 200:
+            logger.info(f"{name} exists in {github_org}")
+            return name
+        else:
+            logger.error(f"Unexpected http error code {resp.code}")
+    except urllib.error.HTTPError as exc:
+        logger.error(exc)
+        logger.debug("", exc_info=True)
+    raise ValueError(f"{name} does not exist in {github_org}")
+
+
+def finalize_tag(name: str, github_org: str, release: str) -> str:
+    """
+    Check if release is present in the org.
+
+    We'll try a few prefix options in case the user has a typo.
+    In order of priority with no repeats:
+    - user's input
+    - R1.0.0
+    - v1.0.0
+    - 1.0.0
+    """
+    try_release = [release]
+    if release.startswith("R"):
+        try_release.extend([f"v{release[1:]}", f"{release[1:]}"])
+    elif release.startswith("v"):
+        try_release.extend([f"R{release[1:]}", f"{release[1:]}"])
+    elif release[0].isalpha():
+        try_release.extend([f"R{release[1:]}", f"v{release[1:]}", f"{release[1:]}"])
+    else:
+        try_release.extend([f"R{release}", f"v{release}"])
+
+    for rel in try_release:
+        logger.debug(f"Checking for release {rel} in {github_org}/{name}")
+        try:
+            resp = urllib.request.urlopen(
+                f"https://github.com/{github_org}/{name}/releases/tag/{rel}"
+            )
+            if resp.code == 200:
+                logger.info(f"Release {rel} exists in {github_org}/{name}")
+                return rel
+            else:
+                logger.warning(f"Unexpected http error code {resp.code}")
+        except urllib.error.HTTPError:
+            logger.warning(f"Did not find release {rel} in {github_org}/{name}")
+    raise ValueError(f"Unable to find {release} in {github_org}/{name}")
+
+
+def get_target_dir(name: str, ioc_dir: str, release: str) -> str:
+    """
+    Return the directory we'll deploy the IOC in.
+
+    This will look something like:
+    /cds/group/pcds/epics/ioc/common/gigECam/R1.0.0
+    """
+    split_name = name.split("-")
+    return str(Path(ioc_dir) / split_name[1] / "-".join(split_name[2:]) / release)
+
+
+def clone_repo_tag(
+    name: str, github_org: str, release: str, deploy_dir: str, dry_run: bool
+) -> int:
+    """
+    Create a shallow clone of the git repository in the correct location.
+    """
+    # Make sure the parent dir exists
+    parent_dir = Path(deploy_dir).resolve().parent
+    if dry_run:
+        logger.info(f"Dry-run: make {parent_dir} if not existing.")
+    else:
+        logger.debug(f"Ensure {parent_dir} exists")
+        parent_dir.mkdir(parents=True, exist_ok=True)
+    # Shell out to git clone
+    cmd = [
+        "git",
+        "clone",
+        f"https://github.com/{github_org}/{name}",
+        "--depth",
+        "1",
+        "-b",
+        release,
+        deploy_dir,
+    ]
+    if dry_run:
+        logger.debug(f"Dry-run: skip shell command \"{' '.join(cmd)}\"")
+        return ReturnCode.SUCCESS
+    else:
+        return subprocess.run(cmd).returncode
+
+
+def make_in(deploy_dir: str, dry_run: bool) -> int:
+    """
+    Shell out to make in the deploy dir
+    """
+    if dry_run:
+        logger.info(f"Dry-run: skipping make in {deploy_dir}")
+        return ReturnCode.SUCCESS
+    else:
+        return subprocess.run(["make"], cwd=deploy_dir).returncode
+
+
+def get_version() -> str:
+    """
+    Determine what version of engineering_tools is being used
+    """
+    # Possibility 1: git clone (yours)
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(Path(__file__).resolve().parent), "describe", "--tags"],
+            universal_newlines=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        ...
+    # Possibility 2: release dir (someone elses)
+    ver = str(Path(__file__).resolve().parent.parent.stem)
+    if ver.startswith("R"):
+        return ver
+    else:
+        # We tried our best
+        return "unknown.dev"
+
+
+def _main() -> int:
+    """
+    Thin wrapper of main() for log setup, args handling, and high-level error handling.
+    """
+    args = CliArgs(**vars(get_parser().parse_args()))
+    if args.verbose:
+        level = logging.DEBUG
+        fmt = "%(levelname)-8s %(name)s:%(lineno)d: %(message)s"
+    else:
+        level = logging.INFO
+        fmt = "%(levelname)-8s %(name)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt)
+    logger.debug(f"args are {args}")
+    try:
+        if args.version:
+            print(get_version())
+            return ReturnCode.SUCCESS
+        return main(args)
+    except Exception as exc:
+        logger.error(exc)
+        logger.debug("Traceback", exc_info=True)
+        return ReturnCode.EXCEPTION
+
+
+if __name__ == "__main__":
+    exit(_main())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Create a (simplest possible?) ioc-deploy script for deploying IOCs from github to nfs. This would be a replacement for `epics-release` with the general goal of removing references to older version control systems and making the script easier to debug.

Here is the help text:
<details>

```
usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]
                  [--ioc-dir IOC_DIR] [--github_org GITHUB_ORG]
                  [--auto-confirm] [--dry-run] [--verbose]

ioc-deploy is a script for building and deploying ioc tags from github. It
will create a shallow clone of your IOC in the standard release area at the
correct path and "make" it.

optional arguments:
  -h, --help            show this help message and exit
  --version             Show version number and exit.
  --name NAME, -n NAME  The name of the repository to deploy. This is a
                        required argument. If it does not exist on github,
                        we'll also try prepending with 'ioc-common-'.
  --release RELEASE, -r RELEASE
                        The version of the IOC to deploy. This is a required
                        argument.
  --ioc-dir IOC_DIR, -i IOC_DIR
                        The directory to deploy IOCs in. This defaults to
                        $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
                        the environment variable is not set. With your current
                        environment variables, this defaults to
                        /reg/g/pcds/epics/ioc.
  --github_org GITHUB_ORG, --org GITHUB_ORG
                        The github org to deploy IOCs from. This defaults to
                        $GITHUB_ORG, or pcdshub if the environment variable is
                        not set. With your current environment variables, this
                        defaults to pcdshub.
  --auto-confirm, --confirm, --yes, -y
                        Skip the confirmation promps, automatically saying yes
                        to each one.
  --dry-run             Do not deploy anything, just print what would have
                        been done.
  --verbose, -v, --debug
                        Display additional debug information.
```

</details>

Here is some sample output with debug/verbose mode on. Without debug/verbose mode, you'd see mostly the same except no "DEBUG" statements and no line numbers.

<details>

```
ioc-deploy --name ads-ioc -r 0.6.2 --yes --verbose --ioc-dir /cds/home/z/zlentz/ioc
DEBUG    ioc-deploy:241: args are namespace(auto_confirm=True, dry_run=False, github_org='pcdshub', ioc_dir='/cds/home/z/zlentz/ioc', name='ads-ioc', release='0.6.2', verbose=True, version=False)
INFO     ioc-deploy:73: Running ioc-deploy: checking inputs
WARNING  ioc-deploy:119: ads-ioc is not an ioc name, trying ioc-common-ads-ioc
DEBUG    ioc-deploy:121: Checking for ioc-common-ads-ioc in org pcdshub
INFO     ioc-deploy:125: ioc-common-ads-ioc exists in pcdshub
DEBUG    ioc-deploy:156: Checking for release 0.6.2 in pcdshub/ioc-common-ads-ioc
WARNING  ioc-deploy:165: Did not find release 0.6.2 in pcdshub/ioc-common-ads-ioc
DEBUG    ioc-deploy:156: Checking for release R0.6.2 in pcdshub/ioc-common-ads-ioc
INFO     ioc-deploy:160: Release R0.6.2 exists in pcdshub/ioc-common-ads-ioc
INFO     ioc-deploy:78: Deploying pcdshub/ioc-common-ads-ioc at R0.6.2 to /cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2
DEBUG    ioc-deploy:189: Ensure /cds/home/z/zlentz/ioc/common/ads-ioc exists
Cloning into '/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2'...
remote: Enumerating objects: 56, done.
remote: Counting objects: 100% (56/56), done.
remote: Compressing objects: 100% (50/50), done.
remote: Total 56 (delta 3), reused 37 (delta 2), pack-reused 0
Receiving objects: 100% (56/56), 30.46 KiB | 636.00 KiB/s, done.
Resolving deltas: 100% (3/3), done.
Note: switching to '1927fe1b15fa7216276113cfdf2acc6a77fb0d34'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

INFO     ioc-deploy:91: Building IOC at /cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2
make -C ./configure install
make[1]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/configure'
perl -CSD /reg/g/pcds/epics/base/R7.0.2-2.0/bin/rhel7-x86_64/makeMakefile.pl O.rhel7-x86_64 ../..
mkdir -p O.Common
make -C O.rhel7-x86_64 -f ../Makefile TOP=../.. \
    T_A=rhel7-x86_64 install
make[2]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/configure/O.rhel7-x86_64'
perl -CSD /reg/g/pcds/epics/base/R7.0.2-2.0/bin/rhel7-x86_64/convertRelease.pl checkRelease
make[2]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/configure/O.rhel7-x86_64'
make[1]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/configure'
make -C ./app install
make[1]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app'
make -C ./src install
make[2]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/src'
perl -CSD /reg/g/pcds/epics/base/R7.0.2-2.0/bin/rhel7-x86_64/makeMakefile.pl O.rhel7-x86_64 ../../..
mkdir -p O.Common
make -C O.rhel7-x86_64 -f ../Makefile TOP=../../.. \
    T_A=rhel7-x86_64 install
make[3]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/src/O.rhel7-x86_64'
/usr/bin/gcc  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g  -pipe -Wall       -m64       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include                                -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include  -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/include   -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/include -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/compiler/gcc -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/os/Linux -I/reg/g/pcds/epics//base/R7.0.2-2.0/include        -MM -MF adsIocMain.d  ../adsIocMain.c
/usr/bin/gcc  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g  -pipe -Wall       -m64       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include                                -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include  -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/include   -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/include -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/compiler/gcc -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/os/Linux -I/reg/g/pcds/epics//base/R7.0.2-2.0/include        -MM -MF infoFieldArchive.d  ../infoFieldArchive.c
Creating dbd file adsIoc.dbd
perl -CSD /reg/g/pcds/epics//base/R7.0.2-2.0/bin/rhel7-x86_64/dbdExpand.pl   -I. -I.. -I../O.Common -I../../../dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/ethercatmc/R2.1.0-0.1.2/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/twincat-ads/R2.0.0-0.0.7/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/dbd -I/reg/g/pcds/epics//base/R7.0.2-2.0/dbd -o adsIoc.dbd base.dbd iocAdmin.dbd asSupport.dbd ads.dbd asyn.dbd drvAsynIPPort.dbd dbArchive.dbd system.dbd caPutLog.dbd ads.dbd motorSupport.dbd devSoftMotor.dbd EthercatMcSupport.dbd
perl -CSD /reg/g/pcds/epics//base/R7.0.2-2.0/bin/rhel7-x86_64/registerRecordDeviceDriver.pl   -I. -I.. -I../O.Common -I../../../dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/ethercatmc/R2.1.0-0.1.2/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/twincat-ads/R2.0.0-0.0.7/dbd -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/dbd -I/reg/g/pcds/epics//base/R7.0.2-2.0/dbd    -o adsIoc_registerRecordDeviceDriver.cpp ../O.Common/adsIoc.dbd adsIoc_registerRecordDeviceDriver /cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2
/usr/bin/g++  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g  -pipe -Wall       -m64       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include                                -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include  -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/include   -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/include -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/compiler/gcc -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/os/Linux -I/reg/g/pcds/epics//base/R7.0.2-2.0/include        -MM -MF adsIoc_registerRecordDeviceDriver.d  adsIoc_registerRecordDeviceDriver.cpp
make[3]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/src/O.rhel7-x86_64'
make[3]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/src/O.rhel7-x86_64'
Installing created dbd file ../../../dbd/adsIoc.dbd
mkdir ../../../dbd
/usr/bin/g++  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g  -pipe -Wall       -m64       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include                                -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include  -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/include   -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/include -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/compiler/gcc -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/os/Linux -I/reg/g/pcds/epics//base/R7.0.2-2.0/include        -c adsIoc_registerRecordDeviceDriver.cpp
/usr/bin/gcc  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g  -pipe -Wall       -m64       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include                                -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include  -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/include   -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/include -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/compiler/gcc -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/os/Linux -I/reg/g/pcds/epics//base/R7.0.2-2.0/include        -c ../infoFieldArchive.c
In file included from /reg/g/pcds/epics//base/R7.0.2-2.0/include/dbAccess.h:19:0,
                 from ../infoFieldArchive.c:8:
/reg/g/pcds/epics//base/R7.0.2-2.0/include/dbBase.h:162:5: warning: ‘rset’ is deprecated (declared at /reg/g/pcds/epics//base/R7.0.2-2.0/include/recSup.h:67) [-Wdeprecated-declarations]
     rset        *prset;
     ^
In file included from /reg/g/pcds/epics//base/R7.0.2-2.0/include/dbAccess.h:23:0,
                 from ../infoFieldArchive.c:8:
/reg/g/pcds/epics//base/R7.0.2-2.0/include/dbAccessDefs.h:210:46: warning: ‘rset’ is deprecated (declared at /reg/g/pcds/epics//base/R7.0.2-2.0/include/recSup.h:67) [-Wdeprecated-declarations]
 epicsShareFunc rset * dbGetRset(const struct dbAddr *paddr);
                                              ^
/usr/bin/gcc  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g  -pipe -Wall       -m64       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include                                -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/autosave/R5.8-2.1.0/include  -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include/os/Linux -I/reg/g/pcds/epics//R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/include   -I/reg/g/pcds/epics//R7.0.2-2.0/modules/asyn/R4.35-0.0.1/include      -I/reg/g/pcds/epics//R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/include -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/compiler/gcc -I/reg/g/pcds/epics//base/R7.0.2-2.0/include/os/Linux -I/reg/g/pcds/epics//base/R7.0.2-2.0/include        -c ../adsIocMain.c
/usr/bin/g++ -o adsIoc -Wl,-Bstatic -L/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/asyn/R4.35-0.0.1/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/autosave/R5.8-2.1.0/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/caPutLog/R3.7-1.0.0/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/ethercatmc/R2.1.0-0.1.2/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/iocAdmin/R3.1.15-1.10.0/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/motor/R6.9-ess-0.0.1/lib/rhel7-x86_64 -L/reg/g/pcds/epics/R7.0.2-2.0/modules/twincat-ads/R2.0.0-0.0.7/lib/rhel7-x86_64 -L/reg/g/pcds/epics/base/R7.0.2-2.0/lib/rhel7-x86_64         -m64    -rdynamic         adsIoc_registerRecordDeviceDriver.o infoFieldArchive.o adsIocMain.o    -lcaPutLog -lads -lmotor -lsoftMotor -lEthercatMcSupport -ldevIocStats -lasyn -lautosave -ldbRecStd -ldbCore -lca -lCom -Wl,-Bdynamic  -lpthread   -lreadline -lncurses -lm -lrt -ldl -lgcc
Installing created executable ../../../bin/rhel7-x86_64/adsIoc
mkdir ../../../bin
mkdir ../../../bin/rhel7-x86_64
make[3]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/src/O.rhel7-x86_64'
make[2]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/src'
make -C ./Db install
make[2]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/Db'
perl -CSD /reg/g/pcds/epics/base/R7.0.2-2.0/bin/rhel7-x86_64/makeMakefile.pl O.rhel7-x86_64 ../../..
mkdir -p O.Common
make -C O.rhel7-x86_64 -f ../Makefile TOP=../../.. \
    T_A=rhel7-x86_64 install
make[3]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/Db/O.rhel7-x86_64'
Installing template file ../../../db/EthercatMC.template
mkdir ../../../db
Installing template file ../../../db/EthercatMCdebug.template
Installing template file ../../../db/EthercatMChome.template
Installing template file ../../../db/EthercatMCreadback.template
Installing template file ../../../db/EthercatMCslitAvoidCollSoftlimits.template
Installing template file ../../../db/EthercatMCslit_hard.template
Installing template file ../../../db/EthercatMCslit_soft.template
Installing ../../../db/caPutLog.db
Installing ../../../db/TwinCAT_TaskInfo.db
Installing ../../../db/TwinCAT_AppInfo.db
Installing ../../../db/TwinCAT_Dependency.db
Installing ../../../db/TwinCAT_Project.db
Installing DB_INSTALLS ../../../db/iocSoft.db
Installing DB_INSTALLS ../../../db/devIocInfo.db
Installing DB_INSTALLS ../../../db/save_restoreStatus.db
Installing DB_INSTALLS ../../../db/asynRecord.db
make[3]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/Db/O.rhel7-x86_64'
make[2]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app/Db'
make[1]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/app'
make -C ./iocBoot install
make[1]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/iocBoot'
make -C ./templates install
make[2]: Entering directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/iocBoot/templates'
perl -CSD /reg/g/pcds/epics/base/R7.0.2-2.0/bin/rhel7-x86_64/convertRelease.pl -t /cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2 envPaths
make[2]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/iocBoot/templates'
make[1]: Leaving directory `/cds/home/z/zlentz/ioc/common/ads-ioc/R0.6.2/iocBoot'
```

</details>

The script is contained in a single file and is reasonably portable. It only relies on the python standard library, not on pypi/conda packages, and it runs on psbuild-rhel7-01 and on psbuild-rocky9-01.

The code is contained in the `ioc_deploy.py` file to register as a python file in vscode, but it can also be run from the symbolic link `ioc-deploy` to make it look more script-like when running.

When run as a script, the general execution chain is:
- Run `_main` in such a way that its return value becomes our script exit code
- `_main` sets up general scripty things such as args and last-chance error handling
- `_main` calls `main` which does all the stuff you think about when you imagine the script running.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are migrating our EPICS IOCs to GitHub. See https://confluence.slac.stanford.edu/display/PCDS/ECS+EPICS+IOC+Github+Migration+Plan

Since tagging/releasing will be done via the GitHub interface, and there is no more cvs/svn/afs in the deploy loop, `epics-release` is somewhat bloated and obsolete compared to the current needs, so a simpler replacement is desirable.

Somewhat selfishly, I'd prefer to maintain a small script like this instead of the larger eco_tools infrastructure, which provides more features but is more difficult to debug when things go wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively, a lot

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll add this to the README after making this PR

<!--
## Screenshots (if appropriate):
-->
