### PR TITLE
ENH: check for github early to avoid long timeouts, decrease usage of git clone

### DIFF
--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -839,7 +839,7 @@ def _main() -> int:
         if args.version:
             print(get_version())
             return ReturnCode.SUCCESS
-        logger.info("ioc-deploy: checking inputs")
+        logger.info("Checking inputs")
         if not (args.name and args.release) and not args.path_override:
             logger.error(
                 "Must provide both --name and --release, or --path-override. Check ioc-deploy --help for usage."

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -568,7 +568,7 @@ def finalize_tag(name: str, github_org: str, release: str, verbose: bool) -> str
             verbose=verbose,
         )
     except subprocess.CalledProcessError as exc:
-        raise ValueError(f"Unable to access {github_org}/{name}") from exc
+        raise ValueError(f"Unable to access {github_org}/{name}, please make sure you have the correct access rights and the repository exists.") from exc
     for rel in release_permutations(release=release):
         logger.debug(f"Trying variant {rel}")
         if rel in tags:
@@ -827,7 +827,10 @@ def _ls_remote(
     verbose: bool = False,
 ) -> List[str]:
     """
-    Run git ls-remote --tags --refs or raise a subprocess.CalledProcessError
+    Return git ls-remote's output or raise a subprocess.CalledProcessError
+
+    This will call "git ls-remote --tags --refs", which is a fast way
+    to check if a remote repo is accessible and get a list of tags.
 
     The code here is more complex than _clone so we can print stdout and stderr
     interleaved in verbose mode while also capturing stdout separately.
@@ -849,6 +852,11 @@ def _ls_remote(
             if verbose:
                 print(line, end="")
             output.append(line.strip())
+    if proc.returncode:
+        raise subprocess.CalledProcessError(
+            returncode=proc.returncode,
+            cmd=cmd,
+        )
     return output
 
 

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -221,7 +221,9 @@ def main_deploy(args: CliArgs) -> int:
     """
     logger.info("Checking github connectivity")
     if not get_github_available(verbose=args.verbose):
-        logger.error("Github is not reachable, please check to make sure you're on a psbuild host.")
+        logger.error(
+            "Github is not reachable, please check to make sure you're on a psbuild host."
+        )
         return ReturnCode.EXCEPTION
 
     logger.info("Checking repos and ioc deploy directories")
@@ -353,7 +355,7 @@ def get_deploy_info(args: CliArgs) -> DeployInfo:
 
     if args.path_override:
         deploy_dir = args.path_override
-        if (args.name and args.release):
+        if args.name and args.release:
             name = args.name
             release = args.release
         else:
@@ -399,9 +401,7 @@ def get_deploy_info(args: CliArgs) -> DeployInfo:
         )
 
     if not args.path_override:
-        deploy_dir = get_target_dir(
-            name=name, ioc_dir=args.ioc_dir, release=release
-        )
+        deploy_dir = get_target_dir(name=name, ioc_dir=args.ioc_dir, release=release)
 
     return DeployInfo(deploy_dir=deploy_dir, pkg_name=name, rel_name=release)
 
@@ -464,7 +464,9 @@ def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> st
         area = find_casing_in_dir(dir=ioc_dir, name=area)
     except RuntimeError:
         logger.info("This is a new area, checking readme for casing")
-        name = casing_from_readme_clone(name=name, github_org=github_org, verbose=verbose)
+        name = casing_from_readme_clone(
+            name=name, github_org=github_org, verbose=verbose
+        )
         logger.info(f"Using casing: {name}")
         return name
     logger.info(f"Using {area} as the area")
@@ -473,7 +475,9 @@ def finalize_name(name: str, github_org: str, ioc_dir: str, verbose: bool) -> st
         suffix = find_casing_in_dir(dir=str(Path(ioc_dir) / area), name=suffix)
     except RuntimeError:
         logger.info("This is a new ioc, checking readme for casing")
-        casing = casing_from_readme_clone(name=name, github_org=github_org, verbose=verbose)
+        casing = casing_from_readme_clone(
+            name=name, github_org=github_org, verbose=verbose
+        )
         # Use suffix from readme but keep area from directory search
         suffix = split_ioc_name(casing)[2]
     logger.info(f"Using {suffix} as the name")
@@ -568,7 +572,9 @@ def finalize_tag(name: str, github_org: str, release: str, verbose: bool) -> str
             verbose=verbose,
         )
     except subprocess.CalledProcessError as exc:
-        raise ValueError(f"Unable to access {github_org}/{name}, please make sure you have the correct access rights and the repository exists.") from exc
+        raise ValueError(
+            f"Unable to access {github_org}/{name}, please make sure you have the correct access rights and the repository exists."
+        ) from exc
     for rel in release_permutations(release=release):
         logger.debug(f"Trying variant {rel}")
         if rel in tags:
@@ -838,7 +844,13 @@ def _ls_remote(
 
     Returns the stdout lines as a list of strings.
     """
-    cmd = ["git", "ls-remote", "--tags", "--refs", f"git@github.com:{github_org}/{name}"]
+    cmd = [
+        "git",
+        "ls-remote",
+        "--tags",
+        "--refs",
+        f"git@github.com:{github_org}/{name}",
+    ]
     kwds = {
         "stdout": subprocess.PIPE,
         "bufsize": 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This should be the second-to-last PR from me about this script from the Jira epic.

Main goal: make `ioc-deploy` succeed and fail faster, avoiding slow commands and long timeouts.

Main changes:
- Before a deploy action, `ping` github as a quick connectivity check.
- Check tags, auth, and repo availability all at once using `git ls-remote` one time instead of through multiple `git clone` commands.
- Rearrange logic in `get_deploy_info`, `finalize_name`, and `finalize_tag` to facilitate the above.

Incidental changes:
- Normalize `DeployInfo` to only use `str`, not `None` because it simplified some implementation details
- Rearrange some of the docstrings to match where code has moved
- Allow providing `--path-override` by itself during the deploy routines, which previously would error out. This fell out naturally from the rest of the refactor and I didn't realize it hadn't been supported previously.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Full details at https://jira.slac.stanford.edu/browse/ECS-6096

If you `git clone` from a server like `las-console` or `rix-control`, one of the following will happen:
- If you have psproxy configured, you will be prompted for your password separately on each clone.
- If you do not have psproxy configured, you will time out after 2 minutes.

Both of these cases are avoided by this PR. I wanted to avoid setting timeouts on git clone because the command can take an arbitrarily long amount of time based on the network situation and file sizes. For the same reason, I wanted to avoid calling git clone multiple times if it could be avoided.

For example: cloning the gigECam ioc can often be slow, so I'd like this script to only do it once.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively, extensively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only in this PR and release notes. The expected results of running `ioc-deploy` remains unchanged, it should just succeed and fail faster.

<!--
## Screenshots (if appropriate):
-->
