### PR TITLE
ENH: add gige-vimba helper script for running the vimba software

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ optional arguments:<br/>
     <td>gige-vimba</td>
     <td>
 usage: gige-vimba<br/>
-Launches the Vimba Viewer GUI software for GigE Cameras from the vendor.<br/>
+Launches the Vimba Viewer GUI software for GigE Cameras from Allied Vision.<br/>
 This GUI lets you change camera IPs and other settings not supported by the IOC.<br/>
 It also lets you check if a camera works or change settings prior to setting up an IOC.<br/>
 It does not have any command-line arguments.<br/>

--- a/README.md
+++ b/README.md
@@ -289,6 +289,17 @@ optional arguments:<br/>
 </tr>
 
 <tr>
+    <td>gige-vimba</td>
+    <td>
+usage: gige-vimba<br/>
+Launches the Vimba Viewer GUI software for GigE Cameras from the vendor.<br/>
+This GUI lets you change camera IPs and other settings not supported by the IOC.<br/>
+It also lets you check if a camera works or change settings prior to setting up an IOC.<br/>
+It does not have any command-line arguments.<br/>
+This uses a build of the software installed in /cds/group/pcds/package/external/Vimba_6_0<br/>
+</tr>
+
+<tr>
     <td>grep_ioc</td>
     <td>
 usage: grep_ioc KEYWORD [hutch]<br/>

--- a/scripts/gige-vimba
+++ b/scripts/gige-vimba
@@ -1,0 +1,3 @@
+#!/bin/bash
+export GENICAM_GENTL64_PATH=/cds/group/pcds/package/external/Vimba_6_0/VimbaGigETL/CTI/x86_64bit
+/cds/group/pcds/package/external/Vimba_6_0/Tools/Viewer/Bin/x86_64bit/VimbaViewer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`gige-vimba` simply opens a rhel7/rocky9-compatible vimba configuration gui from the vendor.
See https://www.alliedvision.com/en/products/vimba-sdk/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is useful for setting up and debugging gige cameras from allied vision.
This has been sitting in my personal bin folder for a while but it shouldn't live there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
In the README

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/5ec33891-cb54-4aac-adde-cc067d0aca69)
