### PR TITLE
pkg_release: quoting TEST_OUTPUT, TAG, and TEMP

### DIFF
--- a/scripts/pkg_release
+++ b/scripts/pkg_release
@@ -42,12 +42,12 @@ if ! ping -c 1 github.com &> /dev/null; then
 fi
 echo "Connection successful."
 TEST_OUTPUT=$(ssh -Tx git@github.com 2>&1) # Test ssh key with github and use ssh if appropriate, https otherwise
-if echo $TEST_OUTPUT | grep "successfully authenticated" > /dev/null; then
+if echo "$TEST_OUTPUT" | grep "successfully authenticated" > /dev/null; then
   echo "Attemping clone using SSH..."
   echo "URL = $SSH_URL"
   set -e  # Catch error in git clone
   git clone "${SSH_URL}" "${TEMP}"
-elif echo $TEST_OUTPUT | grep "Permission denied\|no kex alg" > /dev/null; then
+elif echo "$TEST_OUTPUT" | grep "Permission denied\|no kex alg" > /dev/null; then
   echo "Attemping clone using HTTPS..."
   echo "URL = $URL"
   set -e  # Catch error in git clone
@@ -61,7 +61,7 @@ echo "Checking out tag..."
 pushd "${TEMP}"
 git tag -l | grep "${TAG}" >/dev/null
 if [ "${?}" == "1" ]; then
-  echo "Error: could not find tag "${TAG}". Aborting."
+  echo "Error: could not find tag ${TAG}. Aborting."
   echo "Available tags:"
   git tag -l
   exit
@@ -69,8 +69,8 @@ fi
 set -e  # Catch error in git checkout
 git checkout "${TAG}"
 popd
-echo "Renaming "${TEMP}" directory to ${TAG}"
+echo "Renaming ${TEMP} directory to ${TAG}"
 mv "${TEMP}" "${TAG}"
 echo "Write-protecting directory..."
 chmod -R a-w "${TAG}"
-echo "Created $(readlink -f ${TAG})"
+echo "Created $(readlink -f "${TAG}")"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- quoted TEST_OUTPUT in two places - it's a string like "Hi KaushikMalapati! You've successfully authenticated, but GitHub does not provide shell access." which is grepped through 
- put TAG directly in quotes and quoted TAG in one place - git tag, cannot have spaces
- put TEMP directly in quotes, it's always the string "pkg_release_tempdir"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
[kaushikm@psbuild-rhel7-02 scripts]$ git branch
  master
* shellcheck-pkg_release
[kaushikm@psbuild-rhel7-02 scripts]$ ./pkg_release engineering_tools R3.13.3
Testing connection to github.com
Connection successful.
Attemping clone using SSH...
URL = git@github.com:pcdshub/engineering_tools
Cloning into 'pkg_release_tempdir'...
remote: Enumerating objects: 5374, done.
remote: Counting objects: 100% (974/974), done.
remote: Compressing objects: 100% (378/378), done.
remote: Total 5374 (delta 673), reused 624 (delta 596), pack-reused 4400 (from 3)
Receiving objects: 100% (5374/5374), 1.07 MiB | 4.11 MiB/s, done.
Resolving deltas: 100% (3564/3564), done.
Updating files: 100% (91/91), done.
Checking out tag...
~/et/scripts/pkg_release_tempdir ~/et/scripts
Note: switching to 'R3.13.3'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 687e270 Merge pull request #250 from patoppermann/master
~/et/scripts
Renaming pkg_release_tempdir directory to R3.13.3
Write-protecting directory...
Created /cds/home/k/kaushikm/et/scripts/R3.13.3
[kaushikm@psbuild-rhel7-02 scripts]$ ls -ltr
total 560
-rwxrwxr-x 1 kaushikm gu 11647 Nov 19 15:31 BLmotors
lrwxrwxrwx 1 kaushikm gu    17 Nov 19 15:31 afs-remote-fix -> afs_remote_fix.py
-rwxrwxr-x 1 kaushikm gu  1920 Nov 19 15:31 afs_remote_fix.py
-rwxrwxr-x 1 kaushikm gu   116 Nov 19 15:31 archive-details
-rw-rw-r-- 1 kaushikm gu  1968 Nov 19 15:31 archive-details.py
-rw-rw-r-- 1 kaushikm gu  1086 Nov 19 15:31 constants.py
-rw-rw-r-- 1 kaushikm gu  6761 Nov 19 15:31 daq_utils.py
-rwxrwxr-x 1 kaushikm gu   202 Nov 19 15:31 daqutils
-rwxrwxr-x 1 kaushikm gu  6464 Nov 19 15:31 detector_totals.py
-rw-rw-r-- 1 kaushikm gu 13864 Nov 19 15:31 deviceDict.json
-rwxrwxr-x 1 kaushikm gu  1884 Nov 19 15:31 elog_par_post
-rwxrwxr-x 1 kaushikm gu 10914 Nov 19 15:31 epicsArchChecker
-rwxrwxr-x 1 kaushikm gu  2045 Nov 19 15:31 epix_gains
-rwxrwxr-x 1 kaushikm gu 13084 Nov 19 15:31 evrStatus
-rwxrwxr-x 1 kaushikm gu   192 Nov 19 15:31 getPVAliases
-rw-rw-r-- 1 kaushikm gu 12795 Nov 19 15:31 getPVAliases.py
-rwxrwxr-x 1 kaushikm gu   445 Nov 19 15:31 get_info
-rw-rw-r-- 1 kaushikm gu  8879 Nov 19 15:31 get_info.py
-rw-rw-r-- 1 kaushikm gu  2170 Nov 19 15:31 hdf5_to_gif.py
-rwxrwxr-x 1 kaushikm gu 13047 Nov 19 15:31 image_saver
-rwxrwxr-x 1 kaushikm gu   707 Nov 19 15:31 ioc-deploy
-rw-rw-r-- 1 kaushikm gu 38148 Nov 19 15:31 ioc_deploy.py
-rwxrwxr-x 1 kaushikm gu  1749 Nov 19 15:31 iocmanager
-rwxrwxr-x 1 kaushikm gu   946 Nov 19 15:31 motor-typhos
-rwxrwxr-x 1 kaushikm gu  1603 Nov 19 15:31 new_bare_repo
-rwxrwxr-x 1 kaushikm gu  4020 Nov 19 15:31 pcds_conda
drwxrwxr-x 1 kaushikm gu     0 Nov 19 15:31 pfeiffer_serial_tools
-rwxrwxr-x 1 kaushikm gu  5601 Nov 19 15:31 pgpwave8_upgrade
-rw-rw-r-- 1 kaushikm gu   611 Nov 19 15:31 pgpwave8_version.py
-rwxrwxr-x 1 kaushikm gu   482 Nov 19 15:31 pmgr
-rwxrwxr-x 1 kaushikm gu   509 Nov 19 15:31 pydev_env
-rwxrwxr-x 1 kaushikm gu   629 Nov 19 15:31 pydev_register
-rwxrwxr-x 1 kaushikm gu  4621 Nov 19 15:31 pyps-deploy
-rwxrwxr-x 1 kaushikm gu 10983 Nov 19 15:31 questionnaire_tools
-rw-rw-r-- 1 kaushikm gu  1525 Nov 19 15:31 run_daq_utils.py
-rwxrwxr-x 1 kaushikm gu    64 Nov 19 15:31 spyder
-rw-rw-r-- 1 kaushikm gu  2131 Nov 19 15:31 ssh-agent-helper
-rwxrwxr-x 1 kaushikm gu  3281 Nov 19 15:31 startami
-rwxrwxr-x 1 kaushikm gu  1277 Nov 19 15:31 stopami
-rwxrwxr-x 1 kaushikm gu  1280 Nov 19 15:31 wheredaq
-rwxrwxr-x 1 kaushikm gu    88 Nov 19 15:31 xpp_update_happi_line
-rw-rw-r-- 1 kaushikm gu  3504 Nov 19 15:31 xpp_update_happi_line.py
-rwxrwxr-x 1 kaushikm gu  3632 Nov 19 16:08 ami_offline_psana
-rwxrwxr-x 1 kaushikm gu  1709 Nov 19 16:08 configdb_readxtc
-rwxrwxr-x 1 kaushikm gu   165 Nov 19 16:08 daq_control
-rwxrwxr-x 1 kaushikm gu   683 Nov 19 16:08 daq_waitwin
-rwxrwxr-x 1 kaushikm gu   300 Nov 19 16:08 get_hutch_name
-rwxrwxr-x 1 kaushikm gu   580 Nov 19 16:08 grep_pv
-rwxrwxr-x 1 kaushikm gu  2200 Nov 19 16:08 imgr
-rwxrwxr-x 1 kaushikm gu  1038 Nov 19 16:08 kinit_helper
-rwxrwxr-x 1 kaushikm gu  4041 Nov 19 16:08 motorInfo
-rwxrwxr-x 1 kaushikm gu  2227 Nov 19 16:08 set_gem_timing
-rwxrwxr-x 1 kaushikm gu  1860 Nov 19 16:08 stopdaq
-rwxrwxr-x 1 kaushikm gu   521 Nov 19 16:08 verify-hutch
-rwxrwxr-x 1 kaushikm gu   193 Nov 25 17:03 grep_more_ioc
-rw-rw-r-- 1 kaushikm gu 24541 Nov 25 17:03 grep_more_ioc.py
-rwxrwxr-x 1 kaushikm gu  1776 Dec  4 19:08 dev_conda
-rwxrwxr-x 1 kaushikm gu  3489 Feb  2 22:04 startami2
-rwxrwxr-x 1 kaushikm gu  1429 Feb  2 22:04 takepeds
-rwxrwxr-x 1 kaushikm gu  4706 Feb  2 22:04 wherepsana
-rwxrwxr-x 1 kaushikm gu   995 Feb  5 18:05 grep_ioc
-rwxrwxr-x 1 kaushikm gu  5507 Feb  8 23:35 motor-expert-screen
-rwxrwxr-x 1 kaushikm gu   454 Feb 17 22:13 archive-resume
-rwxrwxr-x 1 kaushikm gu   451 Feb 17 22:13 getAllEvrFWVersions
-rwxrwxr-x 1 kaushikm gu   435 Feb 17 22:13 getAllTprFWVersions
-rwxrwxr-x 1 kaushikm gu 10483 Feb 17 22:13 serverStat
-rwxrwxr-x 1 kaushikm gu   451 Feb 18 10:47 archive-status
-rwxrwxr-x 1 kaushikm gu   963 Feb 19 00:01 checkcnf
-rwxrwxr-x 1 kaushikm gu  2528 Feb 25 11:34 eloggrabber
-rwxrwxr-x 1 kaushikm gu  9164 Feb 25 11:34 makepeds
-rwxrwxr-x 1 kaushikm gu   928 Mar  1 00:38 get_curr_exp
-rwxrwxr-x 1 kaushikm gu  1720 Mar  1 00:38 get_lastRun
-rwxrwxr-x 1 kaushikm gu 10354 Mar  1 00:39 camViewer
-rwxrwxr-x 1 kaushikm gu  8941 Mar  1 00:39 ioctool
-rwxrwxr-x 1 kaushikm gu  8778 Mar 18 13:37 ipmConfigEpics
-rwxrwxr-x 1 kaushikm gu 31335 Mar 18 13:37 makepeds_psana
-rwxrwxr-x 1 kaushikm gu 18810 Mar 18 13:37 makepeds_psana2
-rwxrwxr-x 1 kaushikm gu  7124 Mar 18 13:37 restartdaq
-rwxrwxr-x 1 kaushikm gu  2168 Mar 18 13:47 pkg_release
dr-xr-xr-x 1 kaushikm gu     0 Mar 18 14:33 R3.13.3
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
