### PR TITLE
use daqutils for daqmgr hutches

### DIFF
--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -26,11 +26,7 @@ def silentremove(filename):
             raise
 
 def call_subprocess(*args):
-    cc = subprocess.run(args, stdout=PIPE, stderr=PIPE)
-    output = None
-    if not cc.returncode:
-        output = str(cc.stdout.strip(), "utf-8")
-    return output
+    return subprocess.check_output(args, stderr=PIPE, universal_newlines=True)
 
 def call_sbatch(cmd, nodelist, scripts_dir):
     sb_script = "#!/bin/bash\n"

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -10,13 +10,14 @@ import os, sys
 import getpass
 import time
 
-DAQBATCH_HUTCHES=['tmo', 'rix']
+DAQBATCH_HUTCHES = ["tmo", "rix"]
 LOCALHOST = socket.gethostname()
-SLURM_PARTITION='drpq'
-SLURM_JOBNAME='submit_daq'
-DAQBATCH_SCRIPT='submit_daq.sh'
-DAQBATCH_OUTPUT='slurm_daq.log'
-MAX_RETRIES=10
+SLURM_PARTITION = "drpq"
+SLURM_JOBNAME = "submit_daq"
+DAQBATCH_SCRIPT = "submit_daq.sh"
+DAQBATCH_OUTPUT = "slurm_daq.log"
+MAX_RETRIES = 10
+
 
 def silentremove(filename):
     try:
@@ -25,8 +26,10 @@ def silentremove(filename):
         if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
             raise
 
+
 def call_subprocess(*args):
     return subprocess.check_output(args, stderr=PIPE, universal_newlines=True)
+
 
 def call_sbatch(cmd, nodelist, scripts_dir):
     sb_script = "#!/bin/bash\n"
@@ -42,20 +45,20 @@ def call_sbatch(cmd, nodelist, scripts_dir):
     daqbatch_script = os.path.join(scripts_dir, DAQBATCH_SCRIPT)
     with open(daqbatch_script, "w") as f:
         f.write(sb_script)
-    call_subprocess('sbatch', daqbatch_script)
+    call_subprocess("sbatch", daqbatch_script)
     silentremove(daqbatch_script)
+
 
 class SbatchManager:
     def __init__(self, user):
         self.user = user
 
-
     def get_job_info(self):
         # Use squeue to get JobId, Comment, JobName, Status, and Reasons (Node List)
         format_string = '"%i %k %j %T %R"'
         lines = call_subprocess(
-                    "squeue", "-u", self.user, "-h", "-o", format_string
-                ).splitlines()
+            "squeue", "-u", self.user, "-h", "-o", format_string
+        ).splitlines()
         job_details = {}
         for i, job_info in enumerate(lines):
             cols = job_info.strip('"').split()
@@ -89,33 +92,31 @@ class SbatchManager:
 
 
 class DaqManager:
-    def __init__(self, opts):
-        self.opts = opts
-        self.verbose = False
-        for o, a in self.opts:
-            if o in ('-v', '--verbose'):
-                self.verbose = True
+    def __init__(self, verbose=False):
+        self.verbose = verbose
         self.hutch = call_subprocess("get_info", "--gethutch")
-        self.user = self.hutch+'opr'
+        self.user = self.hutch + "opr"
         self.sbman = SbatchManager(self.user)
-        self.scripts_dir = f'/reg/g/pcds/dist/pds/{self.hutch}/scripts'
+        self.scripts_dir = f"/reg/g/pcds/dist/pds/{self.hutch}/scripts"
         self.set_cnf_file_and_platform()
 
     def isdaqbatch(self, quiet=False):
         if self.hutch in DAQBATCH_HUTCHES:
-            if not quiet: print('true')
+            if not quiet:
+                print("true")
             return True
         else:
-            if not quiet: print('false')
+            if not quiet:
+                print("false")
             return False
 
     def isvaliduser(self):
-        if getpass.getuser().find('opr') > -1:
+        if getpass.getuser() == self.user:
             return True
         return False
 
     def waitfor(self, subcmd):
-        if subcmd == 'stop':
+        if subcmd == "stop":
             daq_host = self.wheredaq(quiet=True)
             if daq_host is not None:
                 if self.isdaqbatch(quiet=True):
@@ -123,52 +124,57 @@ class DaqManager:
                         daq_host = self.wheredaq(quiet=True)
                         if daq_host is None:
                             break
-                        print(f'wait for daqbatch to stop #retry: {i_retry}')
+                        print(f"wait for daqbatch to stop #retry: {i_retry}")
                         time.sleep(1)
                 else:
-                    print(f'the DAQ did not stop properly (DAQ HOST: {daq_host}), exit now and try again or call your POC or the DAQ phone')
+                    print(
+                        f"the DAQ did not stop properly (DAQ HOST: {daq_host}), exit now and try again or call your POC or the DAQ phone"
+                    )
 
     def set_cnf_file_and_platform(self):
-        self.cnf_file = f'{self.hutch}.py'
-        
-        cc = {'platform': None}
+        self.cnf_file = f"{self.hutch}.py"
+
+        cc = {"platform": None}
         configfilename = os.path.join(self.scripts_dir, self.cnf_file)
         try:
-            exec(compile(open(configfilename).read(), configfilename, 'exec'), {}, cc)
-            if type(cc['platform']) == type('') and cc['platform'].isdigit():
-                rv = int(cc['platform'])
+            exec(compile(open(configfilename).read(), configfilename, "exec"), {}, cc)
+            if type(cc["platform"]) == type("") and cc["platform"].isdigit():
+                rv = int(cc["platform"])
         except:
-            print('deduce_platform Error:', sys.exc_info()[1])
+            print("deduce_platform Error:", sys.exc_info()[1])
             raise
         self.platform = rv
 
     def wheredaq(self, quiet=False):
-        """ Locate where the daq is running.
-        
+        """Locate where the daq is running.
+
         For daqbatch, we use slurm to check if the hutch user is running control_gui.
         """
         daq_host = None
         # Use control_gui job name to locate the running host for the daq
         job_details = self.sbman.get_job_info()
-        if 'control_gui' in job_details:
-            daq_host = job_details['control_gui']['nodelist']
-        
+        if "control_gui" in job_details:
+            daq_host = job_details["control_gui"]["nodelist"]
+
         if not quiet:
-            if daq_host is None: 
-                print(f'DAQ is not running in {self.hutch}')
+            if daq_host is None:
+                print(f"DAQ is not running in {self.hutch}")
             else:
-                print(f'DAQ is running on {daq_host}')
+                print(f"DAQ is running on {daq_host}")
         return daq_host
-    
+
     def calldaq(self, subcmd, daq_host=None):
-        prog = 'daqbatch'
-        cmd = f'pushd {self.scripts_dir}'+' > /dev/null;'
-        cmd += f'source {os.path.join(self.scripts_dir, "setup_env.sh")}'+';'
-        cmd += f'WHEREPROG=$(which {prog}); set -x; $WHEREPROG {subcmd} {os.path.join(self.scripts_dir,self.cnf_file)}'+'; { set +x; } 2>/dev/null;'
-        cmd += f'popd'+' > /dev/null;'
-        
-        if subcmd == 'restart':
-            query_daq_host = self.wheredaq() 
+        prog = "daqbatch"
+        cmd = f"pushd {self.scripts_dir}" + " > /dev/null;"
+        cmd += f'source {os.path.join(self.scripts_dir, "setup_env.sh")}' + ";"
+        cmd += (
+            f"WHEREPROG=$(which {prog}); set -x; $WHEREPROG {subcmd} {os.path.join(self.scripts_dir,self.cnf_file)}"
+            + "; { set +x; } 2>/dev/null;"
+        )
+        cmd += f"popd" + " > /dev/null;"
+
+        if subcmd == "restart":
+            query_daq_host = self.wheredaq()
         else:
             query_daq_host = self.wheredaq(quiet=True)
 
@@ -182,41 +188,21 @@ class DaqManager:
             print(ret.stdout.decode())
         else:
             call_sbatch(cmd, daq_host, self.scripts_dir)
-        
+
         self.waitfor(subcmd)
 
-
     def stopdaq(self):
-        """ Stop the running daq for the current user.
+        """Stop the running daq for the current user.
         Note that daq host is determined by .running file or squeue (daqbatch).
         """
-        self.calldaq('stop')
+        self.calldaq("stop")
 
-    def startdaq(self, daq_host):
-        self.calldaq('start', daq_host=daq_host)
-
-    def restart_daqbatch(self, daq_host):
-        st = time.monotonic()
-        self.calldaq('restart', daq_host=daq_host)
-        en = time.monotonic()
-        print(f'took {en-st:.4f}s. for starting the DAQ')
-
-    def restartdaq(self):
+    def restartdaq(self, daq_host):
         if not self.isvaliduser():
-            print(f'Please run the DAQ from the operator account!')
+            print(f"Please run the DAQ from the operator account!")
             return
-	
-        daq_host = LOCALHOST
-        # User can use -m to specify the host to run the daq
-        for o, a in self.opts:
-            if o == '-m':
-                daq_host = a
-                break
-	
-        if self.isdaqbatch(quiet=True):
-            self.restart_daqbatch(daq_host)
-        else:
-            self.stopdaq()
-            self.startdaq(daq_host)
 
-        
+        st = time.monotonic()
+        self.calldaq("restart", daq_host=daq_host)
+        en = time.monotonic()
+        print(f"took {en-st:.4f}s. for starting the DAQ")

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -118,16 +118,22 @@ class ProcMgrHelper:
 class DaqManager:
     def __init__(self, opts):
         self.opts = opts
+        self.verbose = False
+        for o, a in self.opts:
+            if o in ('-v', '--verbose'):
+                self.verbose = True
         self.hutch = call_subprocess("get_info", "--gethutch")
         self.user = self.hutch+'opr'
         self.sbman = SbatchManager(self.user)
         self.scripts_dir = f'/reg/g/pcds/dist/pds/{self.hutch}/scripts'
         self.set_cnf_file_and_platform()
 
-    def isdaqbatch(self):
+    def isdaqbatch(self, quiet=False):
         if self.hutch in DAQBATCH_HUTCHES:
+            if not quiet: print('true')
             return True
         else:
+            if not quiet: print('false')
             return False
 
     def isvaliduser(self):
@@ -145,7 +151,7 @@ class DaqManager:
                 cnf_ext = '_0.cnf'
             elif LOCALHOST == 'cxi-monitor':
                 cnf_ext = '_1.cnf'
-            elif self.isdaqbatch():
+            elif self.isdaqbatch(quiet=True):
                 cnf_ext = '.py'
             else:
                 cnf_ext = '.cnf'
@@ -167,7 +173,7 @@ class DaqManager:
         For daqbatch, we use slurm to check if the hutch user is running control_gui.
         """
         daq_host = None
-        if self.isdaqbatch():
+        if self.isdaqbatch(quiet=True):
             # Use control_gui job name to locate the running host for the daq
             job_details = self.sbman.get_job_info()
             if 'control_gui' in job_details:
@@ -190,7 +196,7 @@ class DaqManager:
             print(f'DAQ is running on {daq_host}')
     
     def calldaq(self, subcmd, daq_host=None):
-        if self.isdaqbatch(): 
+        if self.isdaqbatch(quiet=True): 
             prog = 'daqbatch'
         else:
             prog = 'procmgr'
@@ -207,7 +213,7 @@ class DaqManager:
         if subcmd == 'stop':
             daq_host = self.wheredaq(quiet=True)
             if daq_host is not None:
-                if self.isdaqbatch():
+                if self.isdaqbatch(quiet=True):
                     for i_retry in range(MAX_RETRIES):
                         daq_host = self.wheredaq(quiet=True)
                         if daq_host is None:
@@ -241,17 +247,10 @@ class DaqManager:
                 daq_host = a
                 break
 	
-        if self.isdaqbatch():
+        if self.isdaqbatch(quiet=True):
             self.restart_daqbatch(daq_host)
         else:
             self.stopdaq()
             self.startdaq(daq_host)
-
-
-
-
-
-
-
 
         

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -28,6 +28,9 @@ def silentremove(filename):
 
 
 def call_subprocess(*args):
+    # FIXME: potentialy wanted to replace with 
+    # return subprocess.check_output(args, stderr=PIPE, universal_newlines=True)
+    # current block: return values are not in expected format. 
     cc = subprocess.run(args, stdout=PIPE, stderr=PIPE)
     output = None
     if not cc.returncode:

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -143,11 +143,10 @@ class DaqManager:
         try:
             exec(compile(open(configfilename).read(), configfilename, "exec"), {}, cc)
             if type(cc["platform"]) == type("") and cc["platform"].isdigit():
-                rv = int(cc["platform"])
-        except:
+                self.platform = int(cc["platform"])
+        except Exception:
             print("deduce_platform Error:", sys.exc_info()[1])
             raise
-        self.platform = rv
 
     def wheredaq(self, quiet=False):
         """Locate where the daq is running.

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -28,7 +28,11 @@ def silentremove(filename):
 
 
 def call_subprocess(*args):
-    return subprocess.check_output(args, stderr=PIPE, universal_newlines=True)
+    cc = subprocess.run(args, stdout=PIPE, stderr=PIPE)
+    output = None
+    if not cc.returncode:
+        output = str(cc.stdout.strip(), "utf-8")
+    return output
 
 
 def call_sbatch(cmd, nodelist, scripts_dir):

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -3,12 +3,13 @@
 #
 # Do not use non-standard python.
 ####################################################
-import subprocess
-from subprocess import PIPE
-import socket
-import os, sys
+import errno
 import getpass
+import os
+import socket
+import subprocess
 import time
+from subprocess import PIPE
 
 DAQMGR_HUTCHES = ["tmo", "rix"]
 LOCALHOST = socket.gethostname()
@@ -37,9 +38,9 @@ def call_sbatch(cmd, nodelist, scripts_dir):
     sb_script += f"#SBATCH --job-name={SLURM_JOBNAME}" + "\n"
     sb_script += f"#SBATCH --nodelist={nodelist}" + "\n"
     sb_script += f"#SBATCH --output={os.path.join(scripts_dir, SLURM_OUTPUT)}" + "\n"
-    sb_script += f"#SBATCH --ntasks=1" + "\n"
-    sb_script += f"unset PYTHONPATH" + "\n"
-    sb_script += f"unset LD_LIBRARY_PATH" + "\n"
+    sb_script += "#SBATCH --ntasks=1\n"
+    sb_script += "unset PYTHONPATH\n"
+    sb_script += "unset LD_LIBRARY_PATH\n"
     sb_script += cmd
     slurm_script = os.path.join(scripts_dir, SLURM_SCRIPT)
     with open(slurm_script, "w") as f:
@@ -154,7 +155,7 @@ class DaqManager:
             f"WHEREPROG=$(which {prog}); set -x; $WHEREPROG {subcmd} {os.path.join(self.scripts_dir,self.cnf_file)}"
             + "; { set +x; } 2>/dev/null;"
         )
-        cmd += f"popd" + " > /dev/null;"
+        cmd += "popd > /dev/null;"
 
         if subcmd == "restart":
             query_daq_host = self.wheredaq()
@@ -182,7 +183,7 @@ class DaqManager:
 
     def restartdaq(self, daq_host):
         if not self.isvaliduser():
-            print(f"Please run the DAQ from the operator account!")
+            print("Please run the DAQ from the operator account!")
             return
 
         st = time.monotonic()

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -1,0 +1,240 @@
+####################################################
+# Utilities to run the daq and view its status.
+#
+# Do not use non-standard python.
+####################################################
+import subprocess
+from subprocess import PIPE
+import socket
+import os, sys
+import getpass
+
+
+DAQBATCH_HUTCHES=['tmo', 'rix']
+LOCALHOST = socket.gethostname()
+SLURM_PARTITION='drpq'
+SLURM_JOBNAME='submit_daq'
+DAQBATCH_SCRIPT='submit_daq.sh'
+DAQBATCH_OUTPUT='slurm_daq.log'
+
+def silentremove(filename):
+    try:
+        os.remove(filename)
+    except OSError as e:
+        if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
+            raise
+
+def call_subprocess(*args):
+    cc = subprocess.run(args, stdout=PIPE, stderr=PIPE)
+    output = None
+    if not cc.returncode:
+        output = str(cc.stdout.strip(), "utf-8")
+    return output
+
+def call_sbatch(cmd, nodelist, scripts_dir):
+    sb_script = "#!/bin/bash\n"
+    sb_script += f"#SBATCH --partition={SLURM_PARTITION}" + "\n"
+    sb_script += f"#SBATCH --job-name={SLURM_JOBNAME}" + "\n"
+    sb_script += f"#SBATCH --nodelist={nodelist}" + "\n"
+    daqbatch_output = os.path.join(scripts_dir, DAQBATCH_OUTPUT)
+    sb_script += f"#SBATCH --output={daqbatch_output}" + "\n"
+    sb_script += f"#SBATCH --ntasks=1" + "\n"
+    sb_script += f"unset PYTHONPATH" + "\n"
+    sb_script += f"unset LD_LIBRARY_PATH" + "\n"
+    sb_script += cmd
+    daqbatch_script = os.path.join(scripts_dir, DAQBATCH_SCRIPT)
+    with open(daqbatch_script, "w") as f:
+        f.write(sb_script)
+    #call_subprocess('sbatch', daqbatch_script)
+    #silentremove(daqbatch_script)
+
+class SbatchManager:
+    def __init__(self, user):
+        self.user = user
+
+
+    def get_job_info(self):
+        # Use squeue to get JobId, Comment, JobName, Status, and Reasons (Node List)
+        format_string = '"%i %k %j %T %R"'
+        lines = call_subprocess(
+                    "squeue", "-u", self.user, "-h", "-o", format_string
+                ).splitlines()
+        job_details = {}
+        for i, job_info in enumerate(lines):
+            cols = job_info.strip('"').split()
+            success = True
+            if len(cols) == 5:
+                job_id, comment, job_name, state, nodelist = cols
+            elif len(cols) > 5:
+                job_id, comment, job_name, state = cols[:4]
+                nodelist = " ".join(cols[5:])
+            else:
+                success = False
+            if success:
+                # Get logfile from job_id
+                scontrol_lines = call_subprocess(
+                    "scontrol", "show", "job", job_id
+                ).splitlines()
+                logfile = ""
+                for scontrol_line in scontrol_lines:
+                    if scontrol_line.find("StdOut") > -1:
+                        scontrol_cols = scontrol_line.split("=")
+                        logfile = scontrol_cols[1]
+
+                job_details[comment] = {
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "state": state,
+                    "nodelist": nodelist,
+                    "logfile": logfile,
+                }
+        return job_details
+
+
+class ProcMgrHelper:
+    def __init__(self, platform, cnf_file):
+        self.platform = platform
+        self.cnf_file = cnf_file
+        self.parse_cnf()
+
+    def parse_cnf(self):
+        self.config = {'platform': repr(self.platform), 'procmgr_config': None, 'TESTRELDIR': None,
+                  'CONFIGDIR': os.path.dirname(os.path.abspath(self.cnf_file)),
+                  'id': 'id', 'cmd': 'cmd', 'flags': 'flags', 'port': 'port', 'host': 'host',
+                  '__file__': self.cnf_file,
+                  'rtprio': 'rtprio', 'env': 'env', 'evr': 'evr', 'conda': 'conda', 'procmgr_macro': {}}
+        try:
+            exec(compile(open(self.cnf_file).read(), self.cnf_file, 'exec'), {}, self.config)
+        except:
+            pass
+            #print('Error parsing configuration file:', sys.exc_info()[1]) 
+
+    def get_value(self, parm):
+        if parm in self.config:
+            return self.config[parm]
+
+
+class DaqManager:
+    def __init__(self, opts):
+        self.opts = opts
+        self.hutch = call_subprocess("get_info", "--gethutch")
+        self.user = self.hutch+'opr'
+        self.sbman = SbatchManager(self.user)
+        self.scripts_dir = f'/reg/g/pcds/dist/pds/{self.hutch}/scripts'
+        self.set_cnf_file_and_platform()
+
+    def isdaqbatch(self):
+        if self.hutch in DAQBATCH_HUTCHES:
+            return True
+        else:
+            return False
+
+    def isvaliduser(self):
+        if getpass.getuser().find('opr') > -1:
+            return True
+        return False
+
+    def set_cnf_file_and_platform(self):
+        self.cnf_file = None
+        for o, a in self.opts:
+            if o in ('-d', '--dss'):
+                self.cnf_file = os.path.join(self.scripts_dir, 'dss.cnf')
+        if self.cnf_file is None:
+            if LOCALHOST == 'cxi-daq':
+                cnf_ext = '_0.cnf'
+            elif LOCALHOST == 'cxi-monitor':
+                cnf_ext = '_1.cnf'
+            elif self.isdaqbatch():
+                cnf_ext = '.py'
+            else:
+                cnf_ext = '.cnf'
+            self.cnf_file = f'{self.hutch}{cnf_ext}'
+        
+        # TODO: Read platform from the configuration file
+        # Current block is for daqbatch, we use psana2 slurm.Config class.
+        # This is current not working in the environment without psana2.
+        self.platform = 0
+        if LOCALHOST == 'cxi-monitor':
+            self.platform = 1
+        elif self.hutch == 'rix':
+            self.platform = 2
+
+    def wheredaq(self, quiet=False):
+        """ Locate where the daq is running.
+        
+        For procmgr, we check the running cnf for active daq.
+        For daqbatch, we use slurm to check if the hutch user is running control_gui.
+        """
+        daq_host = None
+        if self.isdaqbatch():
+            # Use control_gui job name to locate the running host for the daq
+            job_details = self.sbman.get_job_info()
+            if 'control_gui' in job_details:
+                daq_host = job_details['nodelist']
+        else:
+            # For other hutches, we get daq host from the running cnf file. 
+            cnf_file = os.path.join(self.scripts_dir, f'p{self.platform}.cnf.running')
+            if os.path.exists(cnf_file):
+                procmgr_helper = ProcMgrHelper(self.platform, cnf_file)
+                daq_host = procmgr_helper.get_value('procmgr_macro')['HOST']
+        
+        if quiet: return daq_host
+        if daq_host is None:
+            if LOCALHOST == 'cxi-daq':
+                print(f'Main DAQ cxi_0 is not running on {LOCALHOST}')
+            elif LOCALHOST == 'cxi-monitor':
+                print(f'Secondary DAQ cxi_1 is not running on {LOCALHOST}')
+            print(f'DAQ is not running in {self.hutch}')
+        else:
+            print(f'DAQ is running on {daq_host}')
+    
+    def calldaq(self, subcmd, daq_host=None):
+        if self.isdaqbatch(): 
+            prog = 'daqbatch'
+        else:
+            prog = 'procmgr'
+        cmd = f'pushd {self.scripts_dir}'+'\n'
+        cmd += f'source {os.path.join(self.scripts_dir, "setup_env.sh")}'+'\n'
+        cmd += f'{prog} {subcmd} {self.cnf_file}'+'\n'
+        cmd += f'popd'+'\n'
+        if daq_host is None:
+            daq_host = self.wheredaq(quiet=True)
+            if daq_host is None:
+                daq_host = LOCALHOST
+        call_sbatch(cmd, daq_host, self.scripts_dir)
+
+        if subcmd == 'stop':
+            if self.wheredaq(quiet=True) is not None:
+                print('the DAQ did not stop properly, exit now and try again or call your POC or the DAQ phone')
+
+    def stopdaq(self):
+        """ Stop the running daq for the current user.
+        Note that daq host is determined by .running file or squeue (daqbatch).
+        """
+        self.calldaq('stop')
+
+    def startdaq(self, daq_host):
+        self.calldaq('start', daq_host=daq_host)
+
+    def restartdaq(self):
+        if not self.isvaliduser():
+            print(f'Please run the DAQ from the operator account!')
+            return
+        self.stopdaq()
+        
+        daq_host = LOCALHOST
+        # User can use -m to specify the host to run the daq
+        for o, a in self.opts:
+            if o == '-m':
+                daq_host = a
+                break
+        self.startdaq(daq_host)
+
+
+
+
+
+
+
+
+        

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -28,14 +28,7 @@ def silentremove(filename):
 
 
 def call_subprocess(*args):
-    # FIXME: potentialy wanted to replace with
-    # return subprocess.check_output(args, stderr=PIPE, universal_newlines=True)
-    # current block: return values are not in expected format.
-    cc = subprocess.run(args, stdout=PIPE, stderr=PIPE)
-    output = None
-    if not cc.returncode:
-        output = str(cc.stdout.strip(), "utf-8")
-    return output
+    return str(subprocess.check_output(args, stderr=PIPE), "utf-8")
 
 
 def call_sbatch(cmd, nodelist, scripts_dir):

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -118,9 +118,7 @@ class DaqManager:
             return False
 
     def isvaliduser(self):
-        if getpass.getuser() == self.user:
-            return True
-        return False
+        return getpass.getuser() == self.user
 
     def waitfor(self, subcmd):
         if subcmd == "stop":

--- a/scripts/daqutils
+++ b/scripts/daqutils
@@ -1,2 +1,19 @@
 #!/bin/bash
+
+
+# Silent pushd and popd
+pushd () {
+    command pushd "$@" > /dev/null
+}
+
+popd () {
+    command popd "$@" > /dev/null
+}
+
+
+# Go to source directory to make python import works
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR
 python3 run_daq_utils.py $@
+popd
+

--- a/scripts/daqutils
+++ b/scripts/daqutils
@@ -1,19 +1,8 @@
 #!/bin/bash
 
 
-# Silent pushd and popd
-pushd () {
-    command pushd "$@" > /dev/null
-}
-
-popd () {
-    command popd "$@" > /dev/null
-}
-
-
 # Go to source directory to make python import works
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd $SCRIPT_DIR
+cd $SCRIPT_DIR
 python3 run_daq_utils.py $@
-popd
 

--- a/scripts/daqutils
+++ b/scripts/daqutils
@@ -3,6 +3,5 @@
 
 # Go to source directory to make python import works
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd $SCRIPT_DIR
-python3 run_daq_utils.py $@
-
+cd "$SCRIPT_DIR" || exit
+python3 run_daq_utils.py "$@"

--- a/scripts/daqutils
+++ b/scripts/daqutils
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 run_daq_utils.py $@

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# Check if the current's user hutch uses daqbatch. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqbatch)" = "true" ]; then
+    daqutils $(basename "$0") $@
+    exit 0
+fi
+
 usage()
 {
 cat << EOF

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Check if the current's user hutch uses daqbatch. If so,
+# Check if the current's user hutch uses daqmgr. If so,
 # use the python utilities to manage the daq.
-if [ "$(daqutils isdaqbatch)" = "true" ]; then
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
     daqutils $(basename "$0") $@
     exit 0
 fi

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -1,27 +1,58 @@
-import os,sys,time
-from daq_utils import DaqManager
-import getopt
+#!/usr/bin/env python3
+"""
+Enforce more checks and controls for running daqbatch.
+"""
 
-help_messages = {
-        'wheredaq': 'Discover what host is running the daq in the current hutch, if any.',
-        'stopdaq': 'Stop the daq in the current hutch.',
-        'restartdaq': 'Verify requirements for running the daq then stop and start it.',
-        'isdaqbatch': "Determine if the current user's hutch uses daqbatch",
-        }
+from daq_utils import DaqManager, LOCALHOST
+import argparse
+
+
+def restartdaq(daqmgr, args):
+    daqmgr.restartdaq(args.aimhost)
+
+
+def wheredaq(daqmgr, args):
+    daqmgr.wheredaq()
+
+
+def stopdaq(daqmgr, args):
+    daqmgr.stopdaq()
+
+
+def isdaqbatch(daqmgr, args):
+    daqmgr.isdaqbatch()
+
 
 if __name__ == "__main__":
-    commands = ['wheredaq', 'stopdaq', 'restartdaq', 'isdaqbatch']
-    opts, args = getopt.getopt(sys.argv[2:], 'hm:dv', ["help","dss"])
-    cmd = sys.argv[1]
-    if cmd not in commands:
-        print(f'Unsupported command {cmd}')
-        raise
-    for o, a in opts:
-        if o in ("-h", "--help"):
-            print(help_messages[cmd])
-            exit()
+    parser = argparse.ArgumentParser(prog="run_daq_utils", description=__doc__)
 
-    daqman = DaqManager(opts)
-    func = getattr(daqman, cmd)
-    result = func()
+    parser.add_argument("-v", "--verbose", action="store_false")
 
+    subparsers = parser.add_subparsers()
+    psr_restart = subparsers.add_parser(
+        "restartdaq",
+        help="Verify requirements for running the daq then stop and start it.",
+    )
+    psr_restart.add_argument("-m", "--aimhost", action="store_const", const=LOCALHOST)
+    psr_restart.set_defaults(func=restartdaq)
+
+    psr_where = subparsers.add_parser(
+        "wheredaq",
+        help="Discover what host is running the daq in the current hutch, if any.",
+    )
+    psr_where.set_defaults(func=wheredaq)
+
+    psr_stop = subparsers.add_parser(
+        "stopdaq", help="Stop the daq in the current hutch."
+    )
+    psr_stop.set_defaults(func=stopdaq)
+
+    psr_isdaqbatch = subparsers.add_parser(
+        "isdaqbatch", help="Determine if the current hutch uses daqbatch"
+    )
+    psr_isdaqbatch.set_defaults(func=isdaqbatch)
+
+    args = parser.parse_args()
+
+    daqmgr = DaqManager(args.verbose)
+    args.func(daqmgr, args)

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -11,7 +11,7 @@ help_messages = {
 
 if __name__ == "__main__":
     commands = ['wheredaq', 'stopdaq', 'restartdaq', 'isdaqbatch']
-    opts, args = getopt.getopt(sys.argv[2:], 'hm:pwscdv', ["help","dss"])
+    opts, args = getopt.getopt(sys.argv[2:], 'hm:dv', ["help","dss"])
     cmd = sys.argv[1]
     if cmd not in commands:
         print(f'Unsupported command {cmd}')

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -11,7 +11,7 @@ help_messages = {
 
 if __name__ == "__main__":
     commands = ['wheredaq', 'stopdaq', 'restartdaq', 'isdaqbatch']
-    opts, args = getopt.getopt(sys.argv[2:], 'hm:pwscd', ["help","dss"])
+    opts, args = getopt.getopt(sys.argv[2:], 'hm:pwscdv', ["help","dss"])
     cmd = sys.argv[1]
     if cmd not in commands:
         print(f'Unsupported command {cmd}')

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -3,8 +3,9 @@
 Enforce more checks and controls for running the DAQ.
 """
 
-from daq_utils import DaqManager, LOCALHOST
 import argparse
+
+from daq_utils import LOCALHOST, DaqManager
 
 
 def restartdaq(daqmgr, args):

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -6,10 +6,11 @@ help_messages = {
         'wheredaq': 'Discover what host is running the daq in the current hutch, if any.',
         'stopdaq': 'Stop the daq in the current hutch.',
         'restartdaq': 'Verify requirements for running the daq then stop and start it.',
+        'isdaqbatch': "Determine if the current user's hutch uses daqbatch",
         }
 
 if __name__ == "__main__":
-    commands = ['wheredaq', 'stopdaq', 'restartdaq']
+    commands = ['wheredaq', 'stopdaq', 'restartdaq', 'isdaqbatch']
     opts, args = getopt.getopt(sys.argv[2:], 'hm:pwscd', ["help","dss"])
     cmd = sys.argv[1]
     if cmd not in commands:

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Enforce more checks and controls for running daqbatch.
+Enforce more checks and controls for running the DAQ.
 """
 
 from daq_utils import DaqManager, LOCALHOST
@@ -19,8 +19,8 @@ def stopdaq(daqmgr, args):
     daqmgr.stopdaq()
 
 
-def isdaqbatch(daqmgr, args):
-    daqmgr.isdaqbatch()
+def isdaqmgr(daqmgr, args):
+    daqmgr.isdaqmgr()
 
 
 if __name__ == "__main__":
@@ -47,10 +47,10 @@ if __name__ == "__main__":
     )
     psr_stop.set_defaults(func=stopdaq)
 
-    psr_isdaqbatch = subparsers.add_parser(
-        "isdaqbatch", help="Determine if the current hutch uses daqbatch"
+    psr_isdaqmgr = subparsers.add_parser(
+        "isdaqmgr", help="Determine if the current hutch uses daqmgr"
     )
-    psr_isdaqbatch.set_defaults(func=isdaqbatch)
+    psr_isdaqmgr.set_defaults(func=isdaqmgr)
 
     args = parser.parse_args()
 

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -1,0 +1,26 @@
+import os,sys,time
+from daq_utils import DaqManager
+import getopt
+
+help_messages = {
+        'wheredaq': 'Discover what host is running the daq in the current hutch, if any.',
+        'stopdaq': 'Stop the daq in the current hutch.',
+        'restartdaq': 'Verify requirements for running the daq then stop and start it.',
+        }
+
+if __name__ == "__main__":
+    commands = ['wheredaq', 'stopdaq', 'restartdaq']
+    opts, args = getopt.getopt(sys.argv[2:], 'hm:pwscd', ["help","dss"])
+    cmd = sys.argv[1]
+    if cmd not in commands:
+        print(f'Unsupported command {cmd}')
+        raise
+    for o, a in opts:
+        if o in ("-h", "--help"):
+            print(help_messages[cmd])
+            exit()
+
+    daqman = DaqManager(opts)
+    func = getattr(daqman, cmd)
+    result = func()
+

--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# Check if the current's user hutch uses daqbatch. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqbatch)" = "true" ]; then
+    daqutils $(basename "$0") $@
+    exit 0
+fi
+
 usage()
 {
 cat << EOF

--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Check if the current's user hutch uses daqbatch. If so,
+# Check if the current's user hutch uses daqmgr. If so,
 # use the python utilities to manage the daq.
-if [ "$(daqutils isdaqbatch)" = "true" ]; then
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
     daqutils $(basename "$0") $@
     exit 0
 fi

--- a/scripts/testdaqutils
+++ b/scripts/testdaqutils
@@ -1,2 +1,0 @@
-#!/bin/bash
-python3 run_daq_utils.py ${1} $@

--- a/scripts/testdaqutils
+++ b/scripts/testdaqutils
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 run_daq_utils.py wheredaq $@
+python3 run_daq_utils.py ${1} $@

--- a/scripts/testdaqutils
+++ b/scripts/testdaqutils
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 run_daq_utils.py wheredaq $@

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# Check if the current's user hutch uses daqbatch. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqbatch)" = "true" ]; then
+    daqutils $(basename "$0") $@
+    exit 0
+fi
+
 usage()
 {
 cat << EOF

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Check if the current's user hutch uses daqbatch. If so,
+# Check if the current's user hutch uses daqmgr. If so,
 # use the python utilities to manage the daq.
-if [ "$(daqutils isdaqbatch)" = "true" ]; then
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
     daqutils $(basename "$0") $@
     exit 0
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Procmgr is being replaced with slurm for some of the hutches. Daqmgr is the new utility for controlling DAQ slurm jobs. The changes here aim at overriding daq related commands such as restartdaq, stopdaq, etc for daqmgr hutches. These commands uses standard python that does not require sourcing prior to calling them. 
- The top part of daq-related scripts checks if the current hutch is daqmgr hutch and overrides the commands with the python modules added here. All the non daqmgr hutches continue to use existing shell scripts.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
All slurm jobs launched by daqmgr are stored in slurm database. Daqutils added here is written in python to ease the job of reading of and parsing slurm job statuses. Some of these utilities are slimmed down version of what already exist in daqmgr making it easier to future maintenance work.
<!--- If it fixes an open issue, please link to the issue here. -->
Replace procmgr with slurm.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The three commands (restartdaq, stopdaq, and wheredaq) have been tested at tmo and rix.
<!--- Include details of your testing environment, and the tests you ran to -->
Similar to the existing requirement, **/engineering_tools/scripts must be part of $PATH for -opr user accounts.
<!--- see how your change affects other areas of the code, etc. -->
The changes are minimal. None of the preexisting code have been modified apart from the top part of the scripts, which allow overriding daq-related commands. 
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
