### PR TITLE
W8reprogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,9 +655,18 @@ usage: motorInfo MOTOR_PV (motor_pv_2/autosave/archive/pmgr_diff/pmgr_save) OPT<
 <tr>
     <td>pgpwave8_upgrade</td>
     <td>
- Reads the version or upgrade the firmware on a pgpwave8.<br/>
-     The ioc name must be provided and the device defaults to /dev/datadev_0.<br/>
-     Use -r to read the version or -p [MCS_FILE_PATH] to upgrade.
+
+     usage $0 -i IOCNAME [-d DEVICE] [-r] [-p FIRMWARE_PATH]<br/>
+     <br/>
+     Read or upgrade the firmware version of a pgpwave8 given its ioc.<br/>
+     <br/>
+    -i The ioc whose pgpwave8's firmware should be upgraded.<br/>
+    -d The path to the device, defaulting to /dev/datadev_0.<br/>
+    -r Print the firmware version only. Cannot be used with -p.<br/>
+    -p The path to the mcs file containing the new firmware.<br/>
+    Cannot be used with -r. Some firmware images can be found
+    in /cds/group/pcds/package/wave8/images.
+EOF
     </td>
 </tr>
 

--- a/README.md
+++ b/README.md
@@ -653,6 +653,15 @@ usage: motorInfo MOTOR_PV (motor_pv_2/autosave/archive/pmgr_diff/pmgr_save) OPT<
 </tr>
 
 <tr>
+    <td>pgpwave8_upgrade</td>
+    <td>
+ Reads the version or upgrade the firmware on a pgpwave8.<br/>
+     The ioc name must be provided and the device defaults to /dev/datadev_0.<br/>
+     Use -r to read the version or -p [MCS_FILE_PATH] to upgrade.
+    </td>
+</tr>
+
+<tr>
     <td>pkg_release</td>
     <td>
  Checks out a package from the pcdshub github at a particular tag.<br/>

--- a/README.md
+++ b/README.md
@@ -664,8 +664,11 @@ usage: motorInfo MOTOR_PV (motor_pv_2/autosave/archive/pmgr_diff/pmgr_save) OPT<
     -d The path to the device, defaulting to /dev/datadev_0.<br/>
     -r Print the firmware version only. Cannot be used with -p.<br/>
     -p The path to the mcs file containing the new firmware.<br/>
-    Cannot be used with -r. Some firmware images can be found
-    in /cds/group/pcds/package/wave8/images.
+    Cannot be used with -r. Some firmware images can be found<br/>
+    in /cds/group/pcds/package/wave8/images. If -r and -p are not provided,<br/>
+    user will be prompted if they want to use<br/>
+    /cds/group/pcds/package/wave8/images/latest as the new firmware.
+
 EOF
     </td>
 </tr>

--- a/scripts/pgpwave8_upgrade
+++ b/scripts/pgpwave8_upgrade
@@ -38,15 +38,14 @@ remote()
         return 1
     fi
 
-    WAVE8_REPO=/cds/group/pcds/package/wave8/wave8/v2.8.0
+    WAVE8_REPO=/cds/group/pcds/package/wave8/wave8/v2.6.0
     if [[ $READ_VERSION -eq 1 ]]; then
         if [[ $status == "RUNNING" ]]; then
             pv=$(ioctool "$IOCNAME" pvs | grep FpgaVersion_RBV | awk '{print substr($1,1,length($1)-1)}')
             caget "$pv" -0x
         else
-	    # shellcheck disable=SC2164
-	    cd "$(dirname "$0")"
-            python pgpwave8_version.py -l "$LANE" --dev "$DEVICE"
+	    export PYTHONPATH=$WAVE8_REPO/software/scripts
+            python "$ET_DIR/pgpwave8_version.py" -l "$LANE" --dev "$DEVICE"
         fi
         return 0
     fi
@@ -104,7 +103,7 @@ if [[ $READ_VERSION -ne 1 ]]; then
         read -r -p "Would you like to use $(basename "$(realpath $latest)")?" answer
         answer=${answer,,}
         if [[ $answer == "y" ]] || [[ $answer == "yes" ]]; then
-            FWPATH=/cds/group/pcds/package/wave8/images/latest
+            FWPATH=$(realpath /cds/group/pcds/package/wave8/images/latest)
         else
             exit
         fi

--- a/scripts/pgpwave8_upgrade
+++ b/scripts/pgpwave8_upgrade
@@ -1,5 +1,4 @@
 #!/bin/bash
-#mention this path to mcs files in usage - /cds/group/pcds/package/wave8/images
 
 usage()
 {
@@ -12,7 +11,8 @@ Read or upgrade the firmware version of a pgpwave8 given its ioc.
 -d The path to the device, defaulting to /dev/datadev_0
 -r Print the firmware version only. Cannot be used with -p
 -p The path to the mcs file containing the new firmware.
-Cannot be used with -r.
+Cannot be used with -r. Some firmware images can be found
+in /cds/group/pcds/package/wave8/images.
 EOF
 }
 
@@ -43,7 +43,6 @@ remote()
             pv=$(/cds/group/pcds/engineering_tools/latest-released/scripts/ioctool "$IOCNAME" pvs | grep FpgaVersion_RBV | awk '{print substr($1,1,length($1)-1)}')
             caget "$pv" -0x
         else
-            export PYTHONPATH=$WAVE8_REPO/software/scripts
 	    # shellcheck disable=SC2164
 	    cd "$(dirname "$0")"
             python pgpwave8_version.py -l "$LANE" --dev "$DEVICE"

--- a/scripts/pgpwave8_upgrade
+++ b/scripts/pgpwave8_upgrade
@@ -3,7 +3,17 @@
 
 usage()
 {
-    echo "put usage here"
+    cat <<EOF
+usage $0 -i IOCNAME [-d DEVICE] [-r] [-p FIRMWARE_PATH]
+
+Read or upgrade the firmware version of a pgpwave8 given its ioc.
+
+-i The ioc whose pgpwave8's firmware should be upgraded
+-d The path to the device, defaulting to /dev/datadev_0
+-r Print the firmware version only. Cannot be used with -p
+-p The path to the mcs file containing the new firmware.
+Cannot be used with -r.
+EOF
 }
 
 remote()
@@ -26,6 +36,7 @@ remote()
         exit 1
     fi
 
+    # change this to a common path later
     WAVE8_REPO=/cds/home/t/tjohnson/trunk/workarea/wave8
     if [[ $READ_VERSION -eq 1 ]]; then
         if [[ $status == "RUNNING" ]]; then
@@ -33,7 +44,9 @@ remote()
             caget "$pv" -0x
         else
             export PYTHONPATH=$WAVE8_REPO/software/scripts
-            python /cds/home/k/kaushikm/w8script/version.py -l "$LANE" --dev "$DEVICE"
+	    # shellcheck disable=SC2164
+	    cd "$(dirname "$0")"
+            python pgpwave8_version.py -l "$LANE" --dev "$DEVICE"
         fi
         exit 0
     fi
@@ -42,7 +55,6 @@ remote()
         echo "Unable to disable ioc $IOCNAME. Exiting."
         exit 1
     fi
-    #change this to a common path later
     if ! python $WAVE8_REPO/software/scripts/wave8LoadFpga.py --l "$LANE" --dev "$DEVICE" --mcs "$FWPATH"; then
         echo "Firmware update failed."
         exit 1
@@ -154,4 +166,4 @@ echo "Rogue version is $ROGUE_VERSION."
 echo "Host is $HOST."
 
 # shellcheck disable=SC2029
-ssh "$HOST" "$(typeset -f remote); ROGUE_VERSION=$ROGUE_VERSION DEVICE=$DEVICE IOCNAME=$IOCNAME WAVE8_REPO=$WAVE8_REPO LANE=$LANE FWPATH=$FWPATH READ_VERSION=$READ_VERSION remote"
+ssh "$HOST" "$(typeset -f remote); ROGUE_VERSION=$ROGUE_VERSION DEVICE=$DEVICE IOCNAME=$IOCNAME LANE=$LANE FWPATH=$FWPATH READ_VERSION=$READ_VERSION remote"

--- a/scripts/pgpwave8_upgrade
+++ b/scripts/pgpwave8_upgrade
@@ -7,9 +7,9 @@ usage $0 -i IOCNAME [-d DEVICE] [-r] [-p FIRMWARE_PATH]
 
 Read or upgrade the firmware version of a pgpwave8 given its ioc.
 
--i The ioc whose pgpwave8's firmware should be upgraded
--d The path to the device, defaulting to /dev/datadev_0
--r Print the firmware version only. Cannot be used with -p
+-i The ioc whose pgpwave8's firmware should be upgraded.
+-d The path to the device, defaulting to /dev/datadev_0.
+-r Print the firmware version only. Cannot be used with -p.
 -p The path to the mcs file containing the new firmware.
 Cannot be used with -r. Some firmware images can be found
 in /cds/group/pcds/package/wave8/images.
@@ -23,21 +23,20 @@ remote()
     source /cds/group/pcds/pyps/conda/rogue/etc/profile.d/conda.sh
     if ! conda activate rogue_"$ROGUE_VERSION"; then
         echo "A rogue environment for this version is not available."
-        exit 1
+        return 1
     fi
     if [[ ! -e $DEVICE ]]; then
         echo "The device $DEVICE does not exist."
-        exit 1
+        return 1
     fi
     export PATH=/cds/group/pcds/engineering_tools/latest-released/scripts/:$PATH
     # shellcheck disable=SC2034
     if ! status=$(/cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --status); then
-        echo "Unable to get the status of $IOCNAME. Exiting."
-        exit 1
+        echo "Unable to get the status of $IOCNAME."
+        return 1
     fi
 
-    # change this to a common path later
-    WAVE8_REPO=/cds/home/t/tjohnson/trunk/workarea/wave8
+    WAVE8_REPO=/cds/group/pcds/package/wave8/wave8/v2.8.0
     if [[ $READ_VERSION -eq 1 ]]; then
         if [[ $status == "RUNNING" ]]; then
             pv=$(/cds/group/pcds/engineering_tools/latest-released/scripts/ioctool "$IOCNAME" pvs | grep FpgaVersion_RBV | awk '{print substr($1,1,length($1)-1)}')
@@ -47,22 +46,25 @@ remote()
 	    cd "$(dirname "$0")"
             python pgpwave8_version.py -l "$LANE" --dev "$DEVICE"
         fi
-        exit 0
+        return 0
     fi
 
     if [[ $status == "RUNNING" ]] && ! /cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --disable; then
-        echo "Unable to disable ioc $IOCNAME. Exiting."
-        exit 1
+        echo "Unable to disable ioc $IOCNAME."
+        return 1
     fi
     if ! python $WAVE8_REPO/software/scripts/wave8LoadFpga.py --l "$LANE" --dev "$DEVICE" --mcs "$FWPATH"; then
         echo "Firmware update failed."
-        exit 1
+        return 1
     fi
     if [[ $status == "RUNNING" ]] && ! /cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --enable; then
         echo "Unable to enable ioc $IOCNAME."
-        exit 1
+        return 1
     fi
-    echo "CHECK THAT THE WAVE8 IOC IS WORKING."
+    echo "Firmware upgrade complete."
+    if [[ $status == "RUNNING" ]]; then
+	echo "Please check that $IOCNAME is running properly."
+    fi
 }
 
 # shellcheck disable=SC2034

--- a/scripts/pgpwave8_upgrade
+++ b/scripts/pgpwave8_upgrade
@@ -31,9 +31,9 @@ remote()
         echo "The device $DEVICE does not exist."
         return 1
     fi
-    export PATH=/cds/group/pcds/engineering_tools/latest-released/scripts/:$PATH
+    PATH=$PATH:$ET_DIR
     # shellcheck disable=SC2034
-    if ! status=$(/cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --status); then
+    if ! status=$(imgr "$IOCNAME" --status); then
         echo "Unable to get the status of $IOCNAME."
         return 1
     fi
@@ -41,7 +41,7 @@ remote()
     WAVE8_REPO=/cds/group/pcds/package/wave8/wave8/v2.8.0
     if [[ $READ_VERSION -eq 1 ]]; then
         if [[ $status == "RUNNING" ]]; then
-            pv=$(/cds/group/pcds/engineering_tools/latest-released/scripts/ioctool "$IOCNAME" pvs | grep FpgaVersion_RBV | awk '{print substr($1,1,length($1)-1)}')
+            pv=$(ioctool "$IOCNAME" pvs | grep FpgaVersion_RBV | awk '{print substr($1,1,length($1)-1)}')
             caget "$pv" -0x
         else
 	    # shellcheck disable=SC2164
@@ -51,7 +51,7 @@ remote()
         return 0
     fi
 
-    if [[ $status == "RUNNING" ]] && ! /cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --disable; then
+    if [[ $status == "RUNNING" ]] && ! imgr "$IOCNAME" --disable; then
         echo "Unable to disable ioc $IOCNAME."
         return 1
     fi
@@ -59,7 +59,7 @@ remote()
         echo "Firmware update failed."
         return 1
     fi
-    if [[ $status == "RUNNING" ]] && ! /cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --enable; then
+    if [[ $status == "RUNNING" ]] && ! imgr "$IOCNAME" --enable; then
         echo "Unable to enable ioc $IOCNAME."
         return 1
     fi
@@ -130,7 +130,10 @@ if [[ -z $DEVICE ]]; then
     echo "Device flag -d was not provided, assuming the path is $DEVICE."
 fi
 
-if ! CFGPATH=$(/cds/group/pcds/engineering_tools/latest-released/scripts/ioctool "$IOCNAME" cfg); then
+ET_DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+PATH=$PATH:$ET_DIR
+
+if ! CFGPATH=$(ioctool "$IOCNAME" cfg); then
     echo "The ioc could not be found. Check that the correct name was provided with the -i flag."
     usage
     exit 1
@@ -175,4 +178,4 @@ echo "Rogue version is $ROGUE_VERSION."
 echo "Host is $HOST."
 
 # shellcheck disable=SC2029
-ssh "$HOST" "$(typeset -f remote); ROGUE_VERSION=$ROGUE_VERSION DEVICE=$DEVICE IOCNAME=$IOCNAME LANE=$LANE FWPATH=$FWPATH READ_VERSION=$READ_VERSION remote"
+ssh "$HOST" "$(typeset -f remote); ET_DIR=$ET_DIR ROGUE_VERSION=$ROGUE_VERSION DEVICE=$DEVICE IOCNAME=$IOCNAME LANE=$LANE FWPATH=$FWPATH READ_VERSION=$READ_VERSION remote"

--- a/scripts/pgpwave8_upgrade
+++ b/scripts/pgpwave8_upgrade
@@ -12,7 +12,9 @@ Read or upgrade the firmware version of a pgpwave8 given its ioc.
 -r Print the firmware version only. Cannot be used with -p.
 -p The path to the mcs file containing the new firmware.
 Cannot be used with -r. Some firmware images can be found
-in /cds/group/pcds/package/wave8/images.
+in /cds/group/pcds/package/wave8/images. If -r and -p are not provided,
+user will be prompted if they want to use
+/cds/group/pcds/package/wave8/images/latest as the new firmware.
 EOF
 }
 
@@ -97,9 +99,15 @@ fi
 
 if [[ $READ_VERSION -ne 1 ]]; then
     if [[ -z $FWPATH ]]; then
-        echo "The firmware path must be provided with the -p flag if not using the -r flag to read the version."
-        usage
-        exit 1
+	echo "No firmware path was provided with the -p flag."
+        latest=/cds/group/pcds/package/wave8/images/latest
+        read -r -p "Would you like to use $(basename "$(realpath $latest)")?" answer
+        answer=${answer,,}
+        if [[ $answer == "y" ]] || [[ $answer == "yes" ]]; then
+            FWPATH=/cds/group/pcds/package/wave8/images/latest
+        else
+            exit
+        fi
     elif [[ ! -f $FWPATH ]]; then
         echo "The firmware file provided with the -p flag does not exist."
         usage

--- a/scripts/pgpwave8_upgrade.sh
+++ b/scripts/pgpwave8_upgrade.sh
@@ -117,6 +117,7 @@ fi
 RELEASE=$(grep "^RELEASE.*" "$CFGPATH" | tail -1 | tr -d '[:space:]')
 PARENT=${RELEASE#*=}
 
+# shellcheck disable=SC2016
 if [[ $PARENT == '$$UP(PATH)' ]]; then
     PARENT=$(dirname "$(dirname "$CFGPATH")")
 elif [[ ! -d $PARENT ]]; then

--- a/scripts/pgpwave8_upgrade.sh
+++ b/scripts/pgpwave8_upgrade.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#mention this path to mcs files in usage - /cds/group/pcds/package/wave8/images
+
+usage()
+{
+    echo "put usage here"
+}
+
+remote()
+{
+    #!/bin/bash
+    # shellcheck disable=SC1091
+    source /cds/group/pcds/pyps/conda/rogue/etc/profile.d/conda.sh
+    if ! conda activate rogue_"$ROGUE_VERSION"; then
+        echo "A rogue environment for this version is not available."
+        exit 1
+    fi
+    if [[ ! -e $DEVICE ]]; then
+        echo "The device $DEVICE does not exist."
+        exit 1
+    fi
+    export PATH=/cds/group/pcds/engineering_tools/latest-released/scripts/:$PATH
+    # shellcheck disable=SC2034
+    if ! status=$(/cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --status); then
+        echo "Unable to get the status of $IOCNAME. Exiting."
+        exit 1
+    fi
+
+    WAVE8_REPO=/cds/home/t/tjohnson/trunk/workarea/wave8
+    if [[ $READ_VERSION -eq 1 ]]; then
+        if [[ $status == "RUNNING" ]]; then
+            pv=$(/cds/group/pcds/engineering_tools/latest-released/scripts/ioctool "$IOCNAME" pvs | grep FpgaVersion_RBV | awk '{print substr($1,1,length($1)-1)}')
+            caget "$pv" -0x
+        else
+            export PYTHONPATH=$WAVE8_REPO/software/scripts
+            python /cds/home/k/kaushikm/w8script/version.py -l "$LANE" --dev "$DEVICE"
+        fi
+        exit 0
+    fi
+
+    if [[ $status == "RUNNING" ]] && ! /cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --disable; then
+        echo "Unable to disable ioc $IOCNAME. Exiting."
+        exit 1
+    fi
+    #change this to a common path later
+    if ! python $WAVE8_REPO/software/scripts/wave8LoadFpga.py --l "$LANE" --dev "$DEVICE" --mcs "$FWPATH"; then
+        echo "Firmware update failed."
+        exit 1
+    fi
+    if [[ $status == "RUNNING" ]] && ! /cds/group/pcds/engineering_tools/latest-released/scripts/imgr "$IOCNAME" --enable; then
+        echo "Unable to enable ioc $IOCNAME."
+        exit 1
+    fi
+    echo "CHECK THAT THE WAVE8 IOC IS WORKING."
+}
+
+# shellcheck disable=SC2034
+while getopts "rp:i:d:" option; do
+    case $option in
+        p)
+            FWPATH="$OPTARG"
+            ;;
+        i)
+            IOCNAME="$OPTARG"
+            ;;
+        d)
+            DEVICE="$OPTARG"
+            ;;
+        r)
+            READ_VERSION=1
+            ;;
+        ?)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z $IOCNAME ]]; then
+    echo "The ioc name must be provided with the -i flag."
+    usage
+    exit 1
+fi
+
+if [[ $READ_VERSION -ne 1 ]]; then
+    if [[ -z $FWPATH ]]; then
+        echo "The firmware path must be provided with the -p flag if not using the -r flag to read the version."
+        usage
+        exit 1
+    elif [[ ! -f $FWPATH ]]; then
+        echo "The firmware file provided with the -p flag does not exist."
+        usage
+        exit 1
+    elif [[ ! $FWPATH =~ .*mcs ]]; then
+        echo "The firmware file provided with the -p argument is not an mcs file. Check that the correct path was provided with the -p flag."
+        usage
+        exit 1
+    fi
+else
+    if [[ -n $FWPATH ]]; then
+        echo "The firmware path cannot be provided with the -r flag."
+        usage
+        exit 1
+    fi
+fi
+
+if [[ -z $DEVICE ]]; then
+    DEVICE="/dev/datadev_0"
+    echo "Device flag -d was not provided, assuming the path is $DEVICE."
+fi
+
+if ! CFGPATH=$(/cds/group/pcds/engineering_tools/latest-released/scripts/ioctool "$IOCNAME" cfg); then
+    echo "The ioc could not be found. Check that the correct name was provided with the -i flag."
+    usage
+    exit 1
+fi
+RELEASE=$(grep "^RELEASE.*" "$CFGPATH" | tail -1 | tr -d '[:space:]')
+PARENT=${RELEASE#*=}
+
+if [[ $PARENT == '$$UP(PATH)' ]]; then
+    PARENT=$(dirname "$(dirname "$CFGPATH")")
+elif [[ ! -d $PARENT ]]; then
+    echo "Could not find path to parent ioc."
+    exit 1
+fi
+
+LANE=$(grep "^PGP_LANE.*" "$CFGPATH" | tail -1 | tr -d '[:space:]')
+LANE=${LANE#*=}
+if [[ -z $LANE ]]; then
+    echo "Could not find lane number."
+    exit 1
+fi
+
+EPICS_MODULES=$(grep "^EPICS_MODULES.*" "$PARENT"/RELEASE_SITE | tail -1 | tr -d '[:space:]')
+EPICS_MODULES=${EPICS_MODULES#*=}
+
+ROGUEREGISTER_MODULE_VERSION=$(grep "^ROGUEREGISTER_MODULE_VERSION.*" "$PARENT"/configure/RELEASE | tail -1 | tr -d '[:space:]')
+ROGUEREGISTER_MODULE_VERSION=${ROGUEREGISTER_MODULE_VERSION#*=}
+
+ROGUE_DIR=$(grep "^ROGUE_DIR.*" "$EPICS_MODULES"/rogueRegister/"$ROGUEREGISTER_MODULE_VERSION"/configure/CONFIG_SITE | tail -1 | tr -d '[:space:]')
+ROGUE_VERSION=$(echo "$ROGUE_DIR" | grep -Po 'v\d+.\d+.\d+')
+
+# copied from ioctool
+INFO=$(grep_ioc "$IOCNAME" all | grep "id:'$IOCNAME'")
+if [ -z "$INFO" ]; then
+    echo "$IOCNAME could not be found. Exiting..." >&2
+    exit 1
+fi
+HOST=$(echo "$INFO" | sed -n "s/^.*host: '\(\S*\)'.*$/\1/p")
+
+echo "PGP_LANE is $LANE."
+echo "Rogue version is $ROGUE_VERSION."
+echo "Host is $HOST."
+
+# shellcheck disable=SC2029
+ssh "$HOST" "$(typeset -f remote); ROGUE_VERSION=$ROGUE_VERSION DEVICE=$DEVICE IOCNAME=$IOCNAME WAVE8_REPO=$WAVE8_REPO LANE=$LANE FWPATH=$FWPATH READ_VERSION=$READ_VERSION remote"

--- a/scripts/pgpwave8_version.py
+++ b/scripts/pgpwave8_version.py
@@ -1,0 +1,37 @@
+import argparse
+
+import setupLibPaths  # noqa: F401
+import wave8 as w8
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-l",
+    type=int,
+    required=False,
+    default=0,
+    help="PGP lane number",
+)
+
+parser.add_argument(
+    "--dev",
+    type=str,
+    required=False,
+    default="/dev/datadev_0",
+    help="PGP device (default /dev/datadev_0)",
+)
+
+args = parser.parse_args()
+
+# Set base
+wave8Board = w8.Top(
+    dev=args.dev,
+    lane=args.l,
+    promLoad=True,
+    pollEn=False,
+    initRead=True,
+    timeout=5.0,
+)
+
+wave8Board.start()
+wave8Board.AxiVersion.printStatus()
+wave8Board.stop()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adding a script to upgrade a pgpwave8. Provided the iocname and mcs file with the new firmware, it will find the lane, rogue version, host, ssh to the host, activate the corresponding rogue environment, and use wave8LoadFpga.py to upgrade the firmware. If the ioc is running, it will be deactivated and reactivated. It can also get the current firmware from either the ioc or a helper python script. 

I am currently using /cds/home/t/tjohnson/trunk/workarea/wave8, but this repo should be checked out in a common area. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5609

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested reading the version with and without the ioc enabled and upgrading the firmware on ioc-las-crix-pgpw8-03. I think Tyler Johnson should also try test this so someone from the laser group can confirm that it works as expected and get familiar with the script. ioc-las-crix-pgpw8-02, ioc-las-ip1-pgpw8-01, and ioc-las-ip1-pgpw8-02 are all on version 0x2060000.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
README and usage

<!--
## Screenshots (if appropriate):
-->
![image](https://github.com/user-attachments/assets/a2a4d656-7310-495f-a5ec-3bd865caf669)
