### PR TITLE
quoting vars and removing backticks in pmgr for shellcheck

### DIFF
--- a/scripts/pmgr
+++ b/scripts/pmgr
@@ -18,6 +18,6 @@ if [[ -n $1 && ! $1 =~ '--' ]]; then
     HUTCH=$1
     shift
 else
-    HUTCH=`get_hutch_name`
+    HUTCH=$(get_hutch_name)
 fi
-/reg/g/pcds/pyps/config/${HUTCH}/pmgr/pmgr --type ims_motor --hutch ${HUTCH} $@ &
+/reg/g/pcds/pyps/config/"${HUTCH}"/pmgr/pmgr --type ims_motor --hutch "${HUTCH}" "$@" &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removed one instance of legacy backticks
- Quoting two instances of var HUTCH
- Quoting $@, which is used for only --debug and --applyenable, neither of which need to be globbed/expanded (https://www.shellcheck.net/wiki/SC2068)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
[kaushikm@psbuild-rhel7-01 scripts]$ pmgr xcs
[kaushikm@psbuild-rhel7-01 scripts]$ Using production server.
Using production server.

[kaushikm@psbuild-rhel7-01 scripts]$ sshcd mec-control
===============================================================================
This is a Federal computer system and is the property of the United States
Government. It is for authorized use only. Users (authorized or unauthorized)
have no explicit or implicit expectation of privacy.

By using this system you expressly consent to the terms and conditions in
https://www.slac.stanford.edu/comp/policy/use.html
===============================================================================
Current working directory: /cds/home/k/kaushikm/et/scripts
[kaushikm@mec-control scripts]$ ./pmgr --debug
[kaushikm@mec-control scripts]$ pmgr --debug
[kaushikm@mec-control scripts]$ Using production server.
Using production server.
[kaushikm@mec-control scripts]$ ./pmgr --debug --applyenable
[kaushikm@mec-control scripts]$ Using production server.
[kaushikm@mec-control scripts]$ pmgr --debug --applyenable
[kaushikm@mec-control scripts]$ Using production server.
[kaushikm@mec-control scripts]$ ./pmgr --debug --applyenable --help
[kaushikm@mec-control scripts]$ usage: /reg/g/pcds/pyps/apps/pmgr/R2.1.2/pmgrvenv/bin/pmgrLauncher.sh --hutch <hutchname> --type <typename> [--debug] [--applyenable] [--dev] [--help]

[kaushikm@mec-control scripts]$ pmgr --debug --applyenable --help
[kaushikm@mec-control scripts]$ usage: /reg/g/pcds/pyps/apps/pmgr/R2.1.2/pmgrvenv/bin/pmgrLauncher.sh --hutch <hutchname> --type <typename> [--debug] [--applyenable] [--dev] [--help]
```
I didn't take pictures, but I visually confimed that the Apply and Debug were present iff I used the corresponding switch. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
