### PR TITLE
add ued .cnf file

### DIFF
--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -12,6 +12,7 @@ OPTIONS:
 -s silent (do not email jana)
 -c enable core files
 -C (LCLS2 DAQMGR Hutches ONLY!) Select a cnf to use.
+-u UED .cnf file
 EOF
 }
 
@@ -31,7 +32,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 CORESIZE=0
-while getopts "m:pwscdC:" OPTION
+while getopts "m:pwscdCu:" OPTION
 do
     case $OPTION in
 	p)
@@ -49,6 +50,9 @@ do
  	c)
  	    CORESIZE=2000000000
  	    ;;
+	u)
+            UED_CNF=$OPTARG
+            ;;
   C)
       DAQMGR_CNF=$OPTARG
       ;;
@@ -127,6 +131,7 @@ fi
 # If UED machine; bypass drp node requirement, else; check for drp node
 if [ "$HUTCH" == "ued" ]; then
     IS_DAQ_HOST=1
+    CNFFILE=$UED_CNF
 else
     IS_DAQ_HOST=$(netconfig search "$AIMHOST"-$DAQNETWORK --brief | grep -c $DAQNETWORK)
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Ued needs the option to switch between two cnf files.
That's why there is now -u with the options andor.cnf and epix.cnf.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
