### PR TITLE
FIX: issues with ioc-deploy casing

### DIFF
--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -209,12 +209,14 @@ def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> st
             raise ValueError(
                 f"Error cloning repo, make sure {name} exists in {github_org} and check your permissions!"
             ) from exc
-        try:
-            with open(Path(tmpdir) / name / "README.md", "r") as fd:
-                readme_text = fd.read()
+        readme_text = ""
+        # Search for readme in any casing with any file extension
+        pattern = "".join(f"[{char.lower()}{char.upper()}]" for char in "readme") + "*"
+        for readme_path in (Path(tmpdir) / name).glob(pattern):
+            with open(readme_path, "r") as fd:
+                readme_text += fd.read()
             logger.debug("Successfully read repo readme for backup casing check")
-        except FileNotFoundError:
-            readme_text = ""
+        if not readme_text:
             logger.debug("Unable to read repo readme for backup casing check")
     logger.debug("Checking deploy area for casing")
     # GitHub URLs are case-insensitive, so we need further checks

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -133,7 +133,7 @@ def main(args: CliArgs) -> int:
 
     logger.info("Running ioc-deploy: checking inputs")
     upd_name = finalize_name(
-        name=args.name, github_org=args.github_org, verbose=args.verbose
+        name=args.name, github_org=args.github_org, ioc_dir=args.ioc_dir, verbose=args.verbose
     )
     upd_rel = finalize_tag(
         name=upd_name,
@@ -171,11 +171,11 @@ def main(args: CliArgs) -> int:
     return ReturnCode.SUCCESS
 
 
-def finalize_name(name: str, github_org: str, verbose: bool) -> str:
+def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> str:
     """
-    Check if name is present in org and is well-formed.
+    Check if name is present in org, is well-formed, and has correct casing.
 
-    If the name is present, return it.
+    If the name is present, return it, fixing the casing if needed.
     If the name is not present and the correct name can be guessed, guess.
     If the name is not present and cannot be guessed, raise.
 
@@ -187,6 +187,9 @@ def finalize_name(name: str, github_org: str, verbose: bool) -> str:
 
     However, "ads-ioc" will resolve to "ioc-common-ads-ioc".
     Only common IOCs will be automatically discovered using this method.
+
+    Note that GitHub URLs are case-insensitive, so there's no native way to tell
+    from a clone step if you've maintained the correct casing information.
     """
     split_name = name.split("-")
     if len(split_name) < 3 or split_name[0] != "ioc":
@@ -203,7 +206,59 @@ def finalize_name(name: str, github_org: str, verbose: bool) -> str:
             raise ValueError(
                 f"Error cloning repo, make sure {name} exists in {github_org} and check your permissions!"
             ) from exc
+        try:
+            with open(Path(tmpdir) / name / "README.md", "r") as fd:
+                readme_text = fd.read()
+            logger.debug("Successfully read repo readme for backup casing check")
+        except FileNotFoundError:
+            readme_text = ""
+            logger.debug("Unable to read repo readme for backup casing check")
+    logger.debug("Checking deploy area for casing")
+    # GitHub URLs are case-insensitive, so we need further checks
+    # REST API is most reliable but requires different auth
+    # Checking existing directories is ideal because it ensures consistency with earlier releases
+    # Check the readme last as a backup
+    repo_dir = Path(get_target_dir(name=name, ioc_dir=ioc_dir, release="placeholder")).parent
+    if repo_dir.exists():
+        logger.debug(f"{repo_dir} exists, using as-is")
+        return name
+    logger.info(f"{repo_dir} does not exist, checking for other casings")
+    _, area, suffix = name.split("-", maxsplit=2)
+    # First, check for casing on area
+    found_area = False
+    for path in Path(ioc_dir).iterdir():
+        if path.name.lower() == area.lower():
+            area = path.name
+            found_area = True
+            break
+    if not found_area:
+        logger.info("This is a new area, checking readme for casing")
+        return casing_from_readme(name=name, readme_text=readme_text)
+
+    found_suffix = False
+    for path in (Path(ioc_dir) / area).iterdir():
+        if path.name.lower() == suffix.lower():
+            suffix = path.name
+            found_suffix = True
+            break
+    if not found_suffix:
+        logger.info("This is a new ioc, checking readme for casing")
+        return casing_from_readme(name=name, readme_text=readme_text)
+
+    name = "-".join(("ioc", area, suffix))
+    logger.info(f"Found casing: {name}")
     return name
+
+
+def casing_from_readme(name: str, readme_text: str) -> str:
+    try:
+        index = readme_text.lower().index(name.lower())
+    except ValueError:
+        logger.warning("Did not find casing information in readme. Please double-check the name!")
+        return name
+    new_name = readme_text[index:index+len(name)]
+    logger.info(f"Found casing in readme: {new_name}")
+    return new_name
 
 
 def finalize_tag(name: str, github_org: str, release: str, verbose: bool) -> str:

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -237,6 +237,7 @@ def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> st
         if path.name.lower() == area.lower():
             area = path.name
             found_area = True
+            logger.info(f"Using {area} as the area")
             break
     if not found_area:
         logger.info("This is a new area, checking readme for casing")
@@ -247,13 +248,15 @@ def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> st
         if path.name.lower() == suffix.lower():
             suffix = path.name
             found_suffix = True
+            logger.info(f"Using {suffix} as the name")
             break
     if not found_suffix:
         logger.info("This is a new ioc, checking readme for casing")
-        return casing_from_readme(name=name, readme_text=readme_text)
+        # Use suffix from readme but keep area from directory search
+        suffix = casing_from_readme(name=name, readme_text=readme_text).split("-", maxsplit=2)[2]
 
     name = "-".join(("ioc", area, suffix))
-    logger.info(f"Found casing: {name}")
+    logger.info(f"Using casing: {name}")
     return name
 
 

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -133,7 +133,10 @@ def main(args: CliArgs) -> int:
 
     logger.info("Running ioc-deploy: checking inputs")
     upd_name = finalize_name(
-        name=args.name, github_org=args.github_org, ioc_dir=args.ioc_dir, verbose=args.verbose
+        name=args.name,
+        github_org=args.github_org,
+        ioc_dir=args.ioc_dir,
+        verbose=args.verbose,
     )
     upd_rel = finalize_tag(
         name=upd_name,
@@ -218,7 +221,9 @@ def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> st
     # REST API is most reliable but requires different auth
     # Checking existing directories is ideal because it ensures consistency with earlier releases
     # Check the readme last as a backup
-    repo_dir = Path(get_target_dir(name=name, ioc_dir=ioc_dir, release="placeholder")).parent
+    repo_dir = Path(
+        get_target_dir(name=name, ioc_dir=ioc_dir, release="placeholder")
+    ).parent
     if repo_dir.exists():
         logger.debug(f"{repo_dir} exists, using as-is")
         return name
@@ -254,9 +259,11 @@ def casing_from_readme(name: str, readme_text: str) -> str:
     try:
         index = readme_text.lower().index(name.lower())
     except ValueError:
-        logger.warning("Did not find casing information in readme. Please double-check the name!")
+        logger.warning(
+            "Did not find casing information in readme. Please double-check the name!"
+        )
         return name
-    new_name = readme_text[index:index+len(name)]
+    new_name = readme_text[index : index + len(name)]
     logger.info(f"Found casing in readme: {new_name}")
     return new_name
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix an issue where `ioc-deploy` would happily create new folders if you make a casing typo, e.g. `ioc-common-gigecam` will now deploy to `ioc/common/gigECam`.

Github URLs are case-insensitive, e.g. you can clone `ioc-coMMon-GiGeCaM` and it will work just fine.
So, we need to turn to other sources for the correct casing for directory deployment.

The REST API is the most consistent method, but it requires additional authentication.

This PR checks two things in order looking for a match:

- The existing deploy directories
- The README

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-6018

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only, works as I expect

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
