### PR TITLE
add alvium, reservation option &  some checks for permissions

### DIFF
--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -174,15 +174,6 @@ EXP=${EXP:='xxx'}
 QUEUE=${QUEUE:='xxx'}
 INTERACTIVE=${INTERACTIVE:=0}
 
-# also put 'xxx' (default q name) as S3DF so that even if no queue is given,
-# it goes to S3DF
-SDFQUEUES=('milano' 'roma' 'xxx')
-for SDFQUEUE in ${SDFQUEUES[@]}; do
-    if [[ $QUEUE == $SDFQUEUE ]]; then 
-	S3DF=1
-    fi
-done
-
 if [[ $RUN == 0 ]]; then
     if [[ $INTERACTIVE == 0 ]]; then
         printf "Please enter a run number: \n"; read RUN
@@ -191,8 +182,8 @@ if [[ $RUN == 0 ]]; then
 fi
 
 if [[ $EXP == 'xxx' ]]; then
-    HUTCH=`get_info --gethutch`
-    EXP=`get_info --exp --hutch $HUTCH`
+    HUTCH=$(get_info --gethutch)
+    EXP=$(get_info --exp --hutch $HUTCH)
     set -- "$@" '--experiment ' $EXP
 else
     HUTCH=${EXP:0:3}
@@ -212,8 +203,8 @@ else
     else
         DIR=`echo $DIR | sed 's/\/cds\/group\/pcds/\/sdf\/group\/lcls\/ds\/tools/g' | sed 's/\/reg\/g\/pcds/\/sdf\/group\/lcls\/ds\/tools/g'`
     fi
-    echo ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
-    ssh -Y $USER@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
+    echo ssh -Y "$USER"@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
+    ssh -Y "$USER"@s3dflogin ssh -Y psana "$DIR/makepeds_psana $@"
 fi
 
 if [[ $HOSTNAME =~ "sdf" ]]; then
@@ -222,11 +213,11 @@ else
     source pcds_conda
 fi
 
-elog_par_post --file pedestal -e "$EXP" -r $RUN
+elog_par_post --file pedestal -e "$EXP" -r "$RUN"
 
 #if this is a default pedestal run, then do not post as this is handled in takepeds
 if [[ $elogMessage == 'DARK' ]] && [[ $ELOGTXT == '' ]] ; then
-    echo ---- Done processing pedestals for Run $RUN -----
+    echo ---- Done processing pedestals for Run "$RUN" -----
     exit 0
 fi
 
@@ -237,21 +228,21 @@ fi
 
 PYCMD=LogBookPost.py
 echo -- Now posting special message to elog --
-echo -- $elogMessage --
+echo -- "$elogMessage" --
 
 elogMessage+=$ELOGTEXT
-if [[ `whoami` =~ "opr" ]]; then
-    echo $BINPATH $PYCMD -i "${HUTCH^^}" -u `whoami` -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"
+if [[ $(whoami) =~ "opr" ]]; then
+    echo "$BINPATH" $PYCMD -i "${HUTCH^^}" -u $(whoami) -e "$EXP"  -t DARK  -r "$RUN" -m "$elogMessage"
     if [[ $HOSTNAME == 'cxi-monitor' ]]; then
-        $BINPATH $PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage" -s 1&
+        $BINPATH $PYCMD -i "${HUTCH^^}" -u $(whoami) -p pcds -e "$EXP"  -t DARK  -r "$RUN" -m "$elogMessage" -s 1&
     else
-        $BINPATH $PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"&
+        $BINPATH $PYCMD -i "${HUTCH^^}" -u $(whoami) -p pcds -e "$EXP"  -t DARK  -r "$RUN" -m "$elogMessage"&
     fi
 else
-    echo $BINPATH $PYCMD -i "${HUTCH^^}" -e "$EXP"  -t DARK -r $RUN -m "$elogMessage"
+    echo $BINPATH $PYCMD -i "${HUTCH^^}" -e "$EXP"  -t DARK -r "$RUN" -m "$elogMessage"
     if [[ $HOSTNAME == 'cxi-monitor' ]]; then
-        $BINPATH $PYCMD -i "${HUTCH^^}" -e "$EXP" -t DARK -r $RUN -m "$elogMessage" -s 1&
+        $BINPATH $PYCMD -i "${HUTCH^^}" -e "$EXP" -t DARK -r "$RUN" -m "$elogMessage" -s 1&
     else
-        $BINPATH $PYCMD -i "${HUTCH^^}" -e "$EXP" -t DARK -r $RUN -m "$elogMessage"&
+        $BINPATH $PYCMD -i "${HUTCH^^}" -e "$EXP" -t DARK -r "$RUN" -m "$elogMessage"&
     fi
 fi

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -21,6 +21,10 @@ OPTIONS:
                runnumber for pedestal
         -e|--experiment <expname> 
                in case you do not want pedestals for the ongoing experiment
+        -q|--queue <queue>
+               queue for batch submisson
+        -A|--alvium         
+               make pedestals for Alvium (default only cspad/EPIX detectors)
         -O|--opal         
                make pedestals for Opals (default only cspad/EPIX detectors)
         -Z|--zyla         
@@ -31,8 +35,8 @@ OPTIONS:
                make pedestals for Uxi/Icarus detector
         -j|--jungfrau3     
                make pedestals for Jungfrau - 3 run version(default only cspad/EPIX detectors)
-        -q|--queue <queue>
-               queue for batch submisson
+        -r|--reservation <reservation>
+               reservation for batch submisson
         -D|--xtcav_dark
                 dark run for XTCAV
         -L|--xtcav_lasingoff
@@ -103,6 +107,11 @@ do
             elogMessage="DARK for Zyla"
             shift
             ;;
+        -A|--alvium)
+            POSITIONAL+=("$1")
+            elogMessage="DARK for Alvium"
+            shift
+            ;;
         -O|--opal)
             POSITIONAL+=("$1")
             elogMessage="DARK for opal"
@@ -138,6 +147,11 @@ do
         -q|--queue)
             QUEUE="$2"
             POSITIONAL+=("--queue $2")
+            shift
+            shift
+            ;;
+        -r|--reservation)
+            POSITIONAL+=("--reservation $2")
             shift
             shift
             ;;

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -17,6 +17,8 @@ OPTIONS:
                runnumber for pedestal
         -e|--experiment <expname> 
                in case you do not want pedestals for the ongoing experiment
+        -q|--queue <queue>
+               queue for batch submisson
         -O|--opal         
                make pedestals for Opals (default only cspad/EPIX detectors)
         -Z|--zyla         
@@ -27,8 +29,10 @@ OPTIONS:
                make pedestals for Uxi detectors
         -j|--jungfrau3     
                make pedestals for Jungfrau - 3 run version(default only cspad/EPIX detectors)
-        -q|--queue <queue>
-               queue for batch submisson
+        -A|--alvium         
+               make pedestals for Alvium (default only cspad/EPIX detectors)
+        -r|--reservation <reservation>
+               reservation for batch submisson
         -D|--xtcav_dark
                 dark run for XTCAV
         -L|--xtcav_lasingoff
@@ -122,7 +126,7 @@ xtcav_dark()
        printf '#!/bin/bash\nsource $SIT_ENV_DIR/manage/bin/psconda.sh\n' > "$tmpScript"
        CMD="xtcavDark $EXP $RUN"
        printf '%s\n' "${CMD}" >> "$tmpScript"
-       xtcavCmd="sbatch --exclusive  --account lcls:$EXP -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
+       xtcavCmd="sbatch --account lcls:$EXP -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
        echo "run in queue: $xtcavCmd"
        SUBMISSION=$($xtcavCmd)
        check_for_submit_error
@@ -157,7 +161,7 @@ xtcav_lasOff()
        printf '#!/bin/bash\nsource $SIT_ENV_DIR/manage/bin/psconda.sh\n' > "$tmpScript"
        CMD="xtcavLasingOff $EXP $RUN"
        printf '%s\n' "${CMD}" >> "$tmpScript"
-       xtcavCmd="sbatch --exclusive  --account lcls:$EXP -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
+       xtcavCmd="sbatch --account lcls:$EXP -p $QUEUE -o $WORKDIR/xtcav_${EXP}_Run${RUN}_%J.out $tmpScript"
        echo "run in queue: $xtcavCmd"
        SUBMISSION=$($xtcavCmd)
        check_for_submit_error
@@ -266,6 +270,10 @@ do
             XTCAV=2
             shift
             ;;
+        -A|--alvium)
+            WANT_ALVIUM=1
+            shift
+            ;;
         -Z|--zyla)
             WANT_ZYLA=1
             shift
@@ -309,6 +317,11 @@ do
             ;;
         -q|--queue)
             QUEUE=("$2")
+            shift
+            shift
+            ;;
+        -r|--reservation)
+            RESERVATION=("$2")
             shift
             shift
             ;;
@@ -374,13 +387,11 @@ echo "XXXXXXXXXXXXXXXXX START MAKEPEDS at $(date +'%T') on $HOSTNAME XXXXXXXXXXX
 
 RUN=${RUN:=0}
 EXP=${EXP:='xxx'}
-QUEUE=${QUEUE:='xxx'}
 NUMEVT=${NUMEVT:=1000}
 XTCAV=${XTCAV:=0}
 INTERACTIVE=${INTERACTIVE:=0}
 CALIBCODE=${CALIBCODE:=0}
 VALSTR=${VALSTR:='xxx'}
-CALIBDIR=${CALIBDIR:='xxx'}
 DEPLOY=${DEPLOY:=1}
 MYNOISESIGMIN=${MYNOISESIGMIN:=-1}
 MYNOISESIGMAX=${MYNOISESIGMAX:=-1}
@@ -388,7 +399,6 @@ MYADUMIN=${MYADUMIN:=-1}
 MYADUMAX=${MYADUMAX:=-1}
 NUMBUNCH=${NUMBUNCH:=1}
 #one setting to run each process on an own server (currently faster) or not (if we had to use reservations)
-EXCLUSIVE=0
 
 if [ $RUN == 0 ]; then
     if [ $INTERACTIVE -ne 1 ]; then
@@ -431,7 +441,22 @@ fi
 source $SIT_ENV_DIR/manage/bin/psconda.sh
 
 #if you don't pass the queue, it'll run interactively 
-if [[ $QUEUE == 'xxx' ]]; then
+if [ -v QUEUE ]; then
+    USER=`whoami`
+    SBATCH_ARGS="-p $QUEUE --account lcls:$EXP"
+    if sacctmgr show asso account=lcls:${EXP} partition=${QUEUE} -n | grep -q ${USER} ; then
+	if [ -v RESERVATION ]; then
+	    if scontrol show rese -o $RESERVATION | grep -q $EXP; then
+		SBATCH_ARGS="$SBATCH_ARGS --reservation $RESERVATION"
+	    else
+		echo 'Experiment ${EXP} is not not in the reservation ${RESERVATION}, will submit without'
+	    fi
+	fi
+    else
+	echo '`whoami` is not part of account lcls:${EXP}, run interactively'
+	RUNLOCAL=1
+    fi
+else
     RUNLOCAL=1
 fi
 
@@ -455,11 +480,10 @@ fi
 
 echo "Use XTC files from  $XTCDIR."
 
-
 ###########
 # deduce calibdir.
 ###########
-if [ $CALIBDIR != 'xxx' ]; then
+if [ -v CALIBDIR ]; then
     ARG=$ARG' -c '$CALIBDIR
     JFARG=' -C '$CALIBDIR
 else
@@ -538,9 +562,31 @@ fi
 CREATE_TIME=$(date '+%m_%d_%Y_%H:%M:%S')
 printf -v RUNSTR "%04g" "$RUN"
 
+echo Check for data files:
+
+MINWAIT=0
+HAVEFILES=0
+while [[ $MINWAIT < 5 ]]; do
+    NFILES=`ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc* | wc -l`
+    echo $NFILES
+    if [ $NFILES -eq 0 ]; then
+	echo 'Files are not present yet, wait a minute'
+	sleep 60
+	MINWAIT=$((MINWAIT+1))
+    else 
+	HAVEFILES=1
+	MINWAIT=6
+    fi
+done
+if [[ $HAVEFILES == 0 ]]; then
+   echo 'After 5 minutes, files were not present: quit! '
+   exit
+fi
+	
+ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc*
+
 echo Check detectors: 
 
-ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc*
 if [[ $LCLS2 -gt 0 ]]; then
     detnames -r exp="${EXP}",run="${RUN}",dir="${XTCDIR}" > /tmp/detnames_"$EXP"_"$CREATE_TIME"
 else
@@ -604,11 +650,8 @@ if [[ $LCLS2 -gt 0 ]]; then
                         printf '#!/bin/bash\n' > "$tmpScript"
                         printf 'source %s/manage/bin/psconda.sh\n' "${SIT_ENV_DIR}" >> "$tmpScript"
                         printf '%s\n' "${CMD}" >> "$tmpScript"
-                        if [[ $EXCLUSIVE == 1 ]]; then
-                            ep10kaCmd="sbatch --exclusive  --account lcls:$EXP -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
-                        else
-                            ep10kaCmd="sbatch --mem 8GB --cpus-per-task 5  --account lcls:$EXP -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
-                        fi
+                        ep10kaCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 5 -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
+
                         echo "run in queue: $ep10kaCmd"
                         SUBMISSION=$($ep10kaCmd)
                         check_for_submit_error
@@ -696,7 +739,7 @@ fi
 ###
 #check if jungfrau detectors are present
 HAVE_JUNGFRAU=$(grep -c Jungfrau /tmp/detnames_"$EXP"_"$CREATE_TIME")
-if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 )  && ( $WANT_UXI -eq 0 ) ]]; then
+if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 )  && ( $WANT_UXI -eq 0 ) && ( $WANT_ALVIUM -eq 0 ) ]]; then
     
     DETNAMES=$(grep Jungfrau /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
 
@@ -751,11 +794,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
                 printf 'source %s/manage/bin/psconda.sh\n' "${SIT_ENV_DIR}" >> "$tmpScript"
                 printf 'echo $HOSTNAME\n' >> "$tmpScript"
                 printf '%s\n' "${CMDC}" >> "$tmpScript"
-                if [[ $EXCLUSIVE == 1 ]]; then
-                    jfCmd="sbatch --exclusive --account lcls:$EXP -p $QUEUE -o $WORKDIR/jungfrau_${EXP}_RUN${RUN}_%J.out $tmpScript"
-                else
-                    jfCmd="sbatch --mem 8GB --cpus-per-task 1 --account lcls:$EXP -p $QUEUE -o $WORKDIR/jungfrau_${EXP}_RUN${RUN}_%J.out $tmpScript"
-                fi
+                jfCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 1 -o $WORKDIR/jungfrau_${EXP}_RUN${RUN}_%J.out $tmpScript"
                 echo "run in queue: $jfCmd"        
                 SUBMISSION=$($jfCmd)
                 check_for_submit_error
@@ -832,7 +871,7 @@ fi
 ###
 #check if epix10k detectors are present
 HAVE_EPIX10K=$(grep -c Epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME")
-if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 ) && ( $WANT_UXI -eq 0 ) ]]; then
+if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) && ( $WANT_RAYONIX -eq 0 ) && ( $WANT_UXI -eq 0 ) && ( $WANT_ALVIUM -eq 0 ) ]]; then
     echo "-------------------- START EPIX10K PEDESTALS at $(date +'%T') ----------------------------"
     DETNAMES=$(grep Epix10ka /tmp/detnames_"$EXP"_"$CREATE_TIME" | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
     if [[ $RUNLOCAL -ne 1 ]]; then
@@ -856,11 +895,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
                 printf '#!/bin/bash\n' > "$tmpScript"
                 printf 'source %s/manage/bin/psconda.sh\n' "${SIT_ENV_DIR}" >> "$tmpScript"
                 printf '%s\n' "${CMD}" >> "$tmpScript"
-                if [[ $EXCLUSIVE == 1 ]]; then
-                    ep10kaCmd="sbatch --exclusive --account lcls:$EXP -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
-                else
-                    ep10kaCmd="sbatch --mem 8GB --cpus-per-task 5 --account lcls:$EXP -p $QUEUE -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
-                fi
+                ep10kaCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 5 -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
                 echo "run in queue: $ep10kaCmd"
                 SUBMISSION=$($ep10kaCmd)
                 check_for_submit_error
@@ -932,6 +967,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
     for EPIX10K in $DETNAMES; do
         deploy_geometry "$EPIX10K"
     done
+
     echo "-------------------- END EPIX10K PEDESTALS at $(date +'%T') ----------------------------"
 fi
 
@@ -947,6 +983,7 @@ HAVE_UXI=$(grep -c -i Uxi /tmp/detnames_"$EXP"_"$CREATE_TIME")
 HAVE_ISTAR=$(grep -c iStar /tmp/detnames_"$EXP"_"$CREATE_TIME")
 HAVE_OPAL=$(grep -c Opal /tmp/detnames_"$EXP"_"$CREATE_TIME")
 HAVE_RAYONIX=$(grep -c Rayonix /tmp/detnames_"$EXP"_"$CREATE_TIME")
+HAVE_ALVIUM=$(grep -c Alvium /tmp/detnames_"$EXP"_"$CREATE_TIME")
 
 #not like this: calculation
 (( SPECIFIED_CUTS=MYNOISESIGMIN+MYNOISESIGMAX+MYADUMIN+MYADUMAX ))
@@ -1003,6 +1040,15 @@ if [[ ( $HAVE_UXI -ge 1 ) && ( $WANT_UXI -ge 1 ) ]]; then
         DETS="$DETS uxi"
     else
         DETS='uxi'
+    fi
+fi
+
+#add alvium only on request
+if [[ ( $HAVE_ALVIUM -ge 1 ) && ( $WANT_ALVIUM -ge 1 ) ]]; then
+    if [ $SPECIFIED_CUTS -eq -4 ]; then
+        DETS="$DETS Alvium"
+    else
+        DETS='Alvium'
     fi
 fi
 

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -136,7 +136,7 @@ xtcav_dark()
        NJOBS=$((NJOBS+1))
 
        sleep 10
-       echo Running $NJOBS jobs are PIDS: "${JOBIDS[@]}"
+       echo Running "$NJOBS" jobs are PIDS: "${JOBIDS[@]}"
        until check_running_jobs; do
            echo 'Checking again in 10s'
            sleep 10
@@ -514,7 +514,7 @@ if [ ! -w "$WORKDIR" ]; then
     echo 'Typical directory to store calib logfiles & results is not writeable, will attempt to work from /tmp, but things may fail'
     WORKDIR='/tmp'
 fi 
-cd "$WORKDIR"
+cd "$WORKDIR" || exit
 
 ######################
 # work on the XTCAV
@@ -554,7 +554,7 @@ fi
 #    ARG=$ARG' -q '$QUEUE
 #fi
 
-if [ $DEPLOY == 1 ]; then
+if [ "$DEPLOY" == 1 ]; then
     ARG=$ARG' -D '
 fi
 
@@ -566,7 +566,7 @@ echo Check for data files:
 
 MINWAIT=0
 HAVEFILES=0
-while [[ $MINWAIT < 5 ]]; do
+while [[ $MINWAIT -lt 5 ]]; do
     NFILES=`ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc* | wc -l`
     echo $NFILES
     if [ $NFILES -eq 0 ]; then
@@ -691,7 +691,7 @@ if [[ $LCLS2 -gt 0 ]]; then
             fi
 
             echo "---------------EPIX10K PEDESTALS CALCULATED NOW DEPLOY     --------------------"
-            if [ $DEPLOY == 1 ]; then
+            if [ "$DEPLOY" == 1 ]; then
                 if [ $NFAILEDJOBS -gt 0 ]; then
                     read -r -p "$NFAILEDJOBS of the calibration tasks failed, do you want to continue anyways (y/n)?"
                     if [ "$REPLY" != "y" ];then
@@ -701,8 +701,8 @@ if [[ $LCLS2 -gt 0 ]]; then
  
                 for EPIX10K in $DETNAMES; do
                     CMD="epix10ka_deploy_constants -D -d $EPIX10K -e $EXP -r $RUN -L INFO -x :dir=$XTCDIR"
-                    echo 'setting validity....' $VALSTR
-                    if [ $VALSTR != 'xxx' ]; then
+                    echo 'setting validity....$VALSTR'
+                    if [ "$VALSTR" != 'xxx' ]; then
                         CMD=$CMD' -t '$VALSTR
                     fi
                     echo "$cmd"
@@ -787,7 +787,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
                 CMDC=$CMD
             fi
             if [[ $RUNLOCAL != 1 ]]; then
-                tmpScript=$(mktemp -p $WORKDIR jungfrau_multi_tmpXXXXX.sh)
+                tmpScript=$(mktemp -p "$WORKDIR" jungfrau_multi_tmpXXXXX.sh)
                 #trap "rm -f $tmpScript" EXIT
                 chmod u+x "$tmpScript"
                 printf '#!/bin/bash\n' > "$tmpScript"
@@ -820,7 +820,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
     if [[ $RUNLOCAL != 1 ]]; then
         echo 'Wait for 1/2 minutes before checking jobs:'
         sleep 30
-        echo Running $NJOBS jobs are PIDS: "${JOBIDS[@]}"
+        echo Running "$NJOBS" jobs are PIDS: "${JOBIDS[@]}"
         until check_running_jobs; do
                 echo 'Checking again in 10s'
                 sleep 10
@@ -839,7 +839,7 @@ if [[ ( $HAVE_JUNGFRAU -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &
 
     #Now deploy.
     if [ $DEPLOY == 1 ]; then
-        if [ $NFAILEDJOBS -gt 0 ]; then
+        if [ "$NFAILEDJOBS" -gt 0 ]; then
             read -r -p "$NFAILEDJOBS of the calibration tasks failed, do you want to continue (y/n)?"
             if [ "$REPLY" != "y" ];then
                 exit 1
@@ -945,7 +945,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
         for EPIX10K in $DETNAMES; do
             CMD="epix10ka_deploy_constants -D -d $EPIX10K -e $EXP -r $RUN -L INFO -x :dir=$XTCDIR:stream=0-79"
             if [ $VALSTR != 'xxx' ]; then
-                echo 'setting validity....' $VALSTR
+                echo 'setting validity to $VALSTR'
                 CMD=$CMD' -t '$VALSTR
             fi
             echo "$CMD"
@@ -1083,7 +1083,7 @@ echo "for the following detectors: $DETS"
 for MYDET in $DETS; do
     #set thresholds for the detector in question
     #ADU minimum, maximum
-    get_config $MYDET
+    get_config "$MYDET"
 
     LOCARG=$ARG' --thr_int_min '$ADUMIN' --thr_int_max '$ADUMAX' --thr_rms_min '$NOISESIGMIN' --thr_rms_max '$NOISESIGMAX
     #this was likely to work with runs where the zyla rate was < readout rate....


### PR DESCRIPTION
Added the Alvium as a detector you could calibrate.
Should the queues be very busy, allow to add a reservation.
Check that the used account&reservation will work.
Quit when no files will be found after 5 mins waiting.

## Motivation and Context
https://jira.slac.stanford.edu/browse/ECS-4364
https://jira.slac.stanford.edu/browse/ECS-6322

## How Has This Been Tested?
recreating pedestals for epix100, epix10k2m, jungfrau4M and check that it files for a non-existing run.