### PR TITLE
MNT: switch off of deprecated os build and straight to latest

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   get_changed_files:
     name: "get_changed_files"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       PROJECT_FILES: ${{ steps.changed_files.outputs.PROJECT_FILES }}
     steps:


### PR DESCRIPTION
This version of the ubuntu runner image is being removed. We've chosen to go straight to `latest` everywhere to hopefully not need to manually switch it again.
