### PR TITLE
Fixing bug where host never thinks it has a fez interface

### DIFF
--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -79,7 +79,7 @@ done
 
 
 HOST_HAS_FEZ=$(netconfig search "$HOSTNAME"-fez --brief | wc -l)
-let HOST_HAS_FEZ-=1
+
 
 if [[ $# -lt 2 ]]; then
     if [[ $# -lt 1 ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Removed a decrement to HOST_HAS_FEZ made it always nonpositive, leading to a later if block thinking that hosts with a fez interface did not and not checking the the server's fez interface was pingable. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Meant to close #233 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
[kaushikm@mfx-daq ~]$ serverStat daq-xcs-dss06 status
ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
Cannot connect to daq-xcs-dss06-ipmi
daq-xcs-dss06 is a server with IP: 172.21.80.222 (ping success: 1), 172.21.25.34 (cannot ping from machine without fez)
cds interface is up
[kaushikm@mfx-daq ~]$ ssh^C
[kaushikm@mfx-daq ~]$ ping daq-xcs-dss06-fez
PING daq-xcs-dss06-fez.pcdsn (172.21.25.34) 56(84) bytes of data.
64 bytes from 172.21.25.34 (172.21.25.34): icmp_seq=1 ttl=63 time=0.110 ms
64 bytes from 172.21.25.34 (172.21.25.34): icmp_seq=2 ttl=63 time=0.135 ms
^C
--- daq-xcs-dss06-fez.pcdsn ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 0.110/0.122/0.135/0.016 ms
[kaushikm@mfx-daq ~]$ ./et/scripts/serverStat daq-xcs-dss06 status
ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
Cannot connect to daq-xcs-dss06-ipmi
daq-xcs-dss06 is a server with IP: 172.21.80.222 (ping success: 1), 172.21.25.34 (ping success: 1)
cds&fez interfaces are up
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

<!--
## Screenshots (if appropriate):
-->
n/a
