### PR TITLE
Shellcheck ioctool

### DIFF
--- a/scripts/ioctool
+++ b/scripts/ioctool
@@ -191,7 +191,7 @@ if [[ $NAME == *':'* ]]; then #we are assuming that PVs have a colon in them
 #2) If so, then search for ioc using grep_ioc
 #3) If that returns nothing, try converting the camera name to a PV and search for that
 #4) If neither of those produce results return "Did not find name anywhere"
-elif [[ $NAME == *'-'* || $NAME == *'_'* || ^[[:alnum:]]+$ ]]; then
+elif [[ $NAME == *'-'* || $NAME == *'_'* || $NAME =~ ^[[:alnum:]]+$ ]]; then
    INFO=$(grep_ioc "$NAME" all | grep "id:'$NAME'")
       if [ -z "$INFO" ]; then
          #echo "Hutch = $hutch"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- precommit to remove trailing whitespace
- in two places, replace pipe from grep to wc -l with grep -c
- disable warning for cd to iocpath because iocdir exits if iocpath is empty 
- line 194, the third or clause was `^[[:alnum:]]+$`, a regex string not being compared to anything and thus always being evaluated as true (since it's a non empty string). This was changed to be compared to NAME liek `$NAME =~ ^[[:alnum:]]+$`
- In two places we set a VIEWERCFG path, cat-ed the file and piped the output to grep - this was replaced by just using the path as the second argument to grep, getting rid of the variable assignments and cats
- Quoting ioc and $0 to avoid globbing. Neither the name of an ioc nor this script need to be globbed. For $0, it was being used as the -n argument to GETOPTS like `\'$0\'` which I think evaluates literally, so I replaced the \` to double quotes to evaluate to the script name. -n is supposed to be the program name to be used in error reporting https://linux.die.net/man/1/getopt
- Also for GETOPTS,  checked the exit code directly in the below if statement instead of using $?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H cxi ioc-cxi
No match for ioc-cxi
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool IOC:CXI
IOC:CXI is found in 147 places
Which ioc do you care about here? (press enter to exit)
ioc-cxi-1ms-newall-le
ioc-cxi-1ms-stand-ims
ioc-cxi-acr
ioc-cxi-acromag-evr
ioc-cxi-alv-01
ioc-cxi-bk-01
ioc-cxi-BK1
ioc-cxi-cspadPV
ioc-cxi-d51-epix
ioc-cxi-device-states
ioc-cxi-dg1-ims
ioc-cxi-dg1-pim-ims
ioc-cxi-dg2-bmmon
ioc-cxi-dg2-chiller
ioc-cxi-dg2-ipm-ims
ioc-cxi-dg2-newall-le
ioc-cxi-dg2-pfls-ims
ioc-cxi-dg2-pim-ims
ioc-cxi-dg2-stand-ims
ioc-cxi-dg3-bmmon
ioc-cxi-dg3-det-ims
ioc-cxi-dg3-dumb-ims
ioc-cxi-dg3-ipm-ims
ioc-cxi-dg3-newall-le
ioc-cxi-dg3-stand-ims
ioc-cxi-dg3-xfls-ims
ioc-cxi-dg4-ims
ioc-cxi-dg4-newall-le
ioc-cxi-dg4-stand-ims
ioc-cxi-dia-att-ims
ioc-cxi-dia-lusiAtt
ioc-cxi-dia-pfls-ims
ioc-cxi-ds1-dumb-ims
ioc-cxi-ds1-extra-ims
ioc-cxi-ds1-ims
ioc-cxi-ds1-ppenc-ims
ioc-cxi-ds1-stand-ims
ioc-cxi-ds2-ctr
ioc-cxi-ds2-dumb-ims
ioc-cxi-ds2-stand-ims
ioc-cxi-dsa-chiller
ioc-cxi-dsb-01-pico
ioc-cxi-dsb-ims
ioc-cxi-dsb-lusiAtt
ioc-cxi-dsc-chiller
ioc-cxi-dsd-chiller
ioc-cxi-epix-01
ioc-cxi-expstate
ioc-cxi-gige-03
ioc-cxi-gige-04
ioc-cxi-gige-05
ioc-cxi-gige-06
ioc-cxi-gige-07
ioc-cxi-gige-08
ioc-cxi-hmp01
ioc-cxi-hmp02
ioc-cxi-ipimb
ioc-cxi-jettrack
ioc-cxi-jf4m
ioc-cxi-jf4m-blocker
ioc-cxi-jf4m-ls336
ioc-cxi-jf4m-tripper
ioc-cxi-kb1-fmr-ims
ioc-cxi-kb2-fmr-ims
ioc-cxi-knob01
ioc-cxi-las-gige-01
ioc-cxi-las-gige-02
ioc-cxi-las-pico
ioc-cxi-las-xps
ioc-cxi-las-xps1
ioc-cxi-las-xps2
ioc-cxi-mandrel-01
ioc-cxi-mcb-ims
ioc-cxi-mcs2-01
ioc-cxi-mcs2-02
ioc-cxi-mcs2-usr01
ioc-cxi-mks670b
ioc-cxi-mmc-pp30-01
ioc-cxi-mmc-pp30-02
ioc-cxi-mmc-pp30-03
ioc-cxi-mmc-pp30-05
ioc-cxi-mmc-pp30-06
ioc-cxi-mmc-pp30-07
ioc-cxi-mmc-pp30-08
ioc-cxi-mmc-pr32-01
ioc-cxi-mmc-tst
ioc-cxi-navitar1-gige
ioc-cxi-pcdsdevices
ioc-cxi-pi3-ims
ioc-cxi-pico-usr1
ioc-cxi-pico-usr2
ioc-cxi-pp30-1axis-03
ioc-cxi-pp30-1axis-04
ioc-cxi-pp30-1axis-sc1
ioc-cxi-ppenc-ims
ioc-cxi-qadc
ioc-cxi-qadc134
ioc-cxi-rec01-evr
ioc-cxi-rec03-evr
ioc-cxi-rec04-evr
ioc-cxi-sc1-bmmon
ioc-cxi-sc1-ims
ioc-cxi-sc1-mmc
ioc-cxi-sc1-navitar-ims
ioc-cxi-sc1-pi1-ims
ioc-cxi-sc1-PMC100
ioc-cxi-sc2-01-pico
ioc-cxi-sc2-02-pico
ioc-cxi-sc2-ims
ioc-cxi-sc2-navitar-ims
ioc-cxi-sc2-pi2-ims
ioc-cxi-sc2-PMC100
ioc-cxi-sc2-pp30-4axis-01
ioc-cxi-sc2-pp30-4axis-02
ioc-cxi-sc3-ims
ioc-cxi-sc3-PMC100
ioc-cxi-slits-ims
ioc-cxi-smc100-01
ioc-cxi-spec-01
ioc-cxi-spec-02
ioc-cxi-thermotek-01
ioc-cxi-timetool-gige
ioc-cxi-tripper
ioc-cxi-tt
ioc-cxi-userPV
ioc-cxi-usr3-pico
ioc-cxi-usr4-pico
ioc-cxi-usr-bmmon
ioc-cxi-usr-dio
ioc-cxi-usr-dsb-ims
ioc-cxi-usr-dumb-ims
ioc-cxi-usr-hmp-01
ioc-cxi-usr-pico
ioc-cxi-usr-pmc100
ioc-cxi-usr-sc1-smart-ims
ioc-cxi-usr-sc2-dumb-ims
ioc-cxi-usr-sc2-smart-ims
ioc-cxi-usr-xps
ioc-cxi-usr-xps1
ioc-cxi-usr-xps2
ioc-cxi-usr-xps3
ioc-cxi-vacuum
ioc-cxi-xps-berg
ioc-cxi-xps-det2
ioc-cxi-xps-det3
ioc-cxi-xps-las2
ioc-cxi-xps-usr2

No ioc chosen. Exiting...
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H rix PAX01 cfg
No files found for ioc ioc-cam-pax-gige-01
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H rix PAX01
ioc-cam-pax-gige-01
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H xpp PAX01
ioc-cam-pax-gige-01
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H xcs spare
ioc-xcs-gige-spare
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H xcs as01
ioc-xcs-gige-las01
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool -H cxi as01
"as01" is ambiguous:
[kaushikm@psbuild-rhel7-03 scripts]$ ./ioctool --hutch xpp ioc-xpp-xyGraphTrigger cddir
Script is not being sourced. Start with 'source ./ioctool' before calling script with this option.
[kaushikm@psbuild-rhel7-03 scripts]$ source ./ioctool --hutch xpp ioc-xpp-xyGraphTrigger cddir
[kaushikm@psbuild-rhel7-03 R0.1.0]$ pwd
/reg/g/pcds/epics/ioc/xpp/xyGraphTrigger/R0.1.0
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
