### PR TITLE
ENH: ioc deploy rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,14 +393,14 @@ to rebuild an existing release on a new architecture or remove it entirely.
 &nbsp;
 Example command:
 &nbsp;
-"ioc-deploy -n ioc-foo-bar -r R1.0.0"
+"ioc-deploy -n ioc-common-foo -r R1.0.0"
 &nbsp;
 This will clone the repository to the default ioc directory and run make using the
 currently set EPICS environment variables, then apply write protection.
 &nbsp;
 With default settings, this will clone
-from https://github.com/pcdshub/ioc-foo-bar
-to /cds/group/pcds/epics/ioc/foo/bar/R1.0.0
+from https://github.com/pcdshub/ioc-common-foo
+to /cds/group/pcds/epics/ioc/common/foo/R1.0.0
 then cd and make and chmod as appropriate.
 &nbsp;
 If the repository exists but the tag does not, the script will ask if you'd like
@@ -414,10 +414,10 @@ if this is more convenient for you.
 &nbsp;
 Example commands:
 &nbsp;
-"ioc-deploy update-perms rw -n ioc-foo-bar -r R1.0.0"
-"ioc-deploy update-perms ro -n ioc-foo-bar -r R1.0.0"
-"ioc-deploy update-perms rw -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
-"ioc-deploy update-perms ro -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
+"ioc-deploy update-perms rw -n ioc-common-foo -r R1.0.0"
+"ioc-deploy update-perms ro -n ioc-common-foo -r R1.0.0"
+"ioc-deploy update-perms rw -p /cds/group/pcds/epics/ioc/common/foo/R1.0.0"
+"ioc-deploy update-perms ro -p /cds/group/pcds/epics/ioc/common/foo/R1.0.0"
 &nbsp;
 The rebuild action will run make again on your current OS.
 It will conveniently temporarily remove write protections from the release for
@@ -426,8 +426,8 @@ Like update-perms, you can invoke this using similar commands as the deploy acti
 &nbsp;
 Example commands:
 &nbsp;
-"ioc-deploy rebuild -n ioc-foo-bar -r R1.0.0"
-"ioc-deploy rebuild -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
+"ioc-deploy rebuild -n ioc-common-foo -r R1.0.0"
+"ioc-deploy rebuild -p /cds/group/pcds/epics/ioc/common/foo/R1.0.0"
 &nbsp;
 positional arguments:
 &nbsp; {update-perms,rebuild}

--- a/README.md
+++ b/README.md
@@ -442,12 +442,14 @@ positional arguments:
 optional arguments:
 &nbsp; -h, --help            show this help message and exit
 &nbsp; --version             Show version number and exit.
-&nbsp; --name NAME, -n NAME  The name of the repository to deploy. This is a
-&nbsp;                       required argument. If it does not exist on github,
-&nbsp;                       we'll also try prepending with 'ioc-common-'.
+&nbsp; --name NAME, -n NAME  The name of the repository to deploy. You must provide
+&nbsp;                       both the --name and --release arguments, or the
+&nbsp;                       --path-override argument. If it does not exist on
+&nbsp;                       github, we'll also try prepending with 'ioc-common-'.
 &nbsp; --release RELEASE, -r RELEASE
-&nbsp;                       The version of the IOC to deploy. This is a required
-&nbsp;                       argument.
+&nbsp;                       The version of the IOC to deploy. You must provide
+&nbsp;                       both the --name and --release arguments, or the
+&nbsp;                       --path-override argument.
 &nbsp; --ioc-dir IOC_DIR, -i IOC_DIR
 &nbsp;                       The directory to deploy IOCs in. This defaults to
 &nbsp;                       $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
@@ -487,12 +489,14 @@ positional arguments:
 &nbsp;
 optional arguments:
 &nbsp; -h, --help            show this help message and exit
-&nbsp; --name NAME, -n NAME  The name of the repository to deploy. This is a
-&nbsp;                       required argument. If it does not exist on github,
-&nbsp;                       we'll also try prepending with 'ioc-common-'.
+&nbsp; --name NAME, -n NAME  The name of the repository to deploy. You must provide
+&nbsp;                       both the --name and --release arguments, or the
+&nbsp;                       --path-override argument. If it does not exist on
+&nbsp;                       github, we'll also try prepending with 'ioc-common-'.
 &nbsp; --release RELEASE, -r RELEASE
-&nbsp;                       The version of the IOC to deploy. This is a required
-&nbsp;                       argument.
+&nbsp;                       The version of the IOC to deploy. You must provide
+&nbsp;                       both the --name and --release arguments, or the
+&nbsp;                       --path-override argument.
 &nbsp; --ioc-dir IOC_DIR, -i IOC_DIR
 &nbsp;                       The directory to deploy IOCs in. This defaults to
 &nbsp;                       $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
@@ -521,12 +525,14 @@ write permissions, run make, and then reapply permission restrictions.
 &nbsp;
 optional arguments:
 &nbsp; -h, --help            show this help message and exit
-&nbsp; --name NAME, -n NAME  The name of the repository to deploy. This is a
-&nbsp;                       required argument. If it does not exist on github,
-&nbsp;                       we'll also try prepending with 'ioc-common-'.
+&nbsp; --name NAME, -n NAME  The name of the repository to deploy. You must provide
+&nbsp;                       both the --name and --release arguments, or the
+&nbsp;                       --path-override argument. If it does not exist on
+&nbsp;                       github, we'll also try prepending with 'ioc-common-'.
 &nbsp; --release RELEASE, -r RELEASE
-&nbsp;                       The version of the IOC to deploy. This is a required
-&nbsp;                       argument.
+&nbsp;                       The version of the IOC to deploy. You must provide
+&nbsp;                       both the --name and --release arguments, or the
+&nbsp;                       --path-override argument.
 &nbsp; --ioc-dir IOC_DIR, -i IOC_DIR
 &nbsp;                       The directory to deploy IOCs in. This defaults to
 &nbsp;                       $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if

--- a/README.md
+++ b/README.md
@@ -371,12 +371,14 @@ usage: ioc-deploy [-h] [--version] [--name NAME] [--release RELEASE]
 &nbsp;                 [--ioc-dir IOC_DIR] [--path-override PATH_OVERRIDE]
 &nbsp;                 [--auto-confirm] [--dry-run] [--verbose]
 &nbsp;                 [--github_org GITHUB_ORG]
-&nbsp;                 {update-perms} ...
+&nbsp;                 {update-perms,rebuild} ...
 &nbsp;
 ioc-deploy is a script for building and deploying ioc tags from github.
 &nbsp;
-It will take one of two different actions: the normal deploy action,
-or a write permissions change on an existing deployed release.
+It will take one of three different actions:
+- the normal deploy action
+- a write permissions change on an existing deployed release
+- a rebuild on an existing deployed release (perhaps on a new os)
 &nbsp;
 The normal deploy action will create a shallow clone of your IOC in the
 standard release area at the correct path and "make" it.
@@ -404,7 +406,7 @@ then cd and make and chmod as appropriate.
 If the repository exists but the tag does not, the script will ask if you'd like
 to make a new tag and prompt you as appropriate.
 &nbsp;
-The second action will not do any git or make actions, it will only find the
+The update-perms action will not do any git or make actions, it will only find the
 release directory and change the file and directory permissions.
 This can be done with similar commands as above, adding the subparser command,
 and it can be done by passing the specific path you'd like to modify
@@ -417,11 +419,25 @@ Example commands:
 "ioc-deploy update-perms rw -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
 "ioc-deploy update-perms ro -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
 &nbsp;
+The rebuild action will run make again on your current OS.
+It will conveniently temporarily remove write protections from the release for
+the duration of the make so you don't have to do this in multiple steps.
+Like update-perms, you can invoke this using similar commands as the deploy action.
+&nbsp;
+Example commands:
+&nbsp;
+"ioc-deploy rebuild -n ioc-foo-bar -r R1.0.0"
+"ioc-deploy rebuild -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
+&nbsp;
 positional arguments:
-&nbsp; {update-perms}        Subcommands (will not deploy):
+&nbsp; {update-perms,rebuild}
+&nbsp;                       Subcommands (will not deploy):
 &nbsp;   update-perms        Use 'ioc-deploy update-perms' to update the write
 &nbsp;                       permissions of a deployment. See 'ioc-deploy update-
 &nbsp;                       perms --help' for more information.
+&nbsp;   rebuild             Use 'ioc-deploy rebuild' to help rebuild write-
+&nbsp;                       protected releases. See 'ioc-deploy rebuild --help'
+&nbsp;                       for more information.
 &nbsp;
 optional arguments:
 &nbsp; -h, --help            show this help message and exit
@@ -468,6 +484,40 @@ read-only (ro), or owner and group writable (rw).
 positional arguments:
 &nbsp; {ro,rw}               Select whether to make the deployment permissions
 &nbsp;                       read-only (ro) or read-write (rw).
+&nbsp;
+optional arguments:
+&nbsp; -h, --help            show this help message and exit
+&nbsp; --name NAME, -n NAME  The name of the repository to deploy. This is a
+&nbsp;                       required argument. If it does not exist on github,
+&nbsp;                       we'll also try prepending with 'ioc-common-'.
+&nbsp; --release RELEASE, -r RELEASE
+&nbsp;                       The version of the IOC to deploy. This is a required
+&nbsp;                       argument.
+&nbsp; --ioc-dir IOC_DIR, -i IOC_DIR
+&nbsp;                       The directory to deploy IOCs in. This defaults to
+&nbsp;                       $EPICS_SITE_TOP/ioc, or /cds/group/pcds/epics/ioc if
+&nbsp;                       the environment variable is not set. With your current
+&nbsp;                       environment variables, this defaults to
+&nbsp;                       /reg/g/pcds/epics/ioc.
+&nbsp; --path-override PATH_OVERRIDE, -p PATH_OVERRIDE
+&nbsp;                       If provided, ignore all normal path-selection rules in
+&nbsp;                       favor of the specific provided path. This will let you
+&nbsp;                       deploy IOCs or apply protection rules to arbitrary
+&nbsp;                       specific paths.
+&nbsp; --auto-confirm, --confirm, --yes, -y
+&nbsp;                       Skip the confirmation promps, automatically saying yes
+&nbsp;                       to each one.
+&nbsp; --dry-run             Do not deploy anything, just print what would have
+&nbsp;                       been done.
+&nbsp; --verbose, -v, --debug
+&nbsp;                       Display additional debug information.
+&nbsp;
+usage: ioc-deploy rebuild [-h] [--name NAME] [--release RELEASE]
+&nbsp;                         [--ioc-dir IOC_DIR] [--path-override PATH_OVERRIDE]
+&nbsp;                         [--auto-confirm] [--dry-run] [--verbose]
+&nbsp;
+Rebuild a deployment, even if it is write protected. This will briefly relax
+write permissions, run make, and then reapply permission restrictions.
 &nbsp;
 optional arguments:
 &nbsp; -h, --help            show this help message and exit

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -1120,7 +1120,7 @@ def rearrange_sys_argv_for_subcommands() -> str:
     be interpreted the same as:
     ioc-deploy update-perms ro -p some_path
 
-    Otherwise, the first example here is interpretted as if -p was never passed,
+    Otherwise, the first example here is interpreted as if -p was never passed,
     which could be confusing.
 
     Returns

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -20,14 +20,14 @@ to rebuild an existing release on a new architecture or remove it entirely.
 
 Example command:
 
-"ioc-deploy -n ioc-foo-bar -r R1.0.0"
+"ioc-deploy -n ioc-common-foo -r R1.0.0"
 
 This will clone the repository to the default ioc directory and run make using the
 currently set EPICS environment variables, then apply write protection.
 
 With default settings, this will clone
-from https://github.com/pcdshub/ioc-foo-bar
-to /cds/group/pcds/epics/ioc/foo/bar/R1.0.0
+from https://github.com/pcdshub/ioc-common-foo
+to /cds/group/pcds/epics/ioc/common/foo/R1.0.0
 then cd and make and chmod as appropriate.
 
 If the repository exists but the tag does not, the script will ask if you'd like
@@ -41,10 +41,10 @@ if this is more convenient for you.
 
 Example commands:
 
-"ioc-deploy update-perms rw -n ioc-foo-bar -r R1.0.0"
-"ioc-deploy update-perms ro -n ioc-foo-bar -r R1.0.0"
-"ioc-deploy update-perms rw -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
-"ioc-deploy update-perms ro -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
+"ioc-deploy update-perms rw -n ioc-common-foo -r R1.0.0"
+"ioc-deploy update-perms ro -n ioc-common-foo -r R1.0.0"
+"ioc-deploy update-perms rw -p /cds/group/pcds/epics/ioc/common/foo/R1.0.0"
+"ioc-deploy update-perms ro -p /cds/group/pcds/epics/ioc/common/foo/R1.0.0"
 
 The rebuild action will run make again on your current OS.
 It will conveniently temporarily remove write protections from the release for
@@ -53,8 +53,8 @@ Like update-perms, you can invoke this using similar commands as the deploy acti
 
 Example commands:
 
-"ioc-deploy rebuild -n ioc-foo-bar -r R1.0.0"
-"ioc-deploy rebuild -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
+"ioc-deploy rebuild -n ioc-common-foo -r R1.0.0"
+"ioc-deploy rebuild -p /cds/group/pcds/epics/ioc/common/foo/R1.0.0"
 """
 
 import argparse

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -278,6 +278,7 @@ def args_to_dataclass(args: argparse.Namespace) -> CliArgs:
     Therefore, it's the duty of this function to fill in any
     missing arguments with their default values.
     """
+    # TODO use dataclasses.replace once we're free of py3.6
     kw = vars(DEFAULT_ARGS)
     kw.update(vars(args))
     return CliArgs(**kw)

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -1137,9 +1137,11 @@ def rearrange_sys_argv_for_subcommands() -> str:
     """
     Small trick to help argparse deal with my optional subcommand.
 
+    Warning: this mutates sys.argv in place!
+
     This will make argv like this:
     ioc-deploy -p some_path update-perms ro
-    be interpretted the same as:
+    be interpreted the same as:
     ioc-deploy update-perms ro -p some_path
 
     Otherwise, the first example here is interpretted as if -p was never passed,

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -1183,7 +1183,7 @@ def _main() -> int:
         logger.debug("Traceback", exc_info=True)
         rval = ReturnCode.EXCEPTION
     except KeyboardInterrupt:
-        logger.error("Interruped with ctrl+C")
+        logger.error("Interrupted with ctrl+C")
         logger.debug("Traceback", exc_info=True)
         rval = ReturnCode.NO_CONFIRM
 

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -2,8 +2,10 @@
 """
 ioc-deploy is a script for building and deploying ioc tags from github.
 
-It will take one of two different actions: the normal deploy action,
-or a write permissions change on an existing deployed release.
+It will take one of three different actions:
+- the normal deploy action
+- a write permissions change on an existing deployed release
+- a rebuild on an existing deployed release (perhaps on a new os)
 
 The normal deploy action will create a shallow clone of your IOC in the
 standard release area at the correct path and "make" it.
@@ -31,7 +33,7 @@ then cd and make and chmod as appropriate.
 If the repository exists but the tag does not, the script will ask if you'd like
 to make a new tag and prompt you as appropriate.
 
-The second action will not do any git or make actions, it will only find the
+The update-perms action will not do any git or make actions, it will only find the
 release directory and change the file and directory permissions.
 This can be done with similar commands as above, adding the subparser command,
 and it can be done by passing the specific path you'd like to modify
@@ -43,6 +45,16 @@ Example commands:
 "ioc-deploy update-perms ro -n ioc-foo-bar -r R1.0.0"
 "ioc-deploy update-perms rw -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
 "ioc-deploy update-perms ro -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
+
+The rebuild action will run make again on your current OS.
+It will conveniently temporarily remove write protections from the release for
+the duration of the make so you don't have to do this in multiple steps.
+Like update-perms, you can invoke this using similar commands as the deploy action.
+
+Example commands:
+
+"ioc-deploy rebuild -n ioc-foo-bar -r R1.0.0"
+"ioc-deploy rebuild -p -p /cds/group/pcds/epics/ioc/foo/bar/R1.0.0"
 """
 
 import argparse

--- a/scripts/ioc_deploy.py
+++ b/scripts/ioc_deploy.py
@@ -182,7 +182,9 @@ def get_parser(subparser: str = "") -> argparse.ArgumentParser:
             action="store",
             default=argparse.SUPPRESS,
             help=(
-                "The name of the repository to deploy. This is a required argument. "
+                "The name of the repository to deploy. "
+                "You must provide both the --name and --release arguments, "
+                "or the --path-override argument. "
                 "If it does not exist on github, we'll also try prepending with 'ioc-common-'."
             ),
         )
@@ -191,7 +193,11 @@ def get_parser(subparser: str = "") -> argparse.ArgumentParser:
             "-r",
             action="store",
             default=argparse.SUPPRESS,
-            help="The version of the IOC to deploy. This is a required argument.",
+            help=(
+                "The version of the IOC to deploy. "
+                "You must provide both the --name and --release arguments, "
+                "or the --path-override argument."
+            ),
         )
         parser.add_argument(
             "--ioc-dir",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a `rebuild` command to `ioc-deploy`.
This will:
- strip any existing write permissions
- make
- apply write permissions

Which will be useful when trying to build a bunch of common IOCs on both rhel7 and rocky9.

I'm considering also adding a hosts argument to ioc-deploy to deploy to multiple architectures all at once, but I've deferred this because:
- The complexity of this "just one simple deploy script" is getting pretty high
- I didn't want to deal with auth error handling at EOD

Possibly the next update for `ioc-deploy` will bring it into an externally tracked module and then I can add complexity without causing issues in engineering_tools.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-7695

>ioc-deploy works great but has some annoying behavior when you want to build on multiple architectures.
>
> You have to:
>
> - pick rhel7 or rocky9 to start and then run ioc-deploy
> - run the command to un-write-protect the release
> - pick the other os, cd to the deployment and make
> - run the command to re-write-protect the release
>
> I'd prefer to streamline this a bit to either:
>
> - a re-deploy sort of command that handles steps 2-4 all on its own
> - some smarts or options in the initial command to build on both rhel7 and rocky9


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively by deploying and redeploying `ioc-common-pdu_snmp` to `~zlentz/temp/ioc` (this is the only tagged IOC with rocky9 compatibility right now).

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll update the readme.

<!--
## Screenshots (if appropriate):
-->
