### PR TITLE
ENH/MNT: updates/cleanups to conda setup scripts for py312

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,8 @@ For example,
 <tr>
     <td>dev_conda</td>
     <td>
- Source this to activate a pcds conda environment.<br/>
-     By default, this activates the latest environment.<br/>
-     Use export PCDS_CONDA_VER=VERSION before running to pick a different env.<br/>
-     Pick up EPICS environment variable settings just in case user did not
+ Source this to activate a shared in-development version of a pcds conda environment.<br/>
+     The environment provided by this is not guaranteed to be stable.
     </td>
 </tr>
 
@@ -740,8 +738,7 @@ usage: motorInfo MOTOR_PV (motor_pv_2/autosave/archive/pmgr_diff/pmgr_save) OPT<
     <td>
  Source this to activate a pcds conda environment.<br/>
      By default, this activates the latest environment.<br/>
-     Use export PCDS_CONDA_VER=VERSION before running to pick a different env.<br/>
-     Pick up EPICS environment variable settings just in case user did not
+     Use export PCDS_CONDA_VER=VERSION before running to pick a different env.
     </td>
 </tr>
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ For example,
 <tr>
     <td>dev_conda</td>
     <td>
- Source this to activate a shared in-development version of a pcds conda environment.<br/>
-     The environment provided by this is not guaranteed to be stable.
+Source this to activate a shared in-development version of a pcds conda environment.<br/>
+The environment provided by this is not guaranteed to be stable.
     </td>
 </tr>
 
@@ -736,9 +736,9 @@ usage: motorInfo MOTOR_PV (motor_pv_2/autosave/archive/pmgr_diff/pmgr_save) OPT<
 <tr>
     <td>pcds_conda</td>
     <td>
- Source this to activate a pcds conda environment.<br/>
-     By default, this activates the latest environment.<br/>
-     Use export PCDS_CONDA_VER=VERSION before running to pick a different env.
+Source this to activate a pcds conda environment.<br/>
+By default, this activates the latest environment.<br/>
+Use export PCDS_CONDA_VER=VERSION before running to pick a different env.
     </td>
 </tr>
 

--- a/scripts/condarc.yaml
+++ b/scripts/condarc.yaml
@@ -1,0 +1,4 @@
+# Customizations for dev-conda
+# Some options can only be set using config files
+# Included in dev_conda using the CONDARC environment variable
+env_prompt: '(dev-{default_env}) '

--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -36,5 +36,6 @@ PYDM_DISPLAYS_PATH="$(cut -d ":" -f 3- <<< "${PYDM_DISPLAYS_PATH}")"
 export PYDM_DISPLAYS_PATH
 
 # In case you want to use this info
-export IS_PCDS_CONDA=0
+export IS_PCDS_CONDA=1
+export IS_TAG_CONDA=0
 export IS_DEV_CONDA=1

--- a/scripts/dev_conda
+++ b/scripts/dev_conda
@@ -4,7 +4,8 @@ usage()
 cat << EOF
 usage: source $0
 
-Source this to activate the latest version a pcds conda environment.
+Source this to activate a shared in-development version of a pcds conda environment.
+The environment provided by this is not guaranteed to be stable.
 EOF
 }
 
@@ -13,46 +14,27 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-unset LD_LIBRARY_PATH
-unset PYTHONPATH
 
-# Pick up EPICS environment variable settings just in case user did not
-source /cds/group/pcds/setup/epics-ca-env.sh
+# Clear any PCDS_CONDA_VER to ensure we start from default in shared_conda_setup.sh
+unset PCDS_CONDA_VER
 
-# Source the bash setup
-PYPS_ROOT="/cds/group/pcds/pyps"
-APPS_ROOT="${PYPS_ROOT}/apps"
-CONDA_ROOT="${PYPS_ROOT}/conda"
-BASE_ENV="${CONDA_ROOT}/py39"
-source "${BASE_ENV}/etc/profile.d/conda.sh"
+# Target scripts in this directory, resolving symbolic links
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# Add custom config file for putting dev- into prompt
+export CONDARC="${THIS_DIR}/condarc.yaml"
+# Load the shared elements, including whatever the default env is
+source "${THIS_DIR}/shared_conda_setup.sh"
 
-# Activate base env first so things like conda build are available
-conda activate
-# Default to latest pcds release as the base
-conda activate "$(cat "${BASE_ENV}/latest_env")"
-
-PCDSDEVICES_DEV_UI="${APPS_ROOT}/dev/pcdsdevices/pcdsdevices/ui"
-
-EPICS_ROOT="/cds/group/pcds/epics-dev"
-
+# Use PYTHONPATH to load dev modules on top of the default env
 export PYTHONPATH="${APPS_ROOT}/dev/pythonpath"
-export PYQTDESIGNERPATH="${CONDA_ROOT}/dev_designer_plugins/:${PYQTDESIGNERPATH}"
-export PYDM_CONFIRM_QUIT=0
-export PYDM_DEFAULT_PROTOCOL=ca
-export PYDM_DESIGNER_ONLINE=1
-export PYDM_DISPLAYS_PATH="${PCDSDEVICES_DEV_UI}:${EPICS_ROOT}/screens/pydm:${EPICS_ROOT}"
-export PYDM_STYLESHEET="${EPICS_ROOT}/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss"
-export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
-export LUCID_CONFIG="${APPS_ROOT}/hutch-python/lucid_config/"
-export HAPPI_CFG="${APPS_ROOT}/hutch-python/device_config/happi.cfg"
-export TYPHOS_JIRA_EMAIL_SUFFIX="@slac.stanford.edu"
 
-# Keep tokens off of github
-TOKEN_DIR="${CONDA_ROOT}/.tokens"
-source "${TOKEN_DIR}/typhos.sh"
+# Strip out the installed prod stuff from the PYDM displays
+# Before: pcdsdevices_prod:typhos_prod:pcdsdevices_dev:pydm_epics_dev:epics_dev
+# After: pcdsdevices_dev:pydm_epics_dev:epics_dev
+# This allows the pcdsdevices dev folder uis to be found before the installed tag
+PYDM_DISPLAYS_PATH="$(cut -d ":" -f 3- <<< "${PYDM_DISPLAYS_PATH}")"
+export PYDM_DISPLAYS_PATH
 
-# Revert to Software Raster when SSH to avoid issues with QtQuick.
-# The same was done with PyDM and this fixes Designer and friends.
-if [ -n "${SSH_CONNECTION}" ]; then
-  export QT_QUICK_BACKEND="software"
-fi
+# In case you want to use this info
+export IS_PCDS_CONDA=0
+export IS_DEV_CONDA=1

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -5,126 +5,24 @@ cat << EOF
 usage: source $0
 
 Source this to activate a pcds conda environment.
-By default, this activates the latest environment.
+By default, this activates the latest stable environment.
 Use export PCDS_CONDA_VER=<version> before running to pick a different env.
 EOF
 }
 
 if [[ ($1 == "--help") || ($1 == "-h") ]]; then
-	usage
-	exit 0
+	  usage
+	  exit 0
 fi
 
-unset LD_LIBRARY_PATH
-unset PYTHONPATH
+# Target scripts in this directory, resolving symbolic links
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# This is set in dev_conda, unset it here
+unset CONDARC
+# Load elements shared between pcds_conda and dev_conda
+# In pcds_conda, this is all we need to do
+source "${THIS_DIR}/shared_conda_setup.sh"
 
-# Pick up EPICS environment variable settings just in case user did not
-source /cds/group/pcds/setup/epics-ca-env.sh
-
-# Source the bash setup
-PYPS_ROOT="/cds/group/pcds/pyps"
-APPS_ROOT="${PYPS_ROOT}/apps"
-CONDA_ROOT="${PYPS_ROOT}/conda"
-
-# BASE_ENV transition points
-FIRST_PCDS_PY38="4.0.0"
-FIRST_PCDS_PY39="4.2.0"
-
-version_ge () {
-  # Is first version greater than or equal to the second?
-  # Assumes no prefix, just numbers, major.minor.bugfix
-  first_ver="$1"
-  second_ver="$2"
-  first_maj="$(echo "${first_ver}" | cut -d . -f 1)"
-  first_min="$(echo "${first_ver}" | cut -d . -f 2)"
-  first_bug="$(echo "${first_ver}" | cut -d . -f 3)"
-  second_maj="$(echo "${second_ver}" | cut -d . -f 1)"
-  second_min="$(echo "${second_ver}" | cut -d . -f 2)"
-  second_bug="$(echo "${second_ver}" | cut -d . -f 3)"
-  if [[ "${first_maj}" -gt "${second_maj}" ]]; then
-    return 0
-  elif [[ "${first_maj}" -lt "${second_maj}" ]]; then
-    return 1
-  else
-    if [[ "${first_min}" -gt "${second_min}" ]]; then
-      return 0
-    elif [[ "${first_min}" -lt "${second_min}" ]]; then
-      return 1
-    else
-      if [[ "${first_bug}" -ge "${second_bug}" ]]; then
-        return 0
-      else
-        return 1
-      fi
-    fi
-  fi
-}
-
-
-if [[ -z "${PCDS_CONDA_VER}" ]]; then
-  # If env var unset, then default to latest
-  BASE_ENV="${CONDA_ROOT}/py39"
-  PYTHON_VER="3.9"
-  PCDS_CONDA_VER="$(cat "${BASE_ENV}/latest_env")"
-else
-  # Figure out which base to use
-  if [[ -z "${PCDS_CONDA_VER##*-*}" ]]; then
-    # We had a dash, there must be a prefix in the name
-    SERIES="$(echo "${PCDS_CONDA_VER}" | cut -d - -f 1)"
-    VER_NUM="$(echo "${PCDS_CONDA_VER}" | cut -d - -f 2)"
-  else
-    # We didn't have a dash or a prefix, assume it is pcds
-    SERIES="pcds"
-    VER_NUM="${PCDS_CONDA_VER}"
-    PCDS_CONDA_VER="pcds-${PCDS_CONDA_VER}"
-  fi
-  # Figure out where the base environment is
-  # Base environment should be updated with every new python version
-  # But in practice this can be skipped
-  if [[ "${SERIES}" == "pcds" ]]; then
-    if version_ge "${VER_NUM}" "${FIRST_PCDS_PY39}"; then
-      BASE_ENV="${CONDA_ROOT}/py39"
-      PYTHON_VER="3.9"
-    elif version_ge "${VER_NUM}" "${FIRST_PCDS_PY38}"; then
-      BASE_ENV="${CONDA_ROOT}/py36"
-      PYTHON_VER="3.8"
-    else
-      BASE_ENV="${CONDA_ROOT}/py36"
-      PYTHON_VER="3.6"
-    fi
-  else
-    BASE_ENV="${CONDA_ROOT}/py39"
-    PYTHON_VER="3.9"
-  fi
-fi
-
-source "${BASE_ENV}/etc/profile.d/conda.sh"
-conda activate "${PCDS_CONDA_VER}"
-
-ENV_FILES="${BASE_ENV}/envs/${PCDS_CONDA_VER}"
-SITE_PACKAGES="${ENV_FILES}/lib/python${PYTHON_VER}/site-packages"
-PCDSDEVICES_PROD_UI="${SITE_PACKAGES}/pcdsdevices/ui"
-PCDSDEVICES_DEV_UI="${APPS_ROOT}/dev/pcdsdevices/pcdsdevices/ui"
-TYPHOS_PROD_DEVICES_UI="${SITE_PACKAGES}/typhos/ui/devices"
-
-EPICS_ROOT="/cds/group/pcds/epics-dev"
-
-export PYDM_CONFIRM_QUIT=0
-export PYDM_DEFAULT_PROTOCOL=ca
-export PYDM_DESIGNER_ONLINE=1
-export PYDM_DISPLAYS_PATH="${PCDSDEVICES_PROD_UI}:${TYPHOS_PROD_DEVICES_UI}:${PCDSDEVICES_DEV_UI}:${EPICS_ROOT}/screens/pydm:${EPICS_ROOT}"
-export PYDM_STYLESHEET="${EPICS_ROOT}/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss"
-export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
-export LUCID_CONFIG="${APPS_ROOT}/hutch-python/lucid_config/"
-export HAPPI_CFG="${APPS_ROOT}/hutch-python/device_config/happi.cfg"
-export TYPHOS_JIRA_EMAIL_SUFFIX="@slac.stanford.edu"
-
-# Keep tokens off of github
-TOKEN_DIR="${CONDA_ROOT}/.tokens"
-source "${TOKEN_DIR}/typhos.sh"
-
-# Revert to Software Raster when SSH to avoid issues with QtQuick.
-# The same was done with PyDM and this fixes Designer and friends.
-if [ -n "${SSH_CONNECTION}" ]; then
-  export QT_QUICK_BACKEND="software"
-fi
+# In case you want to use this info
+export IS_PCDS_CONDA=1
+export IS_DEV_CONDA=0

--- a/scripts/pcds_conda
+++ b/scripts/pcds_conda
@@ -25,4 +25,5 @@ source "${THIS_DIR}/shared_conda_setup.sh"
 
 # In case you want to use this info
 export IS_PCDS_CONDA=1
+export IS_TAG_CONDA=1
 export IS_DEV_CONDA=0

--- a/scripts/shared_conda_setup.sh
+++ b/scripts/shared_conda_setup.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# This is sourced by pcds_conda and dev_conda
+# It contains the shared lines between those two sourceable scripts
+# See pcds_conda and dev_conda
+
+# Filesystem-specific settings
+# Change these if we change the filesystem again
+PCDS_ROOT="/cds/group/pcds"
+SETUP_ROOT="${PCDS_ROOT}/setup"
+PYPS_ROOT="${PCDS_ROOT}/pyps"
+APPS_ROOT="${PYPS_ROOT}/apps"
+CONDA_ROOT="${PYPS_ROOT}/conda"
+
+# Clear externally set paths that may mess with imports etc.
+unset LD_LIBRARY_PATH
+unset PYTHONPATH
+
+# Pick up EPICS environment variable settings just in case user did not
+source "${SETUP_ROOT}/epics-ca-env.sh"
+
+# BASE_ENV transition points
+FIRST_PCDS_PY38="4.0.0"
+FIRST_PCDS_PY39="4.2.0"
+FIRST_PCDS_PY312="6.0.0"
+
+# Helper script for finding your conda environment
+version_ge () {
+  # Is first version greater than or equal to the second?
+  # Assumes no prefix, just numbers, major.minor.bugfix
+  first_ver="$1"
+  second_ver="$2"
+  first_maj="$(echo "${first_ver}" | cut -d . -f 1)"
+  first_min="$(echo "${first_ver}" | cut -d . -f 2)"
+  first_bug="$(echo "${first_ver}" | cut -d . -f 3)"
+  second_maj="$(echo "${second_ver}" | cut -d . -f 1)"
+  second_min="$(echo "${second_ver}" | cut -d . -f 2)"
+  second_bug="$(echo "${second_ver}" | cut -d . -f 3)"
+  if [[ "${first_maj}" -gt "${second_maj}" ]]; then
+    return 0
+  elif [[ "${first_maj}" -lt "${second_maj}" ]]; then
+    return 1
+  else
+    if [[ "${first_min}" -gt "${second_min}" ]]; then
+      return 0
+    elif [[ "${first_min}" -lt "${second_min}" ]]; then
+      return 1
+    else
+      if [[ "${first_bug}" -ge "${second_bug}" ]]; then
+        return 0
+      else
+        return 1
+      fi
+    fi
+  fi
+}
+
+# Based on the user's selection or non-selection, pick the correct env
+if [[ -z "${PCDS_CONDA_VER}" ]]; then
+  # If env var unset, then default to latest
+  BASE_ENV="${CONDA_ROOT}/py39"
+  PYTHON_VER="3.9"
+  PCDS_CONDA_VER="$(cat "${BASE_ENV}/latest_env")"
+else
+  # Figure out which base to use
+  if [[ -z "${PCDS_CONDA_VER##*-*}" ]]; then
+    # We had a dash, there must be a prefix in the name
+    SERIES="$(echo "${PCDS_CONDA_VER}" | cut -d - -f 1)"
+    VER_NUM="$(echo "${PCDS_CONDA_VER}" | cut -d - -f 2)"
+  else
+    # We didn't have a dash or a prefix, assume it is pcds
+    SERIES="pcds"
+    VER_NUM="${PCDS_CONDA_VER}"
+    PCDS_CONDA_VER="pcds-${PCDS_CONDA_VER}"
+  fi
+  # Figure out where the base environment is
+  # Base environment should be updated with every new python version
+  # But in practice this can be skipped
+  if [[ "${SERIES}" == "pcds" ]]; then
+    if version_ge "${VER_NUM}" "${FIRST_PCDS_PY312}"; then
+      BASE_ENV="${CONDA_ROOT}/py312"
+      PYTHON_VER="3.12"
+    elif version_ge "${VER_NUM}" "${FIRST_PCDS_PY39}"; then
+      BASE_ENV="${CONDA_ROOT}/py39"
+      PYTHON_VER="3.9"
+    elif version_ge "${VER_NUM}" "${FIRST_PCDS_PY38}"; then
+      BASE_ENV="${CONDA_ROOT}/py36"
+      PYTHON_VER="3.8"
+    else
+      BASE_ENV="${CONDA_ROOT}/py36"
+      PYTHON_VER="3.6"
+    fi
+  else
+    BASE_ENV="${CONDA_ROOT}/py39"
+    PYTHON_VER="3.9"
+  fi
+fi
+
+# Setup the conda environment
+source "${BASE_ENV}/etc/profile.d/conda.sh"
+conda activate "${PCDS_CONDA_VER}"
+
+# Common locations, will be used below
+ENV_FILES="${BASE_ENV}/envs/${PCDS_CONDA_VER}"
+SITE_PACKAGES="${ENV_FILES}/lib/python${PYTHON_VER}/site-packages"
+PCDSDEVICES_PROD_UI="${SITE_PACKAGES}/pcdsdevices/ui"
+PCDSDEVICES_DEV_UI="${APPS_ROOT}/dev/pcdsdevices/pcdsdevices/ui"
+TYPHOS_PROD_DEVICES_UI="${SITE_PACKAGES}/typhos/ui/devices"
+EPICS_DEV="${PCDS_ROOT}/epics-dev"
+
+# Various settings for ui apps
+export PYDM_CONFIRM_QUIT=0
+export PYDM_DEFAULT_PROTOCOL=ca
+export PYDM_DESIGNER_ONLINE=1
+# For typhos: check prod folders first, then dev folders if nothing was found
+export PYDM_DISPLAYS_PATH="${PCDSDEVICES_PROD_UI}:${TYPHOS_PROD_DEVICES_UI}:${PCDSDEVICES_DEV_UI}:${EPICS_DEV}/screens/pydm:${EPICS_DEV}"
+export PYDM_STYLESHEET="${EPICS_DEV}/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss"
+export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
+export LUCID_CONFIG="${APPS_ROOT}/hutch-python/lucid_config/"
+export HAPPI_CFG="${APPS_ROOT}/hutch-python/device_config/happi.cfg"
+export TYPHOS_JIRA_EMAIL_SUFFIX="@slac.stanford.edu"
+
+# Keep tokens off of github
+TOKEN_DIR="${CONDA_ROOT}/.tokens"
+source "${TOKEN_DIR}/typhos.sh"
+
+# Revert to Software Raster when SSH to avoid issues with QtQuick.
+# The same was done with PyDM and this fixes Designer and friends.
+if [ -n "${SSH_CONNECTION}" ]; then
+  export QT_QUICK_BACKEND="software"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Prepare for `pcds-6.0.0`, which will be python 3.12
- Clean up the duplicated code between `pcds_conda` and `dev_conda` and put it in a shared script.
- Add `dev-` to the conda prompt when using `dev_conda` (closes #202)
- Add variables that tell us which script we sourced for downstream consumers (like me in my crazy prompt) to use.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We're gearing up for an open beta release of `pcds-6.0.0` which will be python 3.12.

This update enables you to access that environment via:
```
export PCDS_CONDA_VER=6.0.0
source pcds_conda
```
Python 3.9 is still the default.

While I was here I remembered #202 and found a simple way to include it for normal users.

For users with custom prompts etc. like me I added two new exported variables to let us know you're using pcds conda or dev conda in case we want to use this information.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It will be announced when the env is deployed
I updated the readme but it's somewhat unrelated

<!--
## Screenshots (if appropriate):
-->
