### PR TITLE
Fix subprocess output not stripped

### DIFF
--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -95,6 +95,9 @@ class DaqManager:
     def __init__(self, verbose=False):
         self.verbose = verbose
         self.hutch = call_subprocess("get_info", "--gethutch")
+        if len(self.hutch) != 3:
+            raise ValueError(f"Invalid hutch name found (hutch: '{self.hutch}')")
+
         self.user = self.hutch + "opr"
         self.sbman = SbatchManager(self.user)
         self.scripts_dir = f"/reg/g/pcds/dist/pds/{self.hutch}/scripts"

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -29,7 +29,7 @@ def silentremove(filename):
 
 
 def call_subprocess(*args):
-    return str(subprocess.check_output(args, stderr=PIPE), "utf-8")
+    return str(subprocess.check_output(args, stderr=PIPE).strip(), "utf-8")
 
 
 def call_sbatch(cmd, nodelist, scripts_dir):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The refactoring of call_subprocess missed stripping out leading and trailing whitespace. This caused get_info --gethutch called to return invalid hutch name. 
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a new issue found after the software was deployed. Unfortunately, it was not caught earlier. Reason is unknown at the moment. 

A name-validation check using the string length for the hutches was added. This raises ValueError from daqutils inhibiting execution of the codes that follow.
## How Has This Been Tested?
Both tmo and rix have been tested. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
