### PR TITLE
DOC: minor docstring errors from renamed cli args

### DIFF
--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -238,7 +238,7 @@ def main_deploy(args: CliArgs) -> int:
     """
     All main steps of the deploy script.
 
-    This will be called when args has neither of apply_write_protection and remove_write_protection
+    This will be called when no subparser is included.
 
     Will either return an int return code or raise.
     """
@@ -302,7 +302,7 @@ def main_perms(args: CliArgs) -> int:
     """
     All main steps of the only-apply-permissions script.
 
-    This will be called when args has at least one of apply_write_protection and remove_write_protection
+    This will be called when the update-perms subparser is included.
 
     Will either return an int code or raise.
     """
@@ -1065,9 +1065,9 @@ def rearrange_sys_argv_for_subcommands():
     Small trick to help argparse deal with my optional subcommand.
 
     This will make argv like this:
-    ioc-deploy -p some_path perms ro
+    ioc-deploy -p some_path update-perms ro
     be interpretted the same as:
-    ioc-deploy perms ro -p some_path
+    ioc-deploy update-perms ro -p some_path
 
     Otherwise, the first example here is interpretted as if -p was never passed,
     which could be confusing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In one of the ioc-deploy PRs we adjusted the cli arg specifics which made these docstrings incorrect.
This PR fixes a few minor docstrings that I noticed this morning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Incorrect docs can be confusing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No functional changes to the code

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
