### PR TITLE
ENH: allow in-script tagging in ioc-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ from https://github.com/pcdshub/ioc-foo-bar
 to /cds/group/pcds/epics/ioc/foo/bar/R1.0.0
 then cd and make and chmod as appropriate.
 &nbsp;
+If the repository exists but the tag does not, the script will ask if you'd like
+to make a new tag and prompt you as appropriate.
+&nbsp;
 The second action will not do any git or make actions, it will only find the
 release directory and change the file and directory permissions.
 This can be done with similar commands as above, adding the subparser command,

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -554,7 +554,9 @@ def casing_from_text(uncased: str, casing_source: str) -> str:
     return casing_source[index : index + len(uncased)]
 
 
-def finalize_tag(name: str, github_org: str, release: str, auto_confirm: bool, verbose: bool) -> str:
+def finalize_tag(
+    name: str, github_org: str, release: str, auto_confirm: bool, verbose: bool
+) -> str:
     """
     Check if release is present in the org.
 
@@ -621,12 +623,16 @@ def finalize_tag(name: str, github_org: str, release: str, auto_confirm: bool, v
             else:
                 # No commit message = not an annotated commit = displays the linked commit's message
                 print()
-                print("The default message comes from the most recent commit, which is:")
+                print(
+                    "The default message comes from the most recent commit, which is:"
+                )
                 print()
                 print(last_commit.strip())
                 print()
             print("(Optional) if you'd like, you may type a different tag message.")
-            print("For multiline messages in git, the first line is a summary of the message.")
+            print(
+                "For multiline messages in git, the first line is a summary of the message."
+            )
             print("End with ctrl+D on blank line.")
             print()
             while True:
@@ -636,7 +642,12 @@ def finalize_tag(name: str, github_org: str, release: str, auto_confirm: bool, v
                     break
         # Raise errors from these without modifying the error message
         logger.info(f"Creating tag {suggested_tag}")
-        _tag(release=suggested_tag, message=tag_msg.strip(), working_dir=cloned_dir, verbose=verbose)
+        _tag(
+            release=suggested_tag,
+            message=tag_msg.strip(),
+            working_dir=cloned_dir,
+            verbose=verbose,
+        )
         logger.info("Pushing tag to GitHub")
         _push_tag(release=suggested_tag, working_dir=cloned_dir, verbose=verbose)
 

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -120,8 +120,14 @@ def get_parser(subparser: bool = False) -> argparse.ArgumentParser:
     # perms_parser unique arguments that should go first
     perms_parser = subparsers.add_parser(
         PERMS_CMD,
-        help=f"Use 'ioc-deploy {PERMS_CMD}' to update the write permissions of a deployment. See 'ioc-deploy {PERMS_CMD} --help' for more information.",
-        description="Update the write permissions of a deployment. This will make all the files read-only (ro), or owner and group writable (rw).",
+        help=(
+            f"Use 'ioc-deploy {PERMS_CMD}' to update the write permissions of a deployment. "
+            f"See 'ioc-deploy {PERMS_CMD} --help' for more information."
+        ),
+        description=(
+            "Update the write permissions of a deployment. "
+            "This will make all the files read-only (ro), or owner and group writable (rw)."
+        ),
     )
     perms_parser.add_argument(
         "permissions",
@@ -136,7 +142,10 @@ def get_parser(subparser: bool = False) -> argparse.ArgumentParser:
             "-n",
             action="store",
             default="",
-            help="The name of the repository to deploy. This is a required argument. If it does not exist on github, we'll also try prepending with 'ioc-common-'.",
+            help=(
+                "The name of the repository to deploy. This is a required argument. "
+                "If it does not exist on github, we'll also try prepending with 'ioc-common-'."
+            ),
         )
         parser.add_argument(
             "--release",
@@ -150,13 +159,20 @@ def get_parser(subparser: bool = False) -> argparse.ArgumentParser:
             "-i",
             action="store",
             default=current_default_target,
-            help=f"The directory to deploy IOCs in. This defaults to $EPICS_SITE_TOP/ioc, or {EPICS_SITE_TOP_DEFAULT}/ioc if the environment variable is not set. With your current environment variables, this defaults to {current_default_target}.",
+            help=(
+                f"The directory to deploy IOCs in. This defaults to $EPICS_SITE_TOP/ioc, "
+                f"or {EPICS_SITE_TOP_DEFAULT}/ioc if the environment variable is not set. "
+                f"With your current environment variables, this defaults to {current_default_target}."
+            ),
         )
         parser.add_argument(
             "--path-override",
             "-p",
             action="store",
-            help="If provided, ignore all normal path-selection rules in favor of the specific provided path. This will let you deploy IOCs or apply protection rules to arbitrary specific paths.",
+            help=(
+                "If provided, ignore all normal path-selection rules in favor of the specific provided path. "
+                "This will let you deploy IOCs or apply protection rules to arbitrary specific paths."
+            ),
         )
         parser.add_argument(
             "--auto-confirm",
@@ -184,7 +200,11 @@ def get_parser(subparser: bool = False) -> argparse.ArgumentParser:
         "--org",
         action="store",
         default=current_default_org,
-        help=f"The github org to deploy IOCs from. This defaults to $GITHUB_ORG, or {GITHUB_ORG_DEFAULT} if the environment variable is not set. With your current environment variables, this defaults to {current_default_org}.",
+        help=(
+            "The github org to deploy IOCs from. "
+            f"This defaults to $GITHUB_ORG, or {GITHUB_ORG_DEFAULT} if the environment variable is not set. "
+            f"With your current environment variables, this defaults to {current_default_org}."
+        ),
     )
     if subparser:
         return perms_parser
@@ -237,7 +257,8 @@ def main_deploy(args: CliArgs) -> int:
 
     if not (deploy_dir and pkg_name and rel_name):
         logger.error(
-            f"Something went wrong at package/tag normalization: package {pkg_name} at version {rel_name} to dir {deploy_dir}"
+            "Something went wrong at package/tag normalization: "
+            f"package {pkg_name} at version {rel_name} to dir {deploy_dir}"
         )
         return ReturnCode.EXCEPTION
 
@@ -310,14 +331,16 @@ def main_perms(args: CliArgs) -> int:
         logger.error(f"OSError during chmod: {exc}")
         error_path = Path(exc.filename)
         logger.error(
-            f"Please contact file owner {error_path.owner()} or someone with sudo permissions if you'd like to change the permissions here."
+            f"Please contact file owner {error_path.owner()} "
+            "or someone with sudo permissions if you'd like to change the permissions here."
         )
         if allow_write:
             suggest = "ug+w"
         else:
             suggest = "a-w"
         logger.error(
-            f"For example, you might try 'sudo chmod -R {suggest} {deploy_dir}' from a server you have sudo access on."
+            f"For example, you might try 'sudo chmod -R {suggest} {deploy_dir}' "
+            "from a server you have sudo access on."
         )
         return ReturnCode.EXCEPTION
 
@@ -581,7 +604,8 @@ def finalize_tag(
         )
     except subprocess.CalledProcessError as exc:
         raise ValueError(
-            f"Unable to access {github_org}/{name}, please make sure you have the correct access rights and the repository exists."
+            f"Unable to access {github_org}/{name}, "
+            "please make sure you have the correct access rights and the repository exists."
         ) from exc
     for rel in release_permutations(release=release):
         logger.debug(f"Trying variant {rel}")
@@ -612,7 +636,8 @@ def finalize_tag(
             )
         except subprocess.CalledProcessError as exc:
             raise ValueError(
-                f"Error cloning {github_org}/{name}, please make sure you have the correct access rights and the repository exists."
+                f"Error cloning {github_org}/{name}, "
+                "please make sure you have the correct access rights and the repository exists."
             ) from exc
         cloned_dir = str(Path(tmpdir) / name)
         tag_msg = ""
@@ -1085,7 +1110,8 @@ def _main() -> int:
         logger.info("Checking inputs")
         if not (args.name and args.release) and not args.path_override:
             logger.error(
-                "Must provide both --name and --release, or --path-override. Check ioc-deploy --help for usage."
+                "Must provide both --name and --release, or --path-override. "
+                "Check ioc-deploy --help for usage."
             )
             return ReturnCode.EXCEPTION
         try:

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -910,7 +910,7 @@ def get_last_commit_info(
     verbose: bool = False,
 ) -> str:
     """
-    Return the most recent commit message or raise a subprocess.CalledProcessError
+    Return the most recent commit's information or raise a subprocess.CalledProcessError
     """
     cmd = ["git", "log", "-1"]
     kwds = {

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -28,6 +28,9 @@ from https://github.com/pcdshub/ioc-foo-bar
 to /cds/group/pcds/epics/ioc/foo/bar/R1.0.0
 then cd and make and chmod as appropriate.
 
+If the repository exists but the tag does not, the script will ask if you'd like
+to make a new tag and prompt you as appropriate.
+
 The second action will not do any git or make actions, it will only find the
 release directory and change the file and directory permissions.
 This can be done with similar commands as above, adding the subparser command,

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -1130,7 +1130,7 @@ def _main() -> int:
     except KeyboardInterrupt:
         logger.error("Interruped with ctrl+C")
         logger.debug("Traceback", exc_info=True)
-        rval = ReturnCode.EXCEPTION
+        rval = ReturnCode.NO_CONFIRM
 
     if rval == ReturnCode.SUCCESS:
         logger.info("ioc-deploy completed successfully")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Main goal: allow us to make releases from the command line without going to the github website, for convenience

Main changes:

- If the provided release number does not exist, prompt the user to create a new tag.
- Enforce Rx.x.x format for the new tag
- The new tag is an annotated tag if we're adding a message to it, and a non-annotated tag otherwise
- Show the last commit message to the user for tag context, confirmation that they pushed their code, and as the defacto "default" message if they decide not to include one with their tag

Other things to note:

- Increase logging consistency between shell out functions
- Have a special message for `KeyboardInterrupt`, since it's way more likely to happen when the user is dropped into a text prompt, and seeing a traceback when you do it is a bit annoying.
- With `--auto-confirm`, the tag will be made automatically with no message.

I also snuck some smaller changes into here


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-6035

For releasing hutch-specific templated IOCs that amount to version bumps, etc., people have expressed that they find it annoying to open up github and do by hand what in the past they had done all in the command-line, so I provide these features here.

This isn't so necessary or useful for when you're already on github doing a code review process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to the help text and readme

<!--
## Screenshots (if appropriate):
-->
