### PR TITLE
ENH: add quick script for repointing afs remotes to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ git pull origin master
 
 <table>
 <tr>
+    <td>afs-remote-fix</td>
+    <td>
+usage: afs-remote-fix<br/>
+Will change your afs remotes from e.g.<br/>
+origin          /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/common/ims.git<br/>
+to</br>
+origin          git@github.com:your-username/ioc-common-ims.git<br/>
+upstream        git@github.com:pcdshub/ioc-common-ims.git<br/>
+    </td>
+</tr>
+
+<tr>
     <td>ami_offline_psana</td>
     <td>
 usage: ami_offline_psana options<br/>

--- a/scripts/afs-remote-fix
+++ b/scripts/afs-remote-fix
@@ -1,0 +1,1 @@
+afs_remote_fix.py

--- a/scripts/afs_remote_fix.py
+++ b/scripts/afs_remote_fix.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+"""
+afs-remote-fix is a script for repointing your afs git remotes towards github.
+
+It will check if you're currently in a git ioc repo with an afs remote as your origin,
+switching it to your fork and adding an upstream remote to pcdshub.
+
+An afs remote is a git remote with a path that looks something like this:
+/afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/common/ims.git
+
+If this path is your origin, after running the script you will instead have:
+
+origin          git@github.com:your-username/ioc-common-ims.git
+upstream        git@github.com:pcdshub/ioc-common-ims.git
+
+If the origin is not an afs path, this script will exit without taking any action.
+
+The script will prompt you for your github username, which is not necessarily
+the same as your slac username.
+"""
+import subprocess
+
+
+def main() -> int:
+    origin = subprocess.check_output(["git", "remote", "get-url", "origin"], universal_newlines=True).strip()
+    if not origin.startswith("/afs/"):
+        print(f"Your origin {origin} is not an afs repo.")
+        return 1
+    elif "/ioc/" not in origin:
+        print(f"Your origin {origin} is not an ioc repo.")
+        return 1
+    _, ioc_path = origin.split("/ioc/")
+    repo_name = f"ioc-{ioc_path.replace('/', '-', 1)}"
+    username = input("Please input your github username:\n")
+    new_origin = f"git@github.com:{username}/{repo_name}"
+    new_upstream = f"git@github.com:pcdshub/{repo_name}"
+    print("\nPlanning to set:")
+    print(f"origin to {new_origin}")
+    print(f"upstream to {new_upstream}")
+    confirm = input("Confirm? y/n\n")
+    if not confirm.lower().startswith("y"):
+        return 1
+    subprocess.run(["git", "remote", "set-url", "origin", new_origin])
+    subprocess.run(["git", "remote", "add", "upstream", new_upstream])
+    subprocess.run(["git", "remote", "-v"])
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/scripts/afs_remote_fix.py
+++ b/scripts/afs_remote_fix.py
@@ -18,11 +18,14 @@ If the origin is not an afs path, this script will exit without taking any actio
 The script will prompt you for your github username, which is not necessarily
 the same as your slac username.
 """
+
 import subprocess
 
 
 def main() -> int:
-    origin = subprocess.check_output(["git", "remote", "get-url", "origin"], universal_newlines=True).strip()
+    origin = subprocess.check_output(
+        ["git", "remote", "get-url", "origin"], universal_newlines=True
+    ).strip()
     if not origin.startswith("/afs/"):
         print(f"Your origin {origin} is not an afs repo.")
         return 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `afs-remote-fix` (`afs_remote_fix.py`), a tiny script for changing a user's afs remote to point toward their fork and to pcdshub.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We're migrating the afs repos so this will be useful.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only in the readme and in the file

<!--
## Screenshots (if appropriate):
-->
