### PR TITLE
Output when duplicate/missing aliases/PVs are not found

### DIFF
--- a/scripts/epicsArchChecker
+++ b/scripts/epicsArchChecker
@@ -291,7 +291,7 @@ def report_warnings(extraKeys, noKeyPVs):
 
 
 def report_statusPV(myKeys, myPVs, myFiles):
-    """This function will display the no connected PVs."""
+    """This function will display the unconnected PVs."""
     totalInfo = []
     for pv in range(len(myPVs)):
         statusPV = []
@@ -299,7 +299,7 @@ def report_statusPV(myKeys, myPVs, myFiles):
             ophyd.signal.EpicsSignal(myPVs[pv]).get()
         except Exception:
             statusPV.append(myPVs[pv])
-            statusPV.append("No connected!")
+            statusPV.append("Not connected!")
             statusPV.append(myKeys[pv])
             statusPV.append(myFiles[pv])
         if statusPV:
@@ -307,7 +307,7 @@ def report_statusPV(myKeys, myPVs, myFiles):
     if totalInfo:
         sortedList = sorted(totalInfo, key=lambda x: x[3])
         table = PrettyTable()
-        print("PVs NO connected:")
+        print("PVs not connected:")
         table.field_names = ["PV Name", "Status", "Alias", "Location"]
         table.add_rows(sortedList)
         print(table)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I added output for successful checks
- No duplicate aliases found.
- No duplicate PVs found
- No aliases withouts PVs found
- No PVs without aliases found.
- Everything looks great!

I also found that the script sourced for epicsArchVerify doesn't work anymore. I will make an issue for that. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-7449
https://slac.slack.com/archives/C03D4JT7U15/p1742596232013779

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
arch file without any errors
[kaushikm@psbuild-rhel7-01 scripts]$ time ./epicsArchChecker /reg/g/pcds/dist/pds/cxi/misc/epicsArch.txt
epicsArch_machine.txt
epicsArch_CXI_sequencer.txt
epicsArch_CXI_vacuum.txt
epicsArch_CXI_beamline.txt
epicsArch_CXI_gasPhase.txt
epicsArch_CXI_EVRlaser.txt
epicsArch_CXI_laser.txt
epicsArch_CXI_DS1.txt
epicsArch_CXI_PI3.txt
epicsArch.txt
No duplicate aliases found.
No duplicate PVs found.
No aliases withouts PVs found.
No PVs without aliases found.
Everything looks great!

real    0m2.366s
user    0m1.099s
sys     0m0.332s
[kaushikm@psbuild-rhel7-01 scripts]$ time epicsArchChecker /reg/g/pcds/dist/pds/cxi/misc/epicsArch.txt
epicsArch_machine.txt
epicsArch_CXI_sequencer.txt
epicsArch_CXI_vacuum.txt
epicsArch_CXI_beamline.txt
epicsArch_CXI_gasPhase.txt
epicsArch_CXI_EVRlaser.txt
epicsArch_CXI_laser.txt
epicsArch_CXI_DS1.txt
epicsArch_CXI_PI3.txt
epicsArch.txt

real    0m2.619s
user    0m1.079s
sys     0m0.357s
[kaushikm@psbuild-rhel7-01 scripts]$ time ./epicsArchChecker -s /reg/g/pcds/dist/pds/cxi/misc/epicsArch.txt
epicsArch_machine.txt
epicsArch_CXI_sequencer.txt
epicsArch_CXI_vacuum.txt
epicsArch_CXI_beamline.txt
epicsArch_CXI_gasPhase.txt
epicsArch_CXI_EVRlaser.txt
epicsArch_CXI_laser.txt
epicsArch_CXI_DS1.txt
epicsArch_CXI_PI3.txt
epicsArch.txt
No duplicate aliases found.
No duplicate PVs found.
No aliases withouts PVs found.
No PVs without aliases found.
All the PVs are connected!
Everything looks great!

real    0m11.698s
user    0m3.780s
sys     0m0.786s
[kaushikm@psbuild-rhel7-01 scripts]$ time epicsArchChecker -s /reg/g/pcds/dist/pds/cxi/misc/epicsArch.txt
epicsArch_machine.txt
epicsArch_CXI_sequencer.txt
epicsArch_CXI_vacuum.txt
epicsArch_CXI_beamline.txt
epicsArch_CXI_gasPhase.txt
epicsArch_CXI_EVRlaser.txt
epicsArch_CXI_laser.txt
epicsArch_CXI_DS1.txt
epicsArch_CXI_PI3.txt
epicsArch.txt
All the PVs are connected!

real    0m12.647s
user    0m3.705s
sys     0m0.672s
```
```
[kaushikm@psbuild-rhel7-01 scripts]$ ./epicsArchChecker ~/cxi/epics_CXI_Cameras.txt
epics_CXI_Cameras.txt
No duplicate aliases found.
No duplicate PVs found.
Aliases with no pv, WARNING!!!!:
+---------------+-----------------------+-------------------+
|     Alias     |        Location       | Line number error |
+---------------+-----------------------+-------------------+
| dia_cam_width | epics_CXI_Cameras.txt |         3         |
+---------------+-----------------------+-------------------+
PVs with no Alias, WARNING!!!!:
+---------------------------+-----------------------+-------------------+
|          PV name          |        Location       | Line number error |
+---------------------------+-----------------------+-------------------+
| XRT:DIA:CVV:01:LIVE_IMAGE | epics_CXI_Cameras.txt |         2         |
+---------------------------+-----------------------+-------------------+
[kaushikm@psbuild-rhel7-01 scripts]$ epicsArchChecker ~/cxi/epics_CXI_Cameras.txt
epics_CXI_Cameras.txt
Aliases with no pv, WARNING!!!!:
+---------------+-----------------------+-------------------+
|     Alias     |        Location       | Line number error |
+---------------+-----------------------+-------------------+
| dia_cam_width | epics_CXI_Cameras.txt |         3         |
+---------------+-----------------------+-------------------+
PVs with no Alias, WARNING!!!!:
+---------------------------+-----------------------+-------------------+
|          PV name          |        Location       | Line number error |
+---------------------------+-----------------------+-------------------+
| XRT:DIA:CVV:01:LIVE_IMAGE | epics_CXI_Cameras.txt |         2         |
+---------------------------+-----------------------+-------------------+
[kaushikm@psbuild-rhel7-01 scripts]$ ./epicsArchChecker ~/cxi/epics_CXI_Cameras.txt
nonexistantfile.txt  File not found!
[Errno 2] No such file or directory: 'nonexistantfile.txt'
nonexistantfile.txt
epics_CXI_Cameras.txt
No duplicate aliases found.
No duplicate PVs found.
No aliases withouts PVs found.
No PVs without aliases found.
[kaushikm@psbuild-rhel7-01 scripts]$ epicsArchChecker ~/cxi/epics_CXI_Cameras.txt
nonexistantfile.txt  File not found!
[Errno 2] No such file or directory: 'nonexistantfile.txt'
nonexistantfile.txt
epics_CXI_Cameras.txt
[kaushikm@psbuild-rhel7-01 scripts]$ ./epicsArchChecker ~/cxi/epics_CXI_Cameras.txt
epics_CXI_Cameras.txt

-------------------------------------------- Duplicate by Aliases--------------------------------------------

Duplicate Alias:  dia_cam_live_image


                 PV                               Location                       Line number error
==============================================================================================================
     XRT:DIA:CVV:01:LIVE_IMAGE             epics_CXI_Cameras.txt                        № 2
     XRT:DIA:CVV:01:LIVE_IMAGE             epics_CXI_Cameras.txt                        № 4
=========================================================================================================


-------------------------------------------- Duplicate by PVs --------------------------------------------

Duplicate PV:  XRT:DIA:CVV:01:LIVE_IMAGE


               Alias                              Location                       Line number error
=========================================================================================================
         dia_cam_live_image                epics_CXI_Cameras.txt                        № 2
         dia_cam_live_image                epics_CXI_Cameras.txt                        № 4
=========================================================================================================


No aliases withouts PVs found.
No PVs without aliases found.
[kaushikm@psbuild-rhel7-01 scripts]$ epicsArchChecker ~/cxi/epics_CXI_Cameras.txt
epics_CXI_Cameras.txt

-------------------------------------------- Duplicate by Aliases--------------------------------------------

Duplicate Alias:  dia_cam_live_image


                 PV                               Location                       Line number error
==============================================================================================================
     XRT:DIA:CVV:01:LIVE_IMAGE             epics_CXI_Cameras.txt                        № 2
     XRT:DIA:CVV:01:LIVE_IMAGE             epics_CXI_Cameras.txt                        № 4
=========================================================================================================


-------------------------------------------- Duplicate by PVs --------------------------------------------

Duplicate PV:  XRT:DIA:CVV:01:LIVE_IMAGE


               Alias                              Location                       Line number error
=========================================================================================================
         dia_cam_live_image                epics_CXI_Cameras.txt                        № 2
         dia_cam_live_image                epics_CXI_Cameras.txt                        № 4
=========================================================================================================
```
```
[kaushikm@psbuild-rhel7-01 scripts]$ ./epicsArchChecker -s ~/cxi/epics_CXI_Cameras.txt
epics_CXI_Cameras.txt
No duplicate aliases found.
No duplicate PVs found.
No aliases withouts PVs found.
No PVs without aliases found.
PVs NO connected:
+------------------------------+---------------+---------------+-----------------------+
|           PV Name            |     Status    |     Alias     |        Location       |
+------------------------------+---------------+---------------+-----------------------+
| XRT:DIA:CVV:01:N_OF_COL32323 | No connected! | dia_cam_width | epics_CXI_Cameras.txt |
+------------------------------+---------------+---------------+-----------------------+
[kaushikm@psbuild-rhel7-01 scripts]$ epicsArchChecker -s ~/cxi/epics_CXI_Cameras.txt
epics_CXI_Cameras.txt
PVs NO connected:
+------------------------------+---------------+---------------+-----------------------+
|           PV Name            |     Status    |     Alias     |        Location       |
+------------------------------+---------------+---------------+-----------------------+
| XRT:DIA:CVV:01:N_OF_COL32323 | No connected! | dia_cam_width | epics_CXI_Cameras.txt |
+------------------------------+---------------+---------------+-----------------------+
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
