### PR TITLE
Shellcheck getcurrexp

### DIFF
--- a/scripts/get_curr_exp
+++ b/scripts/get_curr_exp
@@ -33,22 +33,22 @@ do
 done
 
 DIRTMP=$(dirname  "${BASH_SOURCE[0]}")
-DIR="$( cd $DIRTMP && pwd -P )"
+DIR="$( cd "$DIRTMP" && pwd -P )"
 PATH=$PATH:$DIR
 
-if [ $INSTRUMENT != 'xxx' ]; then
-    CURR_EXP=$(get_info --hutch ${INSTRUMENT^^} --exp)
+if [[ $INSTRUMENT != 'xxx' ]]; then
+    CURR_EXP=$(get_info --hutch "${INSTRUMENT^^}" --exp)
 else
     CURR_EXP=$(get_info --exp)
-    if [ $CURR_EXP == 'unknown_hutch' ]; then
+    if [[ $CURR_EXP == 'unknown_hutch' ]]; then
 	echo 'Cannot autodetermine hutch, for which hutch would you like to get this information? '
 	read -rt 5 hutch
-	if [ $hutch == '' ]; then
+	if [[ $hutch == '' ]]; then
 	    echo 'no response, will quit'
 	    exit 1
 	fi
-	CURR_EXP=$(get_info --hutch ${hutch^^} --exp)
+	CURR_EXP=$(get_info --hutch "${hutch^^}" --exp)
     fi
 fi
 
-echo $CURR_EXP
+echo "$CURR_EXP"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- I used the -r flag when trying to read in the hutch name. This stops blackslashes from escaping in the input string, which we don't need for hutch names
- I replaced legacy backticks with $() in four places
- Whitespace auto trimmed
- I used double brackets in if conditions to avoid the globbing warning, and elsewhere just used quotes. The things I quoted were a directory name, INSTRUMENT, hutch, and CURR_EXP,  all of which I think don't need to be globbed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
interactively
```
[kaushikm@psbuild-rhel7-01 scripts]$ ./get_curr_exp
Cannot autodetermine hutch, for which hutch would you like to get this information?
cxi
cxil1037623
[kaushikm@psbuild-rhel7-01 scripts]$ ./get_curr_exp -i mec
\mecl1040023
[kaushikm@psbuild-rhel7-01 scripts]$ ./get_curr_exp
Cannot autodetermine hutch, for which hutch would you like to get this information?
no response, will quit
[kaushikm@psbuild-rhel7-01 scripts]$ ./get_curr_exp -h
usage: ./get_curr_exp options

OPTIONS:
-l add live status
-i/H information for hutch (override autodetection)
[kaushikm@psbuild-rhel7-01 scripts]$ ssh rix-control
===============================================================================
This is a Federal computer system and is the property of the United States
Government. It is for authorized use only. Users (authorized or unauthorized)
have no explicit or implicit expectation of privacy.

By using this system you expressly consent to the terms and conditions in
https://www.slac.stanford.edu/comp/policy/use.html
===============================================================================
Last login: Tue Feb 11 18:31:07 2025 from psbuild-rhel7-01.slac.stanford.edu
  ____  _           _      _____     _____   _ __      __
 / __ \| |         / \    / ___ \ | |  __ \ | |\ \    / /
| (  \/| |        /   \  / /   \/ | | |__) || |  \ \/ /
 ===== ===       ======= ==  O    | |  _  / | |   >  <
/\__) || |____  / _____ \\ \___/\ | | | \ \ | |  / /\ \
\____/ |______|/_/     \_\\_____/ | |_|  \_\|_|/_/    \_\
 National Accelerator Laboratory  | Resonant Inelastic X-ray Scattering
[kaushikm@rix-control ~]$ cd et/scripts
[kaushikm@rix-control scripts]$ ./get_curr_exp
rixx1016923
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
