### PR TITLE
grep_more_ioc improvements

### DIFF
--- a/scripts/grep_more_ioc
+++ b/scripts/grep_more_ioc
@@ -3,4 +3,4 @@
 # execute python script
 THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-/cds/group/pcds/pyps/conda/py39/envs/pcds-5.8.4/bin/python "${THIS_DIR}/grep_more_ioc.py" "$@"
+/cds/group/pcds/pyps/conda/py39/envs/pcds-5.9.1/bin/python "${THIS_DIR}/grep_more_ioc.py" "$@"

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -459,14 +459,14 @@ def main():
     if 'disable' not in df.columns:
         df['disable'] = df.index.size*[False]
     if 'disable' in df.columns:
-        df.disable.fillna(False, inplace=True)
+        df['disable'] = df['disable'].fillna(False).astype(bool)
 
     # Fill the NaN with empty strings for rarely used keys
     for _col in df.columns:
         if _col not in ['delay']:
-            df[_col].fillna('', inplace=True)
+            df[_col] = df[_col].fillna('')
         else:
-            df[_col].fillna(0, inplace=True)
+            df[_col] = df[_col].fillna(0)
 
     # check for the ignore_disabled flag
     if args.ignore_disabled is True:

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -457,7 +457,7 @@ def build_parser():
                         default=False,
                         help="Only print the results of the regex match. Like"
                         " 'grep -o'.")
-    search.add_argument('-n', '--no-color', action='store_true',
+    search.add_argument('-n', '--no_color', action='store_true',
                         default=False,
                         help="Don't wrap the search results with a color")
     return parser

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -559,13 +559,16 @@ def main():
         if not args.only_search:
             print_frame2term(df)
         check_search = []
+        _color = Fore.LIGHTRED_EX
+        if args.no_color:
+            _color = None
         for ioc, d in df.loc[:, ['id', 'dir']].values:
             target_dir = fix_dir(d)
             # Search for pattern after moving into the directory
             if args.search is not None:
                 search_result = (search_file(file=f'{target_dir}{ioc}.cfg',
                                              patt=args.search,
-                                             color_wrap=Fore.LIGHTRED_EX,
+                                             color_wrap=_color,
                                              quiet=args.quiet)
                                  .strip()
                                  )

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -13,6 +13,7 @@ import os.path
 import re
 import sys
 from shutil import get_terminal_size
+from typing import Optional
 
 import pandas as pd
 from colorama import Fore, Style

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -417,9 +417,16 @@ def build_parser():
     search.add_argument('-q', '--quiet', action='store_true', default=False,
                         help='Surpresses file warning for paths that do not'
                         + ' exist.')
-    search.add_argument('-o', '--only_search', action='store_true',
+    search.add_argument('-s', '--only_search', action='store_true',
                         default=False,
                         help="Don't print the dataframe, just search results.")
+    search.add_argument('-o', '--only_results', action='store_true',
+                        default=False,
+                        help="Only print the results of the regex match. Like"
+                        " 'grep -o'.")
+    search.add_argument('-n', '--no-color', action='store_true',
+                        default=False,
+                        help="Don't wrap the search results with a color")
     return parser
 
 ###############################################################################

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -51,7 +51,7 @@ def search_file(*, file: str, output: list = None,
     prefix: str, optional
         A str prefix to add to each line. The default is ''.
     result_only: str, optional
-        Whether to returnsonly the re.findall result instead of
+        Whether to return only the re.findall result instead of
         the whole line. The default is False.
     color_wrap: Fore, optional
         Color wrapping using Colorama.Fore. The default is None.

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -193,12 +193,12 @@ def fix_json(raw_data: str, keys: list[str] = None) -> list[str]:
         valid_keys = re.compile(r'|'.join([key + r'(?=\s?:\s?)'
                                            for key in DEF_IMGR_KEYS]))
         # additional expression for correctly catcing unquoted digits
-        valid_digits = re.compile(r'|'.join([r'(?<=\"' + key + r'\":)\s?\d+'
+        valid_digits = re.compile(r'|'.join([r'(?<=\"' + key + r'\":\s)\d+'
                                             for key in DEF_IMGR_KEYS]))
     else:
         valid_keys = re.compile(r'|'.join([key + r'(?=\s?:\s?)'
                                            for key in keys]))
-        valid_digits = re.compile(r'|'.join([r'(?<=\"' + key + r'\":)\s?\d+'
+        valid_digits = re.compile(r'|'.join([r'(?<=\"' + key + r'\":\s)\d+'
                                             for key in keys]))
     # clean empty rows and white space
     _temp = raw_data.replace(' ', '').strip()

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -33,6 +33,7 @@ pd.set_option("display.max_rows", 1000)
 
 def search_file(*, file: str, output: list = None,
                 patt: str = None, prefix: str = '',
+                result_only: bool = False,
                 quiet: bool = False, color_wrap: Fore = None) -> str:
     """
     Searches file for regex match and appends the result to a list,
@@ -48,6 +49,9 @@ def search_file(*, file: str, output: list = None,
         The regex pattern to search for. The default is None.
     prefix: str, optional
         A str prefix to add to each line. The default is ''.
+    result_only: str, optional
+        Whether to returnsonly the re.findall result instead of
+        the whole line. The default is False.
     color_wrap: Fore, optional
         Color wrapping using Colorama.Fore. The default is None.
     quiet: bool, optional
@@ -73,7 +77,14 @@ def search_file(*, file: str, output: list = None,
     with open(file, 'r', encoding='utf-8') as _f:
         for line in _f.readlines():
             if re.search(patt, line):
-                output.append(re.sub(patt, color + r'\g<0>' + reset, line))
+                if result_only:
+                    # only output the matches with colors wrapped
+                    # make sure to reformat into a single str
+                    _temp = ' '.join([color + match + reset
+                                     for match in re.findall(patt, line)])
+                    output.append(_temp+'\n')
+                else:
+                    output.append(re.sub(patt, color + r'\g<0>' + reset, line))
         return prefix + prefix.join(output)
 
 
@@ -590,6 +601,7 @@ def main():
             if args.search is not None:
                 search_result = (search_file(file=f'{target_dir}{ioc}.cfg',
                                              patt=args.search,
+                                             result_only=args.only_results,
                                              color_wrap=_color,
                                              quiet=args.quiet)
                                  .strip()


### PR DESCRIPTION
## Description
Fixed some bugs in `grep_more_ioc` and added some QOL on the search sub-parsers. I'm probably the only person using this tool, but it makes life livable in `las` given the sheer number of IOCs.

## Motivation and Context
Fixes #213 and #192 and improves functionality for piping output into other commands/scripts.

## How Has This Been Tested?
I have ran `../engineering_tools/grep_more_ioc` to use the changes in my fork and can successfully print all IOCs in all hutches, demonstrating #213 has fixed the issue I was seeing before when `Alias` procmngr keys included forbidden characters and digits that weren't being escaped correctly before reading the JSON.

I have also demonstrated that the new search subparser arguments work as expected:
![image](https://github.com/user-attachments/assets/f0e689b5-c6d8-4d8f-b82c-afca4c55e774)


## Where Has This Been Documented?
This PR.
It is important to add that I have redefined what the `-o` optional flag for `search` does:

Previously, `-o` was `--only_search`, meaning skip printing the `dataframe` for when you only care about the child ioc search results.

We now have the following options:
```
    search.add_argument('-s', '--only_search', action='store_true',
                        default=False,
                        help="Don't print the dataframe, just search results.")
    search.add_argument('-o', '--only_results', action='store_true',
                        default=False,
                        help="Only print the results of the regex match. Like"
                        " 'grep -o'.")
    search.add_argument('-n', '--no_color', action='store_true',
                        default=False,
                        help="Don't wrap the search results with a color")
```

So if you have any scripts built on the output of `grep_more_ioc <patt> <hutch> search -o <regex>` you need to update it to `grep_more_ioc <patt> <hutch> search -s <regex>`

<!--
## Screenshots (if appropriate):
-->
