### PR TITLE
Fixing epicsarch bug on last alias not having a pv

### DIFF
--- a/scripts/epicsArchChecker
+++ b/scripts/epicsArchChecker
@@ -122,6 +122,8 @@ def read_file(filename):
                     else:
                         entries.append((key, pv, filename, lineNum))
                         key = ''
+            if key != '':
+                extraKeys.append((key, filename, keyline))
     except FileNotFoundError as errorDetail:
         print(filename, ' File not found!')
         print(errorDetail)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Probably should have included this in #219
I'm just checking if key is not empty after the for loop in read_file. If it is, that means we did not encounter a pv after the last alias, and it should be in extraKeys, but was not because the for loop only does so when it encounters the next key (a line that starts with * when key is not empty), which does not work on the last alias.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#220 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with variations of this arch file
```
*Port_0_MCP_Front
TMO:MPOD:01:M0:C0:VoltageMeasure ca

*Port_1_MCP_Front
#TMO:MPOD:01:M0:C1:VoltageMeasure ca

#test
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

<!--
## Screenshots (if appropriate):
-->
