### PR TITLE
Camviewer only use config

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -33,7 +33,6 @@ CAMPVFULL=""
 VIEWERCFG="$2"
 # Match "-" or "_" or " ".
 NAME=$(echo "$1" | sed -e 's/-/ /g' -e 's/_/ /g' -e 's/ /[-_ ]/g')
-hutch=$(basename "$(dirname "$VIEWERCFG")")
 #
 # The story here:
 # See how many matches we have in the hutch.
@@ -46,7 +45,7 @@ hutch=$(basename "$(dirname "$VIEWERCFG")")
 #
 # Make a temp file with just the PVs and camera names that match.
 tmp=/tmp/cv.$$
-cat "$VIEWERCFG" | grep -i "$NAME" | grep -v '#' | awk -F, '{ if (split($hutch,a,";")==1) n=$hutch; else n=a[2]; gsub(" ","",n); gsub(" "," ",$4); printf "%s %s\n", n, $4; }' >$tmp
+cat "$VIEWERCFG" | grep -i "$NAME" | grep -v '#' | awk -F, '{ if (split($2,a,";")==1) n=$2; else n=a[2]; gsub(" ","",n); gsub(" "," ",$4); printf "%s %s\n", n, $4; }' >$tmp
 c=$(wc -l <$tmp)
 if [ "$c" -eq 0 ]; then
     echo "No match for $1 in $VIEWERCFG."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Removed trailing whitespace
In list_cams, only print what's in the current hutch's cfg (used with dash ell)
In name_to_pv, do not look through all the other cfgs if the camera isn't found in the current hutch's cfg

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-7235

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
