### PR TITLE
ENH Add option to specify CNF for LCLS2 hutches. Restart/stop AMI only for LCLS2 Hutches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,7 +748,8 @@ usage: restartdaq options<br/>
     OPTIONS:<br/>
     -w sort windows after start<br/>
     -p select partition (same as used last)<br/>
-    -s silent (do not email jana)
+    -s silent (do not email jana)<br/>
+    -C [cnf] : <b>(FOR LCLS2 Hutches)</b> Specify a CNF to run. E.g. qrix.py or crix.py
     </td>
 </tr>
 

--- a/README.md
+++ b/README.md
@@ -792,6 +792,7 @@ Sourcing this script lets ssh-agent set the proper environment variables it need
 usage: startami options<br/>
         <br/>
     we are starting another ami session here<br/>
+    <b>This script restarts AMI1 in LCLS1 hutches and AMI2 in LCLS2 hutches</b><br/>
     <br/>
     OPTIONS:<br/>
     -s: stop the ami client current running on this machine<br/>
@@ -802,7 +803,8 @@ usage: startami options<br/>
 <tr>
     <td>stopami</td>
     <td>
-Kill an AMI process running in the current hutch.
+Kill an AMI process running in the current hutch.<br/>
+<b>This script stops AMI1 in LCLS1 hutches and AMI2 in LCLS2 hutches</b>
     </td>
 </tr>
 

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -92,7 +92,7 @@ class SbatchManager:
 
 
 class DaqManager:
-    def __init__(self, verbose=False):
+    def __init__(self, verbose=False, cnf=None):
         self.verbose = verbose
         self.hutch = call_subprocess("get_info", "--gethutch")
         if len(self.hutch) != 3:
@@ -101,7 +101,10 @@ class DaqManager:
         self.user = self.hutch + "opr"
         self.sbman = SbatchManager(self.user)
         self.scripts_dir = f"/reg/g/pcds/dist/pds/{self.hutch}/scripts"
-        self.cnf_file = f"{self.hutch}.py"
+        if cnf is None:
+            self.cnf_file = f"{self.hutch}.py"
+        else:
+            self.cnf_file = cnf
 
     def isdaqmgr(self, quiet=False):
         if self.hutch in DAQMGR_HUTCHES:

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Check if the current's user hutch uses daqmgr. If so,
-# use the python utilities to manage the daq.
-if [ "$(daqutils isdaqmgr)" = "true" ]; then
-    daqutils $(basename "$0") $@
-    exit 0
-fi
-
 usage()
 {
 cat << EOF
@@ -18,6 +11,7 @@ OPTIONS:
 -p select partition (same as used last)
 -s silent (do not email jana)
 -c enable core files
+-C (LCLS2 DAQMGR Hutches ONLY!) Select a cnf to use.
 EOF
 }
 
@@ -37,7 +31,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 CORESIZE=0
-while getopts "m:pwscd" OPTION
+while getopts "m:pwscdC:" OPTION
 do
     case $OPTION in
 	p)
@@ -55,6 +49,9 @@ do
  	c)
  	    CORESIZE=2000000000
  	    ;;
+  C)
+      DAQMGR_CNF=$OPTARG
+      ;;
  	d)
  	    DSSTEST=1
  	    ;;
@@ -66,6 +63,29 @@ do
 	esac
 done
 
+# Check if the current's user hutch uses daqmgr. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    if [[ -n "$DAQMGR_CNF" ]]; then
+        for arg in "$@"; do
+	          shift
+	          case $arg in
+		            -C)
+		                shift
+		                shift
+		                ;;
+		             *)
+		                set -- "$@"
+		                ;;
+	          esac
+	      done
+        daqutils --cnf "$DAQMGR_CNF" "$(basename "$0")" "$@"
+    else
+        daqutils "$(basename "$0")" "$@"
+    fi
+    exit 0
+fi
+
 if [[ $(whoami) != *'opr'* ]]; then
     echo "Please run the DAQ from the operator account!"
     exit
@@ -73,7 +93,7 @@ fi
 
 HUTCH=$(get_info --gethutch)
 CNFEXT=.cnf
-CNFFILE=$HUTCH$CNFEXT
+CNFFILE="$HUTCH""$CNFEXT"
 if [ "$HOSTNAME" == 'cxi-daq' ]; then
     PEXT=_0
     CNFFILE=$HUTCH$PEXT$CNFEXT
@@ -96,6 +116,7 @@ cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 DAQNETWORK='fez'
 LCLS2_HUTCHES="rix, tmo, ued, txi"
 if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+    # shellcheck disable=SC1090
     source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'
     DAQNETWORK='drp'
@@ -109,8 +130,7 @@ if [ "$IS_DAQ_HOST" == 0 ]; then
     WORKINGHOSTS=''
     #make sure at least cds is up.
     for HOST in $HOSTS; do
-	ping -w 2 "$HOST" >/dev/null 2>&1
-	if [[ $? == 0 ]]; then
+	      if [[ $(ping -w 2 "$HOST" >/dev/null 2>&1) == 0 ]]; then
 	    WORKINGHOSTS=$WORKINGHOSTS' '$HOST
 	fi
     done
@@ -125,12 +145,12 @@ else
     DAQHOST=$(wheredaq)
 fi
 
-PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE | awk '{print $NF}' | sed s/\'//g)
+PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" | awk '{print $NF}' | sed s/\'//g)
 if [[ "$DAQHOST" != *$NOTRUNNING* ]]; then
     echo stop the DAQ on "$DAQHOST" from "$HOSTNAME"
     T="$(date +%s%N)"
     $PROCMGR stop \
-	/reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE
+	/reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE"
 
 
     if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
@@ -146,7 +166,7 @@ else
 	echo while DAQ reports to not run, will stop the DAQ on "$DAQHOST" from "$HOSTNAME" to clear the p"$PLATFORM"$CNFEXT.running file
 	T="$(date +%s%N)"
 	$PROCMGR stop \
-	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE
+	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE"
 
         if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM"$CNFEXT.running ]; then
             echo 'the DAQ did not stop properly, exit now and try again follow the escalation procedure'
@@ -164,7 +184,7 @@ T="$(date +%s%N)"
 echo start DAQ on "$AIMHOST"
 if [ "$HOSTNAME" == "$AIMHOST" ]; then
     $PROCMGR start \
-        /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE -c $CORESIZE -o /reg/g/pcds/pds/"$HUTCH"/logfiles
+        /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" -c $CORESIZE -o /reg/g/pcds/pds/"$HUTCH"/logfiles
 else
     ssh -Y "$AIMHOST" restartdaq
 fi
@@ -199,7 +219,7 @@ if [ ${#DOWIN} != 0 ] ||  [ ${#SELPART} != 0 ]; then
 	    SELPART=0
 	fi
     fi
-    if [ -f /reg/neh/operator/"$HUTCH"\opr/bin/"$HUTCH"\_cleanup_windows_daq ]; then
+    if [ -f /reg/neh/operator/"$HUTCH"opr/bin/"$HUTCH"_cleanup_windows_daq ]; then
 	if [ ${#DOWIN} != 0 ]; then
 	    echo 'This instrument does not have standard locations for DAQ windows setup'
 	fi
@@ -210,13 +230,13 @@ fi
 if [ ${#DOWIN} != 0 ]; then
     T="$(date +%s%N)"
     if [ "$HUTCH" == 'xpp' ]; then
-	test=$(xdotool search --sync --onlyvisible --name 'ProcStat')
+        xdotool search --sync --onlyvisible --name 'ProcStat'
     fi
     if [ "$HUTCH" == 'xcs' ]; then
 	sleep 2
     fi
     echo 'resorting the windows now using: /reg/neh/operator/'"$HUTCH"'opr/bin/'"$HUTCH"'_cleanup_windows_daq'
-    /reg/neh/operator/"$HUTCH"\opr/bin/"$HUTCH"\_cleanup_windows_daq
+    /reg/neh/operator/"$HUTCH"opr/bin/"$HUTCH"_cleanup_windows_daq
     Tdinter="$(($(date +%s%N)-T))"
     Sinter="$((Tdinter/1000000000))"
     Minter="$((Tdinter/1000000))"

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="run_daq_utils", description=__doc__)
 
     parser.add_argument("-v", "--verbose", action="store_false")
-
+    parser.add_argument("--cnf", default=None)
     subparsers = parser.add_subparsers()
     psr_restart = subparsers.add_parser(
         "restartdaq",
@@ -55,5 +55,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    daqmgr = DaqManager(args.verbose)
+    daqmgr = DaqManager(args.verbose, args.cnf)
     args.func(daqmgr, args)

--- a/scripts/startami
+++ b/scripts/startami
@@ -17,7 +17,6 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-STOP_AMI=0
 while getopts "sc:" OPTION
 do
     case "$OPTION" in
@@ -33,28 +32,28 @@ do
 	    ;;
 	esac
 done
-shift "$(($OPTIND-1))"
+shift "$((OPTIND-1))"
 
-if [[ `whoami` != *'opr'* ]]; then
+if [[ $(whoami) != *'opr'* ]]; then
     echo "Please run ami from the operator account!"
     exit
 fi
 
-HUTCH=`get_hutch_name`
+HUTCH=$(get_hutch_name)
 if [ "$(daqutils isdaqmgr)" = "true" ]; then
-    daqutils --cnf ${HUTCH}_ami.py restartdaq $@
+    daqutils --cnf "${HUTCH}"_ami.py restartdaq "$@"
     exit 0
 fi
 
-EXPNAME=`get_curr_exp`
+EXPNAME=$(get_curr_exp)
 CNFEXT=.cnf
 
-if [[ $HUTCH == 'cxi' ]]; then
-    if [[ $HOSTNAME == 'cxi-daq' ]]; then
+if [[ "$HUTCH" == 'cxi' ]]; then
+    if [[ "$HOSTNAME" == 'cxi-daq' ]]; then
         CNFEXT=_0.cnf
-    elif [[ $HOSTNAME == 'cxi-monitor' ]]; then
+    elif [[ "$HOSTNAME" == 'cxi-monitor' ]]; then
         CNFEXT=_1.cnf
-    elif [[ -z $CONFIG ]]; then
+    elif [[ -z "$CONFIG" ]]; then
         echo 'You must provide cxi config file (-c) if not on daq machine'
         exit 1
     fi
@@ -66,46 +65,46 @@ if [[ -z $CONFIG ]]; then
 fi
 
 #
-# this is XPP specific. Don't think we should have local plugins anyways, 
-# only release ones. 
+# this is XPP specific. Don't think we should have local plugins anyways,
+# only release ones.
 #
 source /reg/g/pcds/setup/pathmunge.sh
-if [ $HUTCH == 'xpp' ]; then
+if [ "$HUTCH" == 'xpp' ]; then
     ldpathmunge /reg/neh/operator/xppopr/ami_plugins
-elif [ $HUTCH == 'xcs' ]; then
+elif [ "$HUTCH" == 'xcs' ]; then
     ldpathmunge /reg/neh/operator/xcsopr/online/ami_plugins
 fi
 
 
-DAQHOST=`wheredaq`
-ami_base_path=`grep ami_base_path /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG | grep -v '#' | grep -v 'ami_base_path+'  | awk 'BEGIN { FS = "=" }; { print $2}' | sed s/\'//g`
-ami_path=$ami_base_path`grep ami_path /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG | grep -v 'ami_path+' | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+// | sed s/\'//g`
+DAQHOST=$(wheredaq)
+ami_base_path=$(grep ami_base_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep -v '#' | grep -v 'ami_base_path+'  | awk 'BEGIN { FS = "=" }; { print $2}' | sed s/\'//g)
+ami_path=$ami_base_path$(grep ami_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep -v 'ami_path+' | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+// | sed s/\'//g)
 
-proxy_cds=`/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG | grep ami_proxy | awk {'print $1'} | sed s/'-fez'/''/g`
+proxy_cds=$(/reg/g/pcds/dist/pds/"$HUTCH"/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep ami_proxy | awk '{print $1}' | sed s/'-fez'/''/g)
 
-amicmd=`grep ami_client /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG | grep -v '#' |  awk 'BEGIN { FS = ":" }; { print $4}' | sed s/ami_path//g | sed s/\'+proxy_cds/$proxy_cds/g | sed  s:\'+expname:$EXPNAME/:g | sed s/+\'//g | sed s/\'\}\)//g` 
+amicmd=$(grep ami_client /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep -v '#' |  awk 'BEGIN { FS = ":" }; { print $4}' | sed s/ami_path//g | sed s/\'+proxy_cds/"$proxy_cds"/g | sed  s:\'+expname:"$EXPNAME"/:g | sed s/+\'//g | sed s/\'\}\)//g)
 
 if [[ "$DAQHOST" == *"$HOSTNAME" ]]; then  # Check host and daq host line share host name...
     #running on the DAQ host, this will restart the ami_client!
-    read -p "Do you really intend to restart the ami_client on $DAQHOST? (y/n)"
+    read -r -p "Do you really intend to restart the ami_client on $DAQHOST? (y/n)"
     if [ "$REPLY" == "y" ];then
 	echo "Restarting the ami_client...";
-	/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr stop \
-	    /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG ami_client 
-	/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr start \
- 	    /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG -c 2000000000 -o /reg/g/pcds/pds/$HUTCH/logfiles ami_client 
+	/reg/g/pcds/dist/pds/"$HUTCH"/current/tools/procmgr/procmgr stop \
+	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" ami_client
+	/reg/g/pcds/dist/pds/"$HUTCH"/current/tools/procmgr/procmgr start \
+ 	    /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" -c 2000000000 -o /reg/g/pcds/pds/"$HUTCH"/logfiles ami_client
 	exit
     else
-	read -p "Do you want to start a second client on the DAQ host $DAQHOST? (y/n)"
+	read -r -p "Do you want to start a second client on the DAQ host $DAQHOST? (y/n)"
 	if [ "$REPLY" == "n" ];then
 	    exit
 	else
-	    echo "Starting another ami_client on "$DAQHOST , calling:
+	    echo "Starting another ami_client on ""$DAQHOST" , calling:
 	fi
     fi
 else
-    echo --- connect to proxy on: $proxy_cds, calling:
-fi    
+    echo --- connect to proxy on: "$proxy_cds", calling:
+fi
 
-echo $ami_path$amicmd
-exec $ami_path$amicmd&
+echo "$ami_path""$amicmd"
+exec "$ami_path""$amicmd"&

--- a/scripts/startami
+++ b/scripts/startami
@@ -41,6 +41,11 @@ if [[ `whoami` != *'opr'* ]]; then
 fi
 
 HUTCH=`get_hutch_name`
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    daqutils --cnf ${HUTCH}_ami.py restartdaq $@
+    exit 0
+fi
+
 EXPNAME=`get_curr_exp`
 CNFEXT=.cnf
 

--- a/scripts/stopami
+++ b/scripts/stopami
@@ -14,6 +14,10 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 HUTCH=`get_hutch_name`
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    daqutils --cnf ${HUTCH}_ami.py stopdaq $@
+    exit 0
+fi
 DAQHOST=`wheredaq`
 RESCNT=`echo $DAQHOST |wc| awk {'print $2'}`
 if [ $RESCNT -eq 1 ]; then
@@ -23,7 +27,7 @@ if [ $RESCNT -eq 1 ]; then
 	if [ "$REPLY" == "y" ];then
 	    echo "Restarting the ami_client...";
 	    /reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr stop \
-		/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf ami_client 
+		/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf ami_client
 	fi
     fi
 fi

--- a/scripts/stopami
+++ b/scripts/stopami
@@ -13,41 +13,41 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-HUTCH=`get_hutch_name`
+HUTCH=$(get_hutch_name)
 if [ "$(daqutils isdaqmgr)" = "true" ]; then
-    daqutils --cnf ${HUTCH}_ami.py stopdaq $@
+    daqutils --cnf "${HUTCH}"_ami.py stopdaq "$@"
     exit 0
 fi
-DAQHOST=`wheredaq`
-RESCNT=`echo $DAQHOST |wc| awk {'print $2'}`
-if [ $RESCNT -eq 1 ]; then
-    if [ $HOSTNAME == $DAQHOST ]; then
+DAQHOST=$(wheredaq)
+RESCNT=$(echo "$DAQHOST" |wc| awk '{print $2}')
+if [ "$RESCNT" -eq 1 ]; then
+    if [ "$HOSTNAME" == "$DAQHOST" ]; then
         #running on the DAQ host, this will restart the ami_client!
-	read -p "Do you really intend to stop the ami_client on $DAQHOST where the daq is running? (y/n)"
+	read -r -p "Do you really intend to stop the ami_client on $DAQHOST where the daq is running? (y/n)"
 	if [ "$REPLY" == "y" ];then
 	    echo "Restarting the ami_client...";
-	    /reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr stop \
-		/reg/g/pcds/dist/pds/$HUTCH/scripts/$HUTCH.cnf ami_client
+	    /reg/g/pcds/dist/pds/"$HUTCH"/current/tools/procmgr/procmgr stop \
+		/reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$HUTCH".cnf ami_client
 	fi
     fi
 fi
 
-AMI_PROCID=`ps -ef | grep online_ami | grep current | awk {'print $2'}`
-HAVE_ID=`echo $AMI_PROCID | wc | awk {'print $2'}`
-if [ $HAVE_ID -gt 0 ]; then
+AMI_PROCID=$(pgrep online_ami | awk '{print $1}')
+HAVE_ID=$(echo "$AMI_PROCID" | wc | awk '{print $2}')
+if [ "$HAVE_ID" -gt 0 ]; then
     for id in $AMI_PROCID; do
-	echo 'killing ' $id
-	kill $id
+	echo 'killing ' "$id"
+	kill "$id"
     done
 fi
 
 sleep 2
 
-AMI_PROCID=`ps -ef | grep online_ami | grep current | awk {'print $2'}`
-HAVE_ID=`echo $AMI_PROCID | wc | awk {'print $2'}`
-if [ $HAVE_ID -gt 0 ]; then
+AMI_PROCID=$(pgrep online_ami | awk '{print $1}')
+HAVE_ID=$(echo "$AMI_PROCID" | wc | awk '{print $2}')
+if [ "$HAVE_ID" -gt 0 ]; then
     for id in $AMI_PROCID; do
-	echo 'kill -9 ' $id
-	kill -9 $id
+	echo 'kill -9 ' "$id"
+	kill -9 "$id"
     done
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a `--cnf` option to `run_daq_utils.py` which is passed to `daq_utils.DaqManager`. This allows us to indicate which cnf file to use for restarting/stopping the DAQ in LCLS2 hutches.

Currently, this is used for:
  - Restarting AMI processes only in LCLS2 hutches instead of the entire DAQ, and the `startami` and `stopami` scripts have been updated accordingly. 
  - Allowing for RIX to switch between QRIX and ChemRIX cnfs for `restartdaq`. `restartdaq -C <CNF>` will now work for LCLS2 hutches. `stopdaq` will still work as previously, assuming both CNFs have imported from the same "master/main" cnf.

*NOTE:* After this PR the `startami` and `stopami` scripts will perform the following depending on hutch:
  - `startami`: Restart AMI1 in LCLS1 hutches AMI2 in LCLS2 hutches
  - `stopami`: Stop AMI1 in LCLS1 hutches, and AMI2 in LCLS2 hutches

For AMI2 running in LCLS1 hutches a separate script is needed, e.g. as being introduced in #212 

*NOTE:* `stopami` was not currently working for LCLS1 hutches (`startami` was.). This PR introduces a minor fix for that.

For starting and stopping AMI in LCLS2 hutches, a new standard has been introduced where each hutch will have a `$HUTCH_ami.py` cnf file. This cnf inherits only the AMI processes from the main CNF. This allows it to be used to restart AMI independently of the rest of the DAQ processes.

Examples of this cnf are:
RIX:
```bash
rix-daq:scripts> ll rix_ami.py
-rw-rw-r-- 1 rixopr xs 103 oct 23 13:43 rix_ami.py
rix-daq:scripts> cat rix_ami.py
from rix import *
from psdaq.slurm.config import Config
config = Config({})
config.extend(procmgr_ami)
```
TMO:
```bash
tmo-daq:scripts> cat tmo_ami.py
from tmo import *
from psdaq.slurm.config import Config
config = Config({})
config.extend(procmgr_ami)
```

TXI:
```bash
txi-daq:scripts> cat txi_ami.py
from txi import *
from psdaq.slurm.config import Config
config = Config({})
config.extend(procmgr_ami)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initially motivated by the need to have a standard way of restarting AMI (and AMI ONLY) across the LCLS2 hutches. This PR's cnf feature also provides a mechanism to allow restarting QRIX and ChemRIX DAQs independently from the same hutch if they are differentiated by different configuration files.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Testing `startami` and `stopami` in LCLS2 hutches
Tested by starting the DAQ with appropriate paths modified to point to the modified `daqutils` to ensure that the modified version is called. The specific changes (not included in the PR) are, for example for `startami`.

```diff
--- a/scripts/startami
+++ b/scripts/startami
@@ -39,8 +39,11 @@ if [[ `whoami` != *'opr'* ]]; then
     echo "Please run ami from the operator account!"
     exit
 fi
-
 HUTCH=`get_hutch_name`
+if [ "$(/cds/home/opr/txiopr/scripts/engineering_tools/scripts/daqutils isdaqmgr)" = "true" ]; then
+    /cds/home/opr/txiopr/scripts/engineering_tools/scripts/daqutils --cnf ${HUTCH}_ami.py restartdaq $@
+    exit 0
+fi
 EXPNAME=`get_curr_exp`
 CNFEXT=.cnf

@@ -104,3 +107,4 @@ fi

 echo $ami_path$amicmd
 exec $ami_path$amicmd&
````
This was needed to prevent picking up the standard/central installation of `engineering_tools`. There were other alternatives (modifying paths, startup shell scripts for opr scripts etc...)

The checkout of this branch was located at `~txiopr/scripts/engineering_tools` for all testing.

This was tested in the LCLS2 hutches running from the `$HUTCH-daq` machines using the operator account.

Note that the startami scripts pick up different cnf files.

TXI:
```bash
txi-daq:scripts> ./startami
DAQ is not running in txi
+ /cds/home/opr/txiopr/git/lcls2_100824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/txi/scripts/txi_ami.py

took 6.5332s. for starting the DAQ
txi-daq:scripts> ./stopami
+ /cds/home/opr/txiopr/git/lcls2_100824/install/bin/daqmgr stop /reg/g/pcds/dist/pds/txi/scripts/txi_ami.py

txi-daq:scripts> ./restartdaq
DAQ is not running in txi
+ /cds/home/opr/txiopr/git/lcls2_100824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/txi/scripts/txi.py

took 2.6325s. for starting the DAQ
txi-daq:scripts> stopdaq
+ /cds/home/opr/txiopr/git/lcls2_100824/install/bin/daqmgr stop /reg/g/pcds/dist/pds/txi/scripts/txi.py
```

RIX:
```bash
rix-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/startami
DAQ is not running in rix
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/rix/scripts/rix_ami.py

took 3.8405s. for starting the DAQ
rix-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/stopami
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr stop /reg/g/pcds/dist/pds/rix/scripts/rix_ami.py

rix-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/restartdaq
DAQ is not running in rix
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/rix/scripts/rix.py

took 2.8847s. for starting the DAQ
```

TMO:
```bash
tmo-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/startami
DAQ is not running in tmo
+ /cds/home/opr/tmoopr/git/lcls2_102224/install/bin/daqmgr restart /reg/g/pcds/dist/pds/tmo/scripts/tmo_ami.py

took 3.4237s. for starting the DAQ
tmo-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/stopami
+ /cds/home/opr/tmoopr/git/lcls2_102224/install/bin/daqmgr stop /reg/g/pcds/dist/pds/tmo/scripts/tmo_ami.py

tmo-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/restartdaq
DAQ is not running in tmo
+ /cds/home/opr/tmoopr/git/lcls2_102224/install/bin/daqmgr restart /reg/g/pcds/dist/pds/tmo/scripts/tmo.py

took 2.9897s. for starting the DAQ
```

### Verifying `startami` and `stopami` in LCLS1 hutches

The code affecting LCLS1 hutches was modified to bring it in line with spellcheck requirements. The `stopami` script was previously not working and now is.

MFX:
```bash
mfx-daq:~> ~txiopr/scripts/engineering_tools/scripts/stopami
killing  332
mfx-daq:~> ~txiopr/scripts/engineering_tools/scripts/startami
Do you really intend to restart the ami_client on DAQ is running on mfx-daq? (y/n)y
Restarting the ami_client...
/reg/g/pcds/dist/pds/mfx/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/mfx/scripts/p0.cnf.running' to stop
Current experiment is mfxl1039823
/reg/g/pcds/dist/pds/mfx/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/mfx/scripts/p0.cnf.running' to start
Current experiment is mfxl1039823
```

XCS:
```bash
xcs-daq:~> ~txiopr/scripts/engineering_tools/scripts/stopami
killing  20465
xcs-daq:~> ~txiopr/scripts/engineering_tools/scripts/startami
ldpathmunge: /reg/neh/operator/xcsopr/online/ami_plugins is not a directory
Do you really intend to restart the ami_client on DAQ is running on xcs-daq? (y/n)y
Restarting the ami_client...
/reg/g/pcds/dist/pds/xcs/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/xcs/scripts/p0.cnf.running' to stop
Current experiment is xcsx1015123
/reg/g/pcds/dist/pds/xcs/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/xcs/scripts/p0.cnf.running' to start
Current experiment is xcsx1015123
```

### Verifying `restartdaq -C <cnf>` and `stopdaq`

TXI:
```bash
txi-daq:scripts> ./restartdaq -C txi_ami.py
DAQ is not running in txi
+ /cds/home/opr/txiopr/git/lcls2_100824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/txi/scripts/txi_ami.py

took 6.6249s. for starting the DAQ
```

RIX:

**NOTE** : `stopdaq` will try and stop `rix.py` but this is fine since both `qrix.py` and `crix.py` are derived from it.
```bash
rix-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/restartdaq -C qrix.py
DAQ is not running in rix
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/rix/scripts/qrix.py
Warning: no qrix_w8_0 found in main_config

took 5.0917s. for starting the DAQ
rix-daq:scripts> ~txiopr/scripts/engineering_tools/scripts/restartdaq -C crix.py
 DAQ is not running in rix
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr restart /reg/g/pcds/dist/pds/rix/scripts/crix.py

took 3.1730s. for starting the DAQ

(ps-4.6.3) rix-daq:scripts> stopdaq
+ /cds/home/opr/rixopr/git/lcls2_101824/install/bin/daqmgr stop /reg/g/pcds/dist/pds/rix/scripts/rix.py
```

### Verifying `restartdaq` spellcheck changes haven't affected LCLS1 hutches

MFX:
```bash
mfx-daq:~> ~txiopr/scripts/engineering_tools/scripts/restartdaq
DAQ is currently not running
start DAQ on mfx-daq
/reg/g/pcds/dist/pds/mfx/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/mfx/scripts/mfx.cnf' to start
Current experiment is mfxl1039823
and 8.8318 for starting the DAQ
mfx-daq:~> ~txiopr/scripts/engineering_tools/scripts/stopdaq
stop the DAQ from mfx-daq
/reg/g/pcds/dist/pds/mfx/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/mfx/scripts/p0.cnf.running' to stop
Current experiment is mfxl1039823
```

XCS:
```bash
xcs-daq:~> ~txiopr/scripts/engineering_tools/scripts/restartdaq
DAQ is currently not running
start DAQ on xcs-daq
/reg/g/pcds/dist/pds/xcs/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/xcs/scripts/xcs.cnf' to start
Current experiment is xcsx1015123
ERR: no restart message...
and 7.7061 for starting the DAQ
xcs-daq:~> ~txiopr/scripts/engineering_tools/scripts/restartdaq
stop the DAQ on DAQ is running on xcs-daq from xcs-daq
/reg/g/pcds/dist/pds/xcs/current/tools/procmgr/procmgr: using config file '/reg/g/pcds/dist/pds/xcs/scripts/p0.cnf.running' to stop
Current experiment is xcsx1015123
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated README for behaviour of `startami` and `stopami`.

## Screenshots (if appropriate):
**After** `stopami` **in MFX**
![image](https://github.com/user-attachments/assets/7e6dff54-b0eb-467d-97f8-8f7a8c1f4d80)

**After** `startami` **again, in MFX**
![image](https://github.com/user-attachments/assets/ce9c1c2c-1245-408b-9047-2040654d646a)


**After** `stopami` **in XCS**
![image](https://github.com/user-attachments/assets/311288b9-2e97-4f85-9fdd-47f1c79d82d3)

**After** `startami` **again, in XCS**
![image](https://github.com/user-attachments/assets/5c1be648-dd5a-49e3-8296-50aae5b5af6f)
