### PR TITLE
MNT: replace flake8 + isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,12 +23,11 @@ repos:
     -   id: shellcheck
         args: [-x]  # allow source files outside of checked files
 
--   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.6
     hooks:
-    -   id: flake8
-
--   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
-    hooks:
-    -   id: isort
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+exclude = [
+    ".git",
+]
+
+line-length = 88
+
+[lint]
+select = ["C", "E", "F", "W", "B", "I"]
+ignore = ["C901"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I'm putting this up for consideration because I find this tool very helpful.

Replace the flake8 pre-commit with ruff, using the config I've been using.
The settings are negotiable (comparing with the existing .flake8 config file, maybe there are more changes to make here before merging)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
flake8 doesn't fix things for you
isort is slow

ruff is fast and fixes things for you

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is the config I've been using in other projects

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a
<!--
## Screenshots (if appropriate):
-->
