### PR TITLE
Add --no_filename flag for search subarg in grep_more_ioc

### DIFF
--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -461,6 +461,9 @@ def build_parser():
     search.add_argument('-n', '--no_color', action='store_true',
                         default=False,
                         help="Don't wrap the search results with a color")
+    search.add_argument('-O', '--no_filename', action='store_true',
+                        default=False,
+                        help="Don't print filename before results")
     return parser
 
 ###############################################################################
@@ -612,7 +615,8 @@ def main():
                                  .strip()
                                  )
                 if len(search_result) > 0:
-                    print(f'{Fore.LIGHTYELLOW_EX}{ioc}:{Style.RESET_ALL}')
+                    if not args.no_filename:
+                        print(f'{Fore.LIGHTYELLOW_EX}{ioc}:{Style.RESET_ALL}')
                     print(''.join(search_result.strip()))
                     check_search.append(len(search_result))
         if len(check_search) == 0:


### PR DESCRIPTION
## Description
Add the `-O, --no_filename` flag to the `search` subarg in `grep_more_ioc`. This, combined with some sneaky regex, can let you do some very useful automation for `caget` and `caput`-ing a batch of PVs.

## Motivation and Context
In MODS there's often very many aliases for records and obscure PVs to check for device settings that can be laborious to compare and update. This helps streamline the process by giving an output that's easy to mangle with `xargs`. Take, for example, checking the temperature on all the Basler gigecams in the MODS:
```
~$ grep_more_ioc -d lm.k.*gige las search -qsnoO '^CAM_PV\s*\=\s*([_:\w]*)' |  xargs -I {} bas -c 'caget {}:TemperatureAbs_RBV'
LM1K2:COM_DP2_NF1:TemperatureAbs_RBV 46
LM1K2:EJX_DP2_FF1:TemperatureAbs_RBV 57
LM1K2:INJ_DP1_TF1_FF1:TemperatureAbs_RBV 57
LM1K2:INJ_DP1_TF1_NF1:TemperatureAbs_RBV 58
LM1K4:ATM_DP1_TF1_FF1:TemperatureAbs_RBV 57
LM1K4:ATM_DP2_TF1_FF1:TemperatureAbs_RBV 57
LM1K4:ATM_DP1_TF1_NF1:TemperatureAbs_RBV 56
LM1K4:ATM_DP2_TF1_NF1:TemperatureAbs_RBV 54
LM1K4:COM_DP1_TF1_FF1:TemperatureAbs_RBV 54
LM1K4:COM_DP2_TF1_FF1:TemperatureAbs_RBV 55
...
```

You could also get creative with `printf` statements to pre-format JIRA-friendly tables for info dumping into tickets or confluence pages.

## How Has This Been Tested?
Tested this in my branch and there are no unintended affects. Pretty simple and harmless change.

## Where Has This Been Documented?
In this PR and the code!

<!--
## Screenshots (if appropriate):
-->
