### PR TITLE
hot fix (pedestal processing for jungfrau in lcls2)

### DIFF
--- a/scripts/makepeds_psana2
+++ b/scripts/makepeds_psana2
@@ -679,8 +679,8 @@ if [[ $HAVE_JUNGFRAU -ge 1 ]]; then
                 echo "Checking job $JOBID"
                 if grep -q 'exit code' "$WORKDIR"/*"$JOBID".out; then
                     NFAILEDJOBS=$((NFAILEDJOBS+1))
-                elif ! grep -q 'DONE' "$WORKDIR"/*"$JOBID".out; then
-                    NFAILEDJOBS=$((NFAILEDJOBS+1))
+#                elif ! grep -q 'DONE' "$WORKDIR"/*"$JOBID".out; then
+#                    NFAILEDJOBS=$((NFAILEDJOBS+1))
                 fi
             done
 


### PR DESCRIPTION
A change in the underlying code made a change in makepeds necessary - the log no longer ends in a line w/ DONE and we will use the return code exclusively to see if the jobs succeeded.