### PR TITLE
Using epics7 env for rocky9 compatibility

### DIFF
--- a/scripts/motor-expert-screen
+++ b/scripts/motor-expert-screen
@@ -23,7 +23,7 @@ PREFIX=`echo $1 | cut -d . -f 1`
 source /reg/g/pcds/setup/epicsenv-7.0.3.1-2.0.sh
 export PCDS_EDMS=/reg/g/pcds/package/epics/3.14/screens/edm
 #export EDMDATAFILES=.:${PCDS_EDMS}/xps8:${PCDS_EDMS}/ims  # normal EDMDATAFILES line
-export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/cds/group/pcds/epics/ioc/common/smaract/R1.0.11/motorScreens:/cds/group/pcds/epics/ioc/common/mmc/R1.0.6/mmcScreens:/cds/group/pcds/epics/R7.0.3.1-2.0/modules/pcds_motion/R2.6.3
+export EDMDATAFILES=.:${PCDS_EDMS}/xps8:/reg/g/pcds/package/epics/3.14/ioc/common/ims/R2.2.3/imsScreens:/cds/group/pcds/epics/ioc/common/smaract/R1.0.11/motorScreens:/cds/group/pcds/epics/ioc/common/mmc/R1.0.6/mmcScreens:/cds/group/pcds/epics/R3.14.12-0.4.0/modules/pcds_motion/R2.5.0
 
 # this ldpathmunge gives access to xdotool for xpp-control, xpp-daq
 source /reg/g/pcds/setup/pathmunge.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
motor-expert-screen was using epicsenv-3.14.12.sh, but the oldest version of epics base available on rocky9 is 7.0.2, so motor-expert-screen will use that environment from now on

I also had to update how :PN motors are opened, because originally they executed a file that tried to activate the epics 3.14 environment. Now I am directly opening the screen with edm and I added the path to EDMDATAFILES

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-6842

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

<!--
## Screenshots (if appropriate):
-->
