### PR TITLE
grep_more_ioc fix pandas silent downcasting spam

### DIFF
--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -492,15 +492,19 @@ def main():
     # pad the disable column based on the grep_ioc output
     if 'disable' not in df.columns:
         df['disable'] = df.index.size*[False]
-    if 'disable' in df.columns:
-        df['disable'] = df['disable'].fillna(False).astype(bool)
+    # handle stupid pandas 3.0 future warnings early
+    with pd.option_context('future.no_silent_downcasting', True):
+        if 'disable' in df.columns:
+            df['disable'] = (df['disable'].infer_objects().fillna(False))
 
     # Fill the NaN with empty strings for rarely used keys
-    for _col in df.columns:
-        if _col not in ['delay']:
-            df[_col] = df[_col].fillna('')
-        else:
-            df[_col] = df[_col].fillna(0)
+    # handle stupid pandas 3.0 future warnings early
+    with pd.option_context('future.no_silent_downcasting', True):
+        for _col in df.columns:
+            if _col not in ['delay']:
+                df[_col] = df[_col].infer_objects().fillna('')
+            else:
+                df[_col] = df[_col].infer_objects().fillna(0)
 
     # check for the ignore_disabled flag
     if args.ignore_disabled is True:


### PR DESCRIPTION
## Description
Small fix to close #224 spamming terminal with the future warnings. Kind of a weird problem for these calls in pandas, take a look at https://github.com/pandas-dev/pandas/issues/57734 if you're interested.

## Motivation and Context
Wanted to fix the warning spam and stay ahead of changes

## How Has This Been Tested?
Have ran `grep_more_ioc` locally on my branch and confirmed the spam goes away and the script works as intended:
![image](https://github.com/user-attachments/assets/4fdbf81f-f643-4690-938d-2ebe7ab18ba0)
![image](https://github.com/user-attachments/assets/82871e48-3e58-4f8f-990b-a64f1a819c4e)


## Where Has This Been Documented?
This PR

