### PR TITLE
ENH: add messages for ssh-agent-helper exit state to make the result clear

### DIFF
--- a/scripts/ssh-agent-helper
+++ b/scripts/ssh-agent-helper
@@ -40,5 +40,9 @@ fi
 if [ "$rval" -gt 0 ]; then
     echo "Running ssh-add, may prompt for ssh key password"
     # Expire after 12h just in case to avoid infinite key storage
-    ssh-add -t 12h 2> /dev/null
+    if ssh-add -t 12h 2> /dev/null; then
+        echo "ssh-agent-helper complete: key successfully added"
+    else
+        echo "ssh-agent-helper error: at least one key failed to be added"
+    fi
 fi


### PR DESCRIPTION
Reviewers: I mostly want quick opinions about the word choice and the terminal output, you shouldn't spend a lot of time out of your day on this one. I think this is the normal/simplest way to check a return code in a bash script.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If the `ssh-add` step in `ssh-agent-helper` runs, let the user know how it goes.
The script remains silent if it didn't need to do anything.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This came up when @ljansen7 was deploying IOCs a week or so ago and the script output was unclear: did it work? Did it not work? Do I have to do it again?

Jira at https://jira.slac.stanford.edu/browse/ECS-6095

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the script a few times with different conditions:

Correct password:
```
zlentz@pslogin04:~$ source ~/github/engineering_tools/scripts/ssh-agent-helper
Starting ssh agent
Running ssh-add, may prompt for ssh key password
Enter passphrase for /cds/home/z/zlentz/.ssh/id_rsa:
ssh-agent-helper complete: key successfully added
```

Wrong password a bunch, ctrl+c and skips my message
```
zlentz@pslogin02:~$ source ~/github/engineering_tools/scripts/ssh-agent-helper
Starting ssh agent
Running ssh-add, may prompt for ssh key password
Enter passphrase for /cds/home/z/zlentz/.ssh/id_rsa:
Bad passphrase, try again for /cds/home/z/zlentz/.ssh/id_rsa:
Bad passphrase, try again for /cds/home/z/zlentz/.ssh/id_rsa:
Bad passphrase, try again for /cds/home/z/zlentz/.ssh/id_rsa:
Bad passphrase, try again for /cds/home/z/zlentz/.ssh/id_rsa:
```

Empty password, but actually my key is encrypted still and the return code catches it
```
zlentz@pslogin02:~$ source ~/github/engineering_tools/scripts/ssh-agent-helper
Running ssh-add, may prompt for ssh key password
Enter passphrase for /cds/home/z/zlentz/.ssh/id_rsa:
ssh-agent-helper error: at least one key failed to be added
```


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only, later in release notes

<!--
## Screenshots (if appropriate):
-->
