### PR TITLE
fixing shellcheck errors

### DIFF
--- a/scripts/motor-typhos
+++ b/scripts/motor-typhos
@@ -14,7 +14,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-PREFIX=`echo $1 | cut -d . -f 1`
+PREFIX=$(echo "$1" | cut -d . -f 1)
 
 if [ -z "${PREFIX}" ]; then
     usage;
@@ -24,9 +24,7 @@ fi
 # Use the latest tagged environment
 source /reg/g/pcds/pyps/conda/pcds_conda
 
-caget "${PREFIX}:PLC:nErrorId_RBV" > /dev/null 2>&1
-
-if [ $? -eq 0 ]; then
+if caget "${PREFIX}:PLC:nErrorId_RBV" &> /dev/null; then
     echo "* This looks like a Beckhoff axis."
     DEVICE_CLASS="pcdsdevices.epics_motor.BeckhoffAxis"
     NAME="${PREFIX}"  # maybe we can do better?
@@ -36,7 +34,8 @@ else
     NAME="${PREFIX}"
 fi
 
+# shellcheck disable=SC2089
 TYPHOS_ARGS="${DEVICE_CLASS}[{'prefix':'${PREFIX}','name':'${NAME}'}]"
 echo "* Launching typhos with arguments: ${TYPHOS_ARGS}"
 echo "* This may take a bit, please wait..."
-typhos ${TYPHOS_ARGS} > /dev/null 2>&1 &
+typhos "${TYPHOS_ARGS}" &> /dev/null &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- checked exit code directly and used &> to pipe stdout and stderr
- disabled SC2089 for typhos args where we want literal quotes
- quoting TYPHOS_ARGS
- removed legacy backticks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
![image](https://github.com/user-attachments/assets/af500bd7-f620-429f-9a80-7e63cbc35fec)
![image](https://github.com/user-attachments/assets/f11a7d07-fe7f-42c5-8cb2-239f5ad6e734)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
