### PR TITLE
shellcheck/whitespace minutia

### DIFF
--- a/scripts/imgr
+++ b/scripts/imgr
@@ -18,7 +18,7 @@ imgr IOCNAME [--hutch HUTCH] --upgrade RELEASE_DIR
 imgr IOCNAME [--hutch HUTCH] --move HOST
 imgr IOCNAME [--hutch HUTCH] --move HOST:PORT
 imgr [--hutch HUTCH] --list [--host HOST] [--enabled_only|--disabled_only]
- 
+
 EOF
 }
 if [ $# -lt 1 ]; then
@@ -68,7 +68,7 @@ else
     export IOC_DATA=/cds/data/iocData
     export IOC_COMMON=/cds/data/iocCommon
 fi
-PSPKG_OS=$(${PSPKG_ROOT}/etc/pspkg_os.sh)
+PSPKG_OS=$("${PSPKG_ROOT}"/etc/pspkg_os.sh)
 export PSPKG_OS
 if [ "$PSPKG_OS" == rhel5 ]; then
     echo "IocManager 2.0.0 and higher does not run on RHEL5!" >&2
@@ -76,6 +76,6 @@ if [ "$PSPKG_OS" == rhel5 ]; then
 fi
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 export PSPKG_RELEASE=controls-0.1.9
-source $PSPKG_ROOT/etc/set_env.sh
+source "$PSPKG_ROOT"/etc/set_env.sh
 
 /reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/imgr.py "$@" --hutch "${HUTCH,,}"

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -38,7 +38,7 @@ else
     export IOC_DATA=/reg/d/iocData
     export IOC_COMMON=/reg/d/iocCommon
 fi
-PSPKG_OS=$(${PSPKG_ROOT}/etc/pspkg_os.sh)
+PSPKG_OS=$("${PSPKG_ROOT}"/etc/pspkg_os.sh)
 export PSPKG_OS
 if [ "$PSPKG_OS" == rhel5 ]; then
     echo "IocManager 2.0.0 and higher does not run on RHEL5!"
@@ -46,7 +46,7 @@ if [ "$PSPKG_OS" == rhel5 ]; then
 fi
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 export PSPKG_RELEASE=controls-0.1.9
-source $PSPKG_ROOT/etc/set_env.sh
+source "$PSPKG_ROOT"/etc/set_env.sh
 ulimit -c unlimited
 
 /reg/g/pcds/pyps/config/"${HUTCH,,}"/iocmanager/IocManager.py --hutch "${HUTCH,,}" > /dev/null &

--- a/scripts/new_bare_repo
+++ b/scripts/new_bare_repo
@@ -43,7 +43,7 @@ elif [[ ${CWD} != *${REPO}* ]]; then
 else
     git init
     cp -u /cds/sw/tools/bin/eco_tools/gitignore.template .gitignore
-    git add *.cfg Makefile .gitignore
+    git add -- *.cfg Makefile .gitignore
     git commit -m "Initial commit"
     git-bare-repo /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/"${HUTCH}"/"${REPO}".git
     git remote add origin /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/"${HUTCH}"/"${REPO}".git

--- a/scripts/pydev_register
+++ b/scripts/pydev_register
@@ -24,7 +24,7 @@ elif [ ! -e "${1}" ]; then
 fi
 
 PYDEV_DIR=~/pydev
-full_path="$(readlink -f $1)"
+full_path="$(readlink -f "$1")"
 if [ "${2}" == "module" ]; then
   link="${PYDEV_DIR}"
 elif [ "${2}" == "bin" ]; then

--- a/scripts/verify-hutch
+++ b/scripts/verify-hutch
@@ -4,7 +4,7 @@ usage(){
 cat << EOF
 usage: ${BASH_SOURCE[0]} <hutch>
 
-Verifies that the passed argument is a known hutch, exit 0 for success and exit 1 for failure. 
+Verifies that the passed argument is a known hutch, exit 0 for success and exit 1 for failure.
 
 EOF
 }
@@ -21,7 +21,7 @@ fi
 
 hutch=${1,,}
 for i in "tmo" "txi" "rix" "xpp" "xcs" "mfx" "cxi" "mec" "ued" "ued" "det" "lfe" "kfe" "tst" "las" "hpl"; do
-    if [[ $hutch == $i ]]; then
+    if [[ $hutch == "$i" ]]; then
         exit 0
     fi
 done

--- a/scripts/xpp_update_happi_line
+++ b/scripts/xpp_update_happi_line
@@ -1,4 +1,5 @@
 #!/bin/bash
 source pcds_conda
-cd $ENG_TOOL_SCRIPTS
+# shellcheck disable=SC2164
+cd "$ENG_TOOL_SCRIPTS"
 python xpp_update_happi_line.py "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- In imgr and iocmanager - quoting two instances of PSPKG_ROOT in each, set to the constant paths /cds/group/pcds/pkg_mgr and /reg/g/pcds/pkg_mgr
- in new_bare_repo (should this just be removed?) - adding -- before *.cfg
- in pydev_register, quoting $1 which is supposed to be an input path to a binary or module
- in verify-hutch, quoting var i which iterates over hutch names
- in xpp_update_happi_line, quoting ENG_TOOL_SCRIPTS and ignoring the cd warning


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216
This would be the end of the smaller scripts to shellcheck

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new_bare_repo
```
[kaushikm@psbuild-rhel7-03 testrepo]$ ls
example2.cfg  example.cfg  Makefile
[kaushikm@psbuild-rhel7-03 testrepo]$ ../new_bare_repo cxi testrepo
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
Initialized empty Git repository in /cds/home/k/kaushikm/et/scripts/testrepo/.git/
[master (root-commit) 1c0a8b5] Initial commit
 Committer: Kaushik Malapati <kaushikm@psbuild-rhel7-03.Slac.Stanford.EDU>
Your name and email address were configured automatically based
on your username and hostname. Please check that they are accurate.
You can suppress this message by setting them explicitly:

    git config --global user.name "Your Name"
    git config --global user.email you@example.com

After doing this, you may fix the identity used for this commit with:

    git commit --amend --reset-author

 4 files changed, 17 insertions(+)
 create mode 100644 .gitignore
 create mode 100644 Makefile
 create mode 100644 example.cfg
 create mode 100644 example2.cfg
Reinitialized existing Git repository in /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/cxi/testrepo.git/
Successfully created bare repo /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/cxi/testrepo.git
[kaushikm@psbuild-rhel7-03 testrepo]$ git status
On branch master
nothing to commit, working tree clean
[kaushikm@psbuild-rhel7-03 testrepo]$ git show
commit 1c0a8b5f480d899522d1bb23e78548b165e76fb4 (HEAD -> master)
Author: Kaushik Malapati <kaushikm@psbuild-rhel7-03.Slac.Stanford.EDU>
Date:   Fri Mar 28 16:08:45 2025 -0700

    Initial commit

diff --git a/.gitignore b/.gitignore
new file mode 100644
index 0000000..6565f9f
--- /dev/null
+++ b/.gitignore
@@ -0,0 +1,17 @@
+*~
+O.*
+*.log
+*.swp
+bin/
+build/
+children/build/
+db/
+dbd/
+html/
+include/
+lib/
+templates/
+cdCommands
+envPaths
+RELEASE_SITE
+tags
diff --git a/Makefile b/Makefile
new file mode 100644
index 0000000..e69de29
diff --git a/example.cfg b/example.cfg
new file mode 100644
index 0000000..e69de29
diff --git a/example2.cfg b/example2.cfg
new file mode 100644
index 0000000..e69de29
[kaushikm@psbuild-rhel7-03 testrepo]$ ls -la /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/cxi/testrepo.git
total 17
drwxrwxr-x  6 kaushikm gu 2048 Mar 28 16:08 .
drwxrwxr-x 52 bhill    ey 4096 Mar 28 16:08 ..
-rw-rw-r--  1 kaushikm gu  167 Mar 28 16:08 config
-rw-rw-r--  1 kaushikm gu   41 Mar 28 16:08 description
-rw-rw-r--  1 kaushikm gu   23 Mar 28 16:08 HEAD
drwxrwxr-x  2 kaushikm gu 2048 Mar 28 16:08 hooks
drwxrwxr-x  2 kaushikm gu 2048 Mar 28 16:08 info
drwxrwxr-x  4 kaushikm gu 2048 Mar 28 16:08 objects
drwxrwxr-x  4 kaushikm gu 2048 Mar 28 16:08 refs
```
imgr
```
[kaushikm@psbuild-rhel7-03 scripts]$ ./imgr ioc-tst-interlock --hutch tst --disable
Killing IOC on host ioc-tst-13, port 39101...
[kaushikm@psbuild-rhel7-03 scripts]$ ioctool ioc-tst-interlock telnet
ioc-tst-13:39101
Trying 172.21.148.192...
telnet: connect to address 172.21.148.192: Connection refused
[kaushikm@psbuild-rhel7-03 scripts]$ ./imgr ioc-tst-interlock --hutch tst --enable
Starting ioc-tst-interlock on port 39101 of host ioc-tst-13, platform 1...
[kaushikm@psbuild-rhel7-03 scripts]$ ioctool ioc-tst-interlock telnet
ioc-tst-13:39101
Trying 172.21.148.192...
Connected to ioc-tst-13.
Escape character is '^]'.
@@@ Welcome to procServ (procServ Process Server 2.9.0-1.1.0)
@@@ Use ^X to kill the child, auto restart mode is ON, use ^T to toggle auto restart
@@@ procServ server PID: 19081
@@@ Server startup directory: /tmp
@@@ Child startup directory: /tmp
@@@ Child "ioc-tst-interlock" started as: /cds/group/pcds/pyps/config/tst/iocmanager/startProc
@@@ Child log file: /cds/data/iocData/ioc-tst-interlock/iocInfo/ioc.log
@@@ Child "ioc-tst-interlock" PID: 19082
@@@ procServ server started at: Fri Mar 28 16:12:22 2025
@@@ Child "ioc-tst-interlock" started at: Fri Mar 28 16:12:23 2025
@@@ 0 user(s) and 0 logger(s) connected (plus you)
```
iocmanager
![image](https://github.com/user-attachments/assets/67720f2f-66a8-4ca5-8f28-e2b54db666e5)
verify-hutch
```
[kaushikm@psbuild-rhel7-03 scripts]$ ./verify-hutch abc
[kaushikm@psbuild-rhel7-03 scripts]$ echo $?
1
[kaushikm@psbuild-rhel7-03 scripts]$ ./verify-hutch XpP
[kaushikm@psbuild-rhel7-03 scripts]$ echo $?
0
```
xpp_update_happi_lane
![image](https://github.com/user-attachments/assets/a319be69-ce7c-46a1-8c25-b07e7ffcdc07)
ioc for these pvs is currently disabled

pydev_register
![image](https://github.com/user-attachments/assets/6d22fdfb-c0e8-42c0-9ac5-0919bf048d5d)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
