### PR TITLE
Shellcheck get hutch name

### DIFF
--- a/scripts/get_hutch_name
+++ b/scripts/get_hutch_name
@@ -2,7 +2,7 @@
 usage()
 {
 cat << EOF
-usage: $0 
+usage: $0
 
 Returns the hutch name based on the host it is run on
 EOF
@@ -14,8 +14,8 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 DIRTMP=$(dirname  "${BASH_SOURCE[0]}")
-DIR="$( cd $DIRTMP && pwd -P )"
+DIR="$( cd "$DIRTMP" && pwd -P )"
 PATH=$PATH:$DIR
 
 hutch=$(get_info --gethutch)
-echo $hutch
+echo "$hutch"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removing two instances of legacy backticks
- Quotings two vars - hutch (for the hutch name) and DIRTMP, which is the non globbed directory that the script lives in (used to get get_info on PATH)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
[kaushikm@psbuild-rhel7-03 scripts]$ ./get_hutch_name
unknown_hutch
[kaushikm@psbuild-rhel7-03 scripts]$ get_hutch_name
unknown_hutch
[kaushikm@psbuild-rhel7-03 scripts]$ ./get_hutch_name -h
usage: ./get_hutch_name

Returns the hutch name based on the host it is run on
[kaushikm@psbuild-rhel7-03 scripts]$ get_hutch_name -h
usage: /reg/g/pcds/engineering_tools/latest-released/scripts/get_hutch_name

Returns the hutch name based on the host it is run on
[kaushikm@psbuild-rhel7-03 scripts]$ sshcd rix-control
[kaushikm@rix-control scripts]$ ./get_hutch_name
rix
[kaushikm@rix-control scripts]$ get_hutch_name
rix
[kaushikm@rix-control scripts]$ sshcd ued-daq
[kaushikm@ued-daq scripts]$ ./get_hutch_name
ued
[kaushikm@ued-daq scripts]$ get_hutch_name
ued
[kaushikm@ued-daq scripts]$ sshcd cxi-monitor
[kaushikm@cxi-monitor scripts]$ ./get_hutch_name
cxi
[kaushikm@cxi-monitor scripts]$ get_hutch_name
cxi
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
