### PR TITLE
Shellcheck getlastrun

### DIFF
--- a/scripts/get_lastRun
+++ b/scripts/get_lastRun
@@ -52,7 +52,7 @@ if [ $AskLive -eq 1 ]; then
 	CURR_EXP=$(get_info --run --live)
 	if [[ $CURR_EXP == *'xxx'* ]]; then
 	    echo 'For which hutch would you like to get this information? '
-	    read hutch
+	    read -r hutch
 	    CURR_EXP=$(get_info --hutch "$hutch" --run --live)
 	fi
     fi
@@ -63,7 +63,7 @@ elif [ $Ended -eq 1 ]; then
 	CURR_EXP=$(get_info --run --ended)
 	if [[ $CURR_EXP == *'xxx'* ]]; then
 	    echo 'For which hutch would you like to get this information? '
-	    read hutch
+	    read -r hutch
 	    CURR_EXP=$(get_info --hutch "$hutch" --run --ended)
 	fi
     fi
@@ -77,7 +77,7 @@ else
     if [[ $NUM_RET_WORD == 1 ]]; then
 	if [[ $CURR_EXP == 'xxx' ]]; then
 	    echo 'For which hutch would you like to get this information? '
-	    read hutch
+	    read -r hutch
 	    CURR_EXP=$(get_info --hutch "$hutch" --run)
 	fi
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- pre-commit job to remove trailing whitespace
- Replacing lagacy backticks with $() in eleven places
- Putting the braces inside the single quotes when using awk so they aren't literal (https://www.shellcheck.net/wiki/SC1083)
- Using the r flag when reading in the hutch name since it doesn't need backslashes to escape anything in three places
- Stop globbing DIRTMP, INSTRUMENT, hutch, NUM_RET_WORD, and CURR_EXP using quotes or double brackets in if conditions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
[kaushikm@psbuild-rhel7-03 scripts]$ ./get_lastRun
unknown_hutch
[kaushikm@psbuild-rhel7-03 scripts]$ ssh cxi-control
===============================================================================
This is a Federal computer system and is the property of the United States
Government. It is for authorized use only. Users (authorized or unauthorized)
have no explicit or implicit expectation of privacy.

By using this system you expressly consent to the terms and conditions in
https://www.slac.stanford.edu/comp/policy/use.html
===============================================================================
Last login: Sat Feb  8 20:45:17 2025 from xcs-control.pcdsn
  ____  _           _      _____       _____ __      __ _
 / __ \| |         / \    / ___ \ |   / ___ \\ \    / /| |
| (  \/| |        /   \  / /   \/ |  / /   \/  \ \/ /  | |
 ===== ===       ======= ==  O    | | |         >  <   | |
/\__) || |____  / _____ \\ \___/\ |  \ \___/\  / /\ \  | |
\____/ |______|/_/     \_\\_____/ |   \_____//_/    \_\|_|
 National Accelerator Laboratory  | Coherent X-ray Imaging
[kaushikm@cxi-control ~]$ cd et/scripts/
[kaushikm@cxi-control scripts]$ ./get_lastRun
28
[kaushikm@cxi-control scripts]$ ./get_lastRun -H cxi
28
[kaushikm@cxi-control scripts]$ ./get_lastRun -i cxi
28
[kaushikm@cxi-control scripts]$ ssh rix-control
===============================================================================
This is a Federal computer system and is the property of the United States
Government. It is for authorized use only. Users (authorized or unauthorized)
have no explicit or implicit expectation of privacy.

By using this system you expressly consent to the terms and conditions in
https://www.slac.stanford.edu/comp/policy/use.html
===============================================================================
Last login: Mon Feb 24 23:57:13 2025 from psbuild-rhel7-01.slac.stanford.edu
  ____  _           _      _____     _____   _ __      __
 / __ \| |         / \    / ___ \ | |  __ \ | |\ \    / /
| (  \/| |        /   \  / /   \/ | | |__) || |  \ \/ /
 ===== ===       ======= ==  O    | |  _  / | |   >  <
/\__) || |____  / _____ \\ \___/\ | | | \ \ | |  / /\ \
\____/ |______|/_/     \_\\_____/ | |_|  \_\|_|/_/    \_\
 National Accelerator Laboratory  | Resonant Inelastic X-ray Scattering
[kaushikm@rix-control ~]$ cd et/scripts/
[kaushikm@rix-control scripts]$ ./get_lastRun -l
120
ended
[kaushikm@rix-control scripts]$ ./get_lastRun -l -H cxi
28
ended
[kaushikm@rix-control scripts]$ ./get_lastRun -l -i rix
120
ended
[kaushikm@rix-control scripts]$ ./get_lastRun -e
120
[kaushikm@rix-control scripts]$ ./get_lastRun -e -H rix
120
[kaushikm@rix-control scripts]$ ./get_lastRun -e -i cxi
28
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
