### PR TITLE
quoting for glob warning and using printf for newlines

### DIFF
--- a/scripts/archive-status
+++ b/scripts/archive-status
@@ -12,13 +12,12 @@ if [[ -z $1 ]]; then
     usage
     exit 1
 fi
-    
+
 if [[ ($1 == "--help") || ($1 == "-h") ]]; then
     usage
     exit 0
 fi
 
 result=$(curl -s "http://pscaa01.slac.stanford.edu:17665/mgmt/bpl/getPVStatus?pv=$1")
-echo
-echo $result | cut -d'{' -f2 | cut -d'}' -f1 | tr ',' '\n'
-echo
+formatted_result=$(echo "$result" | cut -d'{' -f2 | cut -d '}' -f1 | tr ',' '\n')
+printf "\n%s\n" "$formatted_result"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I should have included this with https://github.com/pcdshub/engineering_tools/pull/235 since I'm doing the same thing
I quote result before cutting and translating and store in a variable, printed with printf and newlines instead of bare echos


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
[kaushikm@psbuild-rhel7-02 scripts]$ ./archive-status SP1K1:MONO:MMS:M_PI:PLC:bAllEnable_RBV

"appliance":"pscaa01"
"pvName":"SP1K1:MONO:MMS:M_PI:PLC:bAllEnable_RBV"
"pvNameOnly":"SP1K1:MONO:MMS:M_PI:PLC:bAllEnable_RBV"
"status":"Paused"
[kaushikm@psbuild-rhel7-02 scripts]$ ./ar
archive-details  archive-resume   archive-status
[kaushikm@psbuild-rhel7-02 scripts]$ ./archive-status MFX:DG1:W8:01:Timing:RxLinkUp_RBV

"pvName":"MFX:DG1:W8:01:Timing:RxLinkUp_RBV"
"status":"Not being archived"
[kaushikm@psbuild-rhel7-02 scripts]$ ./arch
archive-details  archive-resume   archive-status
[kaushikm@psbuild-rhel7-02 scripts]$ ./archive-status LM1K2:INJ_DP1_TF1_FF1:Stats2:CentroidY_RBV

"lastRotateLogs":"Never"
"pvName":"LM1K2:INJ_DP1_TF1_FF1:Stats2:CentroidY_RBV"
"connectionState":"true"
"lastEvent":"Feb\/13\/2025 15:29:07 PST"
"samplingPeriod":"1.0"
"isMonitored":"false"
"connectionLastRestablished":"Never"
"connectionFirstEstablished":"Feb\/05\/2025 11:26:30 PST"
"connectionLossRegainCount":"0"
"status":"Being archived"
"appliance":"pscaa01"
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
