### PR TITLE
BUG: fix second ami client start

### DIFF
--- a/scripts/startami
+++ b/scripts/startami
@@ -107,4 +107,5 @@ else
 fi
 
 echo "$ami_path""$amicmd"
-exec "$ami_path""$amicmd"&
+# shellcheck disable=SC2086
+$ami_path$amicmd &

--- a/scripts/startami
+++ b/scripts/startami
@@ -107,5 +107,4 @@ else
 fi
 
 echo "$ami_path""$amicmd"
-# shellcheck disable=SC2086
-$ami_path$amicmd &
+eval "$ami_path$amicmd &"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
startami fails when trying to get a second client

## Motivation and Context
Shell check forcing some changes that do not work. Revert and ignore shell check.

## How Has This Been Tested?
xpp-control as xppopr

## Where Has This Been Documented?
N/A

<!--
## Screenshots (if appropriate):
-->
