### PR TITLE
MNT Add TXI to DAQMGR_HUTCHES

### DIFF
--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from subprocess import PIPE
 
-DAQMGR_HUTCHES = ["tmo", "rix"]
+DAQMGR_HUTCHES = ["tmo", "rix", "txi"]
 LOCALHOST = socket.gethostname()
 SLURM_PARTITION = "drpq"
 SLURM_JOBNAME = "submit_daq"
@@ -155,8 +155,10 @@ class DaqManager:
         cmd = f"pushd {self.scripts_dir}" + " > /dev/null;"
         cmd += f'source {os.path.join(self.scripts_dir, "setup_env.sh")}' + ";"
         cmd += (
-            f"WHEREPROG=$(which {prog}); set -x; $WHEREPROG {subcmd} {os.path.join(self.scripts_dir,self.cnf_file)}"
-            + "; { set +x; } 2>/dev/null;"
+            f"WHEREPROG=$(which {prog})"
+            "; set -x; "
+            f"$WHEREPROG {subcmd} {os.path.join(self.scripts_dir, self.cnf_file)}"
+            "; { set +x; } 2>/dev/null;"
         )
         cmd += "popd > /dev/null;"
 
@@ -192,4 +194,4 @@ class DaqManager:
         st = time.monotonic()
         self.calldaq("restart", daq_host=daq_host)
         en = time.monotonic()
-        print(f"took {en-st:.4f}s. for starting the DAQ")
+        print(f"took {en-st:.4f}s. for starting the DAQ")  # noqa: E231


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds `TXI` to the list of `DAQMGR_HUTCHES` so `restartdaq` will run the DAQ using SLURM for TXI from the `txi-daq` machine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This normalizes the standard way of running the TXI DAQ to be the same as the other hutches.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by starting the DAQ with paths in `restartdaq` modified to point to the modified file to ensure that the modified version is called. The specific changes (not included in the PR) are:
```diff
diff --git a/scripts/restartdaq b/scripts/restartdaq
index 5496162..bb6dd08 100755
--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -2,8 +2,8 @@

 # Check if the current's user hutch uses daqmgr. If so,
 # use the python utilities to manage the daq.
-if [ "$(daqutils isdaqmgr)" = "true" ]; then
-    daqutils $(basename "$0") $@
+if [ "$(/cds/home/opr/txiopr/scripts/engineering_tools/scripts/daqutils isdaqmgr)" = "true" ]; then
+    /cds/home/opr/txiopr/scripts/engineering_tools/scripts/daqutils $(basename "$0") $@
     exit 0
 fi
````
This was needed to prevent picking up the standard/central installation of `engineering_tools`. There were other alternatives (modifying paths, startup shell scripts for opr scripts etc...)

This was tested in the LCLS2 hutches running from the `$HUTCH-daq` machines using the operator account.

TXI:
```bash
txi-daq:scripts> wheredaq
DAQ is not running in txi
txi-daq:scripts> cd engineering_tools
txi-daq:engineering_tools> ./scripts/restartdaq
DAQ is not running in txi
+ /cds/home/opr/txiopr/git/lcls2_100824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/txi/scripts/txi.py

took 6.8074s. for starting the DAQ
```

RIX:
```bash
rix-daq:scripts> wheredaq
DAQ is not running in rix
rix-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/restartdaq
DAQ is not running in rix
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/rix/scripts/rix.py

took 4.7705s. for starting the DAQ
```

TMO: (**DAQ was running, but given permission by James Cryan to restart it briefly for this test**)
```bash
tmo-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/restartdaq
DAQ is running on tmo-daq
+ /cds/home/opr/tmoopr/git/lcls2_102224/install/bin/daqmgr restart /reg/g/pcds/dist/pds/tmo/scripts/tmo.py

took 4.7999s. for starting the DAQ
tmo-daq:scripts> stopdaq
+ /cds/home/opr/tmoopr/git/lcls2_102224/install/bin/daqmgr stop /reg/g/pcds/dist/pds/tmo/scripts/tmo.py
```

LCLS1 hutches are unaffected by this change since only hutches included in `DAQMGR_HUTCHES` take this code path in `restartdaq`. The latter code is used by LCLS1 hutches.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
No documentation changes for this minor update since it just brings TXI in-line with standard hutch operating procedures.
<!--
## Screenshots (if appropriate):
-->
