### PR TITLE
Feature/mfx is lcls2

### DIFF
--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -61,8 +61,6 @@ OPTIONS:
                 give path for alternative calibdir
         -b|--nbunch
                 number of bunches for the laseroff XTCAV calculations
-        --lcls2
-                force lcls2 (to be used for MFX)
         --sdfdir
                 Directory where engineering tool in on S3DF. For development work only.
 EOF
@@ -167,10 +165,6 @@ do
             shift
             shift
             ;;
-        --lcls2)
-            LCLS2=True
-            shift
-            ;;
         *)
             POSITIONAL+=("$1")
             shift
@@ -201,9 +195,7 @@ else
 fi
 
 LCLS2_HUTCHES="rix, tmo, txi, ued, mfx"
-if [ -v LCLS2 ]; then
-    MAKEPEDSEXE=makepeds_psana2
-elif echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
     echo "This is a LCLS-II experiment"
     MAKEPEDSEXE=makepeds_psana2
     LCLS2=1
@@ -251,11 +243,13 @@ if [ $chk -gt 0 ]; then
     elif [ $chk -eq 5 ]; then
 	echo Deployment of geometry failed
     elif [ $chk -eq 6 ]; then
-	echo Deployment of gain constants
+	echo Deployment of gain constants failed
     elif [ $chk -eq 7 ]; then
 	echo Additional command failed -- jungfrau constants
     elif [ $chk -eq 1 ]; then
 	echo makepeds calibration jobs failed, exited as requested.
+    elif [ $chk -eq 8 ]; then
+	echo detnames failed
     else
 	echo something else went wrong, received error code $sshchk, will exit
     fi

--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -198,7 +198,6 @@ LCLS2_HUTCHES="rix, tmo, txi, ued, mfx"
 if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
     echo "This is a LCLS-II experiment"
     MAKEPEDSEXE=makepeds_psana2
-    LCLS2=1
 else
     echo "This is a LCLS-I experiment"
     MAKEPEDSEXE=makepeds_psana

--- a/scripts/makepeds_psana2
+++ b/scripts/makepeds_psana2
@@ -409,7 +409,11 @@ ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc*
 
 echo Check detectors: 
 
-detnames -r exp="${EXP}",run="${RUN}",dir="${XTCDIR}" > /tmp/detnames_"$EXP"_"$CREATE_TIME"
+CMD="detnames -r exp="${EXP}",run="${RUN}",dir="${XTCDIR}" > /tmp/detnames_"$EXP"_"$CREATE_TIME
+if ! $CMD; then
+    echo 'detnames failed'
+    return 8
+fi
 #running local
 echo "-----------------------"
 echo 'XTC files contain:'

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -21,9 +21,9 @@ HUTCH=${EXP:0:3}
 #SIT_ENV_DIR="/sdf/group/lcls/ds/ana/sw"
 SIT_ENV_DIR="/cds/group/psdm/sw"
 
-LCLS2_HUTCHES="rix, tmo, ued, mfx"
 HUTCH=$(get_info --gethutch)
-if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
+#UED is still using the LCLS2 DAQ w procmgr
+if [[ "$(daqutils isdaqmgr)" = "true" || ${HUTCH} =~ 'ued' ]]; then
     echo "This is an LCLS-II experiment"
     
     SIT_ENV_DIR='/cds/group/pcds/dist/pds/'$HUTCH'/scripts/'


### PR DESCRIPTION
Mostly cleanup of the current 'MFX has an LCLS2 DAQ now' code
--> takepeds uses the same mechanism that takepeds etc use to see if a hucth uses the LCLS1 or LCLS2 DAQ
--> makepeds will report if 'detnames' fails (currently states that things succeeded)
--> makepeds_psana2 no longer has an option for force LCLS2 as I can't see a usecase
