### PR TITLE
drp node bypass for UED machines

### DIFF
--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -124,7 +124,13 @@ else
     PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 fi
 
-IS_DAQ_HOST=$(netconfig search "$AIMHOST"-$DAQNETWORK --brief | grep -c $DAQNETWORK)
+# If UED machine; bypass drp node requirement, else; check for drp node
+if [ "$HUTCH" == "ued" ]; then
+    IS_DAQ_HOST=1
+else
+    IS_DAQ_HOST=$(netconfig search "$AIMHOST"-$DAQNETWORK --brief | grep -c $DAQNETWORK)
+fi
+
 if [ "$IS_DAQ_HOST" == 0 ]; then
     HOSTS=$(netconfig search "$HUTCH"-*-$DAQNETWORK --brief | sed s/-$DAQNETWORK//g)
     WORKINGHOSTS=''


### PR DESCRIPTION
## Description
`restartdaq` command did not function on UED machines as it would request a drp node which was an LCLS-II requirement with a network connection to the drp-network. UED has a stand-a-lone server (ued-cmp002) and no DRP-network. This has been fixed by checking the hostname for the string "ued" before executing a drp check. Similar code has been used in CXI.

## How Has This Been Tested?
DAQ has been restarted through ued-daq computer using the included version of `restartdaq` without issue on 26 November 2024. Tested separately by Ian Roque (iroque) and Patrick Oppermann (opperman).

## Where Has This Been Documented?
Comments have been included in `restartdaq`.