### PR TITLE
Adding SC1090 disable to .shellcheckrc

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,1 +1,1 @@
-disable=SC1091  # allow sourcing files that can't immediately be found (pcds_conda)
+disable=SC1090,SC1091  # allow sourcing files that can't immediately be found (pcds_conda)

--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -59,7 +59,6 @@ cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 #   on the daqutils check above. only UED is procmgr DAQ hutch
 LCLS2_HUTCHES="ued"
 if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
-    # shellcheck disable=SC1090
     source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added SC1090 to the disable line in .shellcheckrc to silence the warning for all scripts in this repo
(This pull request was originally just disabling the warning in a specific script)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran pre-commit on stopdaq, which previously threw a SC1090 warning and now does not.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
