### PR TITLE
Enh/ued takepeds

### DIFF
--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -15,20 +15,43 @@ if [[($1 == "--help") || ($1 == "-h")]]; then
         exit 0
 fi
 
-DAQ_RELEASE=/cds/group/pcds/dist/pds/current
-
-# -R: for norecord , -r forces recording
-station=$(get_info --getstation)
-$DAQ_RELEASE/tools/scanning/take_pedestals -p $station -r
-
-elogMessage="DARK"
-source pcds_conda
-PYCMD=LogBookPost
-
 EXP=`get_curr_exp`
-RUN=`get_lastRun`
 HUTCH=${EXP:0:3}
-echo $PYCMD -i "${HUTCH^^}" -u `whoami` -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"
-$PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"&
 
-echo 'Please call: makepeds -q milano -r '`get_lastRun`' -u <userID>'
+#SIT_ENV_DIR="/sdf/group/lcls/ds/ana/sw"
+SIT_ENV_DIR="/cds/group/psdm/sw"
+
+LCLS2_HUTCHES="rix, tmo, ued"
+HUTCH=$(get_info --gethutch)
+if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+    echo "This is a LCLS-II experiment"
+    
+    SIT_ENV_DIR=$SIT_ENV_DIR'/conda2/'
+    LCLS2=1
+    if [[ ${HUTCH} =~ 'ued' ]]; then
+        source $SIT_ENV_DIR/manage/bin/psconda.sh
+        epixquad_pedestal_scan --record 1 --hutch ued
+    fi
+else
+    echo "This is a LCLS-I experiment"
+    SIT_ENV_DIR=$SIT_ENV_DIR'/conda1/'
+    DAQ_RELEASE=/cds/group/pcds/dist/pds/current
+
+    # -R: for norecord , -r forces recording
+    station=$(get_info --getstation)
+    $DAQ_RELEASE/tools/scanning/take_pedestals -p $station -r
+fi
+
+if [ $? -eq 0 ]; then
+    elogMessage="DARK"
+    source pcds_conda
+    PYCMD=LogBookPost
+
+    RUN=`get_lastRun`
+    echo $PYCMD -i "${HUTCH^^}" -u `whoami` -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"
+    $PYCMD -i "${HUTCH^^}" -u `whoami` -p pcds -e "$EXP"  -t DARK  -r $RUN -m "$elogMessage"&
+
+    echo 'Please call: makepeds -q milano -r '`get_lastRun`' -u <userID>'
+else
+    echo 'takepeds failed, make sure the DAQ is setup appropriately!'
+fi

--- a/scripts/wherepsana
+++ b/scripts/wherepsana
@@ -11,7 +11,9 @@ OPTIONS:
 -h Show usage
 -c Pick a specific DAQ config file rather than automatically selecting
 current hutch's file
--d Also show information about dss node mapping
+-d Also show information about dss node mapping for psana
+-a also show nodes for ami1/ami2
+-e show detailed information for psana and ami1/ami2
 EOF
 }
 
@@ -33,7 +35,7 @@ if [ -z $FOUNDHUTCH ]; then
 fi
 NOTRUNNING='Not running'
 
-while getopts "c:d" OPTION
+while getopts "c:dae" OPTION
 do
     case "$OPTION" in
 	c)
@@ -41,6 +43,13 @@ do
 	    ;;
 	d)
 	    DETAIL="1"
+	    ;;
+	a)
+	    AMI="1"
+	    ;;
+	e)
+	    DETAIL="1"
+            AMI="1"
 	    ;;
 	?)
 	    usage
@@ -73,6 +82,8 @@ fi
 /reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/$HUTCH/scripts/$CONFIG > /tmp/procServStatus.$$
 
 PSANA_NODES=(`grep monreqsrvpsana /tmp/procServStatus.$$ | awk {'print $1'}`)
+AMI2_NODES=(`grep monreqsrvami2_ /tmp/procServStatus.$$ | awk {'print $1'}`)
+AMI1_NODES=(`grep monreqsrvami1_ /tmp/procServStatus.$$ | awk {'print $1'}`)
 
 if [[ -z $DETAIL ]]; then
     NODESTR=''
@@ -101,6 +112,58 @@ else
 	echo ""
     done
 
+fi
+
+if [[ $AMI ]]; then
+    if [[ -z $DETAIL ]]; then
+        NODESTR='ami1: '
+        for ((idx=0; idx<${#AMI1_NODES[@]}; ++idx)); do
+            NODESTR=$NODESTR${AMI1_NODES[idx]}',';
+        done
+        echo ${NODESTR::-1}
+        echo
+        NODESTR='ami2: '
+        for ((idx=0; idx<${#AMI2_NODES[@]}; ++idx)); do
+            NODESTR=$NODESTR${AMI2_NODES[idx]}',';
+        done
+        echo ${NODESTR::-1}
+    else
+        AMI1_MASKS=(`grep monreqsrvami1_ /tmp/procServStatus.$$ | awk -F "-i " {'print $2'} | awk {'print $1'}`)
+        echo 'ami1 runs on the following nodes looking at event nodes out of '${#EVENT[@]}
+        NODESTR=''
+        for ((idx=0; idx<${#AMI1_NODES[@]}; ++idx)); do
+            echo -n ${AMI1_NODES[idx]}':'
+            MASKS=${AMI1_MASKS[idx]}
+	    for ((m=0; m<${#EVENT[@]}; ++m)); do
+	        if [ $((${MASKS}&${EVENT_MASKS[m]})) != 0 ]; then
+	            echo -n ' '${EVENT[m]}
+		    MASKS=$((${MASKS}&~${EVENT_MASKS[m]}))
+	        fi
+            done
+	    if [ ${MASKS} != '0' ]; then
+	        echo " MISSING MON MASK: "$MASKS
+	    fi
+	    echo ""
+        done
+
+        AMI2_MASKS=(`grep monreqsrvami2_ /tmp/procServStatus.$$ | awk -F "-i " {'print $2'} | awk {'print $1'}`)
+        echo 'ami2 runs on the following nodes looking at event nodes out of '${#EVENT[@]}
+        NODESTR=''
+        for ((idx=0; idx<${#AMI2_NODES[@]}; ++idx)); do
+            echo -n ${AMI2_NODES[idx]}':'
+            MASKS=${AMI2_MASKS[idx]}
+	    for ((m=0; m<${#EVENT[@]}; ++m)); do
+	        if [ $((${MASKS}&${EVENT_MASKS[m]})) != 0 ]; then
+	            echo -n ' '${EVENT[m]}
+		    MASKS=$((${MASKS}&~${EVENT_MASKS[m]}))
+	        fi
+            done
+	    if [ ${MASKS} != '0' ]; then
+	        echo " MISSING MON MASK: "$MASKS
+	    fi
+	    echo ""
+        done
+    fi
 fi
 
 rm  /tmp/procServStatus.$$


### PR DESCRIPTION
Adding the a script to take pedestals for the UED 360 Hz epix-quad to takepeds
## Description
Check if we are in an LCLS1 hutch (then call the previous scripts) or a new hutch (then for UED, call the new script)

## Motivation and Context
It is easier for UED staff to use commands they use at other instruments,

## How Has This Been Tested?
I checked that this does not break the old hutches in CXI

## Where Has This Been Documented?
here

In addition, I have added options to wherepsana to also show information for ami processes.