### PR TITLE
grep_more_ioc TLC

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -24,11 +24,11 @@ repos:
         args: [-x]  # allow source files outside of checked files
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -424,6 +424,10 @@ def build_parser():
                              help='Prints the IOC.cfg'
                              + ' file with comments skipped')
 
+    print_frame.add_argument('-l', '--list', type=str,
+                             help='List the column from the dataframe.'
+                             + ' Acceptable keys are: [id, host, port, dir, history]')
+
     print_frame.add_argument('-r', '--release', action='store_true',
                              default=False,
                              help="Adds the parent IOC's"
@@ -437,10 +441,6 @@ def build_parser():
     print_frame.add_argument('-y', '--print_history', action='store_true',
                              default=False,
                              help="Prints the child IOC's history to terminal")
-
-    print_frame.add_argument('-l', '--list', type=str,
-                             help='List the column from the dataframe.'
-                             + ' Acceptable keys are: [id, host, port, dir, history]')
 # --------------------------------------------------------------------------- #
 # search subarguments
 # --------------------------------------------------------------------------- #

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -428,6 +428,10 @@ def build_parser():
                              help='List the column from the dataframe.'
                              + ' Acceptable keys are: [id, host, port, dir, history]')
 
+    print_frame.add_argument('-n', '--no_dataframe',
+                             action='store_true', default=False,
+                             help='Skip printing the dataframe.')
+
     print_frame.add_argument('-r', '--release', action='store_true',
                              default=False,
                              help="Adds the parent IOC's"
@@ -556,7 +560,8 @@ def main():
                       'Release Version',
                       df.pop('Release Version'))
 
-        print_frame2term(df)
+        if not args.no_dataframe:
+            print_frame2term(df)
 
         if args.skip_comments is True:
             for ioc, d in df.loc[:, ['id', 'dir']].values:

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -425,6 +425,7 @@ def build_parser():
                              + ' file with comments skipped')
 
     print_frame.add_argument('-l', '--list', type=str,
+                             metavar='KEY',
                              help='List the column from the dataframe.'
                              + ' Acceptable keys are: [id, host, port, dir, history]')
 
@@ -607,7 +608,7 @@ def main():
                       + Style.RESET_ALL)
 
         if args.list:
-            print('\n'.join(df[args.list].to_list()))
+            print('\n'.join(df[args.list].astype(str).to_list()))
 
 # --------------------------------------------------------------------------- #
 # %%% search

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -453,22 +453,27 @@ def build_parser():
     search.add_argument('search',
                         type=str, help='PATT to use for regex search in file',
                         metavar='PATT')
-    search.add_argument('-q', '--quiet', action='store_true', default=False,
-                        help='Surpresses file warning for paths that do not'
-                        + ' exist.')
-    search.add_argument('-s', '--only_search', action='store_true',
+
+    search.add_argument('-n', '--no_color', action='store_true',
                         default=False,
-                        help="Don't print the dataframe, just search results.")
+                        help="Don't wrap the search results with a color")
+
     search.add_argument('-o', '--only_results', action='store_true',
                         default=False,
                         help="Only print the results of the regex match. Like"
                         " 'grep -o'.")
-    search.add_argument('-n', '--no_color', action='store_true',
-                        default=False,
-                        help="Don't wrap the search results with a color")
+
     search.add_argument('-O', '--no_filename', action='store_true',
                         default=False,
                         help="Don't print filename before results")
+
+    search.add_argument('-q', '--quiet', action='store_true', default=False,
+                        help='Surpresses file warning for paths that do not'
+                        + ' exist.')
+
+    search.add_argument('-s', '--only_search', action='store_true',
+                        default=False,
+                        help="Don't print the dataframe, just search results.")
     return parser
 
 ###############################################################################

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -433,9 +433,14 @@ def build_parser():
                              default=False,
                              help='Prints the child & parent IOC'
                              + ' directories as the final output')
+
     print_frame.add_argument('-y', '--print_history', action='store_true',
                              default=False,
                              help="Prints the child IOC's history to terminal")
+
+    print_frame.add_argument('-l', '--list', type=str,
+                             help='List the column from the dataframe.'
+                             + ' Acceptable keys are: [id, host, port, dir, history]')
 # --------------------------------------------------------------------------- #
 # search subarguments
 # --------------------------------------------------------------------------- #
@@ -590,6 +595,9 @@ def main():
             else:
                 print(f'{Fore.LIGHTRED_EX}No histories found in captured IOCs.'
                       + Style.RESET_ALL)
+
+        if args.list:
+            print(df[args.list].to_string(index=False).replace(' ', ''))
 
 # --------------------------------------------------------------------------- #
 # %%% search

--- a/scripts/grep_more_ioc.py
+++ b/scripts/grep_more_ioc.py
@@ -607,7 +607,7 @@ def main():
                       + Style.RESET_ALL)
 
         if args.list:
-            print(df[args.list].to_string(index=False).replace(' ', ''))
+            print('\n'.join(df[args.list].to_list()))
 
 # --------------------------------------------------------------------------- #
 # %%% search


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add a few new subargs for `print`:
* `-l, --list` for listing column parameters of the `dataframe`. e.g. `grep_more_ioc ctl-las-ip1-srv01 las print -l id`
* `-n, --no_dataframe` for if you _only_ want other printed subarg outputs. Skip printing the `dataframe`
* alphabetized subargs

## Motivation and Context
Just some extra utility I've been running on my dev branch that might be useful in prod.

## How Has This Been Tested?
Been running this for a few weeks out of my dev branch, has been working just fine.

## Where Has This Been Documented?
In this PR!

<!--
## Screenshots (if appropriate):
-->
