### PR TITLE
Adding txi to grep_ioc, quoting vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ optional arguments:<br/>
     <td>
 usage: grep_ioc KEYWORD [hutch]<br/>
         hutch can be any of:<br/>
-    xpp, xcs, cxi, mfx, mec, xrt, aux, det, fee, hpl, icl, las, lfe, tst, thz, all<br/>
+    xpp, xcs, cxi, mfx, mec, xrt, aux, det, fee, hpl, icl, las, lfe, tst, thz, txi, all<br/>
     If no hutch is specified, all hutches will be searched
     </td>
 </tr>

--- a/scripts/grep_ioc
+++ b/scripts/grep_ioc
@@ -5,7 +5,7 @@ usage: $0 <keyword> [hutch]
 
 greps hutch iocmanager config files for keyword
 hutch can be any of:
-xpp, xcs, cxi, mfx, mec, tmo, rix, xrt, aux, det, fee, hpl, icl, las, lfe, kfe, tst, thz, all
+xpp, xcs, cxi, mfx, mec, tmo, rix, xrt, aux, det, fee, hpl, icl, las, lfe, kfe, tst, thz, txi, all
 If no hutch is specified, all hutches will be searched
 EOF
 }
@@ -23,8 +23,8 @@ fi
 if [[ -z $2 ]]; then
     HUTCH="all"
 else
-    for hutchname in "xpp" "xcs" "cxi" "mfx" "mec" "tmo" "rix" "xrt" "aux" "det" "fee" "hpl" "icl" "las" "lfe" "kfe" "tst" "thz" "all"; do 
-        if [[ "${2}" == $hutchname ]]; then
+    for hutchname in "xpp" "xcs" "cxi" "mfx" "mec" "tmo" "rix" "xrt" "aux" "det" "fee" "hpl" "icl" "las" "lfe" "kfe" "tst" "thz" "txi" "all"; do
+        if [[ "${2}" == "$hutchname" ]]; then
             HUTCH=$hutchname
         fi
     done
@@ -35,6 +35,6 @@ else
     if [[ $HUTCH == "all" ]]; then
         grep -i "${1}" /reg/g/pcds/pyps/config/*/iocmanager.cfg
     else
-        grep -i "${1}" /reg/g/pcds/pyps/config/${HUTCH}/iocmanager.cfg
+        grep -i "${1}" /reg/g/pcds/pyps/config/"${HUTCH}"/iocmanager.cfg
     fi
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I added txi to the hutches available in grep_ioc
I quoted two variables that caused shellcheck globbing warnings (both for hutchnames which are always one word anyways)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was trying to use grep_ioc for txi and it said "incorrect hutch name given.  Enter hutch name in lower case (example: xpp)."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did grep_ioc "id" txi and it gave me all the id lines in the txi/iocmanager.cfg file instead of the above error.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I updated the list of hutches in the README.md entry for grep_ioc and the grep_ioc comment at the top of the file.

<!--
## Screenshots (if appropriate):
-->
