### PR TITLE
quoting vars, ignoring cd warnings, removing whitespace

### DIFF
--- a/scripts/grep_pv
+++ b/scripts/grep_pv
@@ -16,21 +16,24 @@ fi
 KEYWORD=$1
 
 if [[ -n $KEYWORD ]]; then
+    # shellcheck disable=SC2164
     cd /reg/d/iocData/
-    for i in ioc-*; do 
-	cd /reg/d/iocData/$i
+    for i in ioc-*; do
+	# shellcheck disable=SC2164
+	cd /reg/d/iocData/"$i"
 	if [ -e ./iocInfo/ ] ; then
+	    # shellcheck disable=SC2164
      	    cd iocInfo
 	    if [ -e ./IOC.pvlist ] ; then
-		if grep -q $KEYWORD IOC.pvlist
-		then 
+		if grep -q "$KEYWORD" IOC.pvlist
+		then
 		    pwd
-		    grep $KEYWORD IOC.pvlist;
+		    grep "$KEYWORD" IOC.pvlist;
 		    echo ""
 		else
 		    :
 		fi
-	    fi 
+	    fi
 	fi
 	cd ../../
     done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- disabling three shellcheck warnings about entering /reg/d/iocData/, a specific ioc's directory within that, and the iocInfo directory within that
- quoting the variable i, which is a directory within /reg/d/iocData/ and doesn't need globbing
- quoting KEYWORD in two places, which is the argument passed to grep 

Arguably I shouldn't have ignored the cd into /reg/d/iocData because there's a chance that you are not on a host with the iocData mount. I can add a check for the directory if you think it's a good idea.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./grep_pv TST:INTERLOCK
/reg/d/iocData/ioc-tst-alias/iocInfo
TST:INTERLOCK:X:ARTIFICIAL:2, "scalcout"
TST:INTERLOCK:X:ARTIFICIAL:1, "ao"
TST:INTERLOCK:X:ALIAS, "ao"

(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ grep_pv TST:INTERLOCK
/reg/d/iocData/ioc-tst-alias/iocInfo
TST:INTERLOCK:X:ARTIFICIAL:2, "scalcout"
TST:INTERLOCK:X:ARTIFICIAL:1, "ao"
TST:INTERLOCK:X:ALIAS, "ao"

(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./grep_pv TST:INT*
/reg/d/iocData/ioc-tst-alias/iocInfo
TST:INTERLOCK:X:ARTIFICIAL:2, "scalcout"
TST:INTERLOCK:X:ARTIFICIAL:1, "ao"
TST:INTERLOCK:X:ALIAS, "ao"

/reg/d/iocData/ioc-tst-try-deploy/iocInfo
TST:INT, "longout"

(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ grep_pv TST:INT*
/reg/d/iocData/ioc-tst-alias/iocInfo
TST:INTERLOCK:X:ARTIFICIAL:2, "scalcout"
TST:INTERLOCK:X:ARTIFICIAL:1, "ao"
TST:INTERLOCK:X:ALIAS, "ao"

/reg/d/iocData/ioc-tst-try-deploy/iocInfo
TST:INT, "longout"

(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ time ./grep_pv TST:INT*
/reg/d/iocData/ioc-tst-alias/iocInfo
TST:INTERLOCK:X:ARTIFICIAL:2, "scalcout"
TST:INTERLOCK:X:ARTIFICIAL:1, "ao"
TST:INTERLOCK:X:ALIAS, "ao"

/reg/d/iocData/ioc-tst-try-deploy/iocInfo
TST:INT, "longout"


real    0m10.107s
user    0m1.220s
sys     0m5.501s
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ time grep_pv TST:INT*
/reg/d/iocData/ioc-tst-alias/iocInfo
TST:INTERLOCK:X:ARTIFICIAL:2, "scalcout"
TST:INTERLOCK:X:ARTIFICIAL:1, "ao"
TST:INTERLOCK:X:ALIAS, "ao"

/reg/d/iocData/ioc-tst-try-deploy/iocInfo
TST:INT, "longout"


real    0m10.733s
user    0m1.330s
sys     0m5.730s
```

If you tried providing two args to grep_pv, it would use the second as another search location instead of part of the search string which is assume is an unlikely bug since you pvs don't have spaces anyways.
```
[kaushikm@psbuild-rhel7-02 scripts]$ grep_pv "TMO VAC"
grep: VAC: No such file or directory
/reg/d/iocData/ioc-ArbiterPLC/iocInfo
grep: VAC: No such file or directory
IOC.pvlist:PMPS:KFE:PVA_CONN_TMO, "stringin"

grep: VAC: No such file or directory
/reg/d/iocData/ioc-at1k4-gige/iocInfo
grep: VAC: No such file or directory
IOC.pvlist:AT1K4:PPM:CAM:IOC:PVA_CONN_TMO, "stringin"
... (truncated for brevity)
``` 

```
[kaushikm@psbuild-rhel7-02 scripts]$ ./grep_pv "TMO VAC"
[kaushikm@psbuild-rhel7-02 scripts]$
```


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
