### PR TITLE
revertdaq

### DIFF
--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -3,56 +3,50 @@
 #
 # Do not use non-standard python.
 ####################################################
+import errno
 import getpass
-import logging
 import os
 import socket
 import subprocess
-import sys
 import time
 from subprocess import PIPE
 
-DAQMGR_HUTCHES = ["tmo", "rix", "txi", "mfx"]
+DAQMGR_HUTCHES = ["tmo", "rix", "txi", "ued"]
 LOCALHOST = socket.gethostname()
 SLURM_PARTITION = "drpq"
 SLURM_JOBNAME = "submit_daq"
+SLURM_SCRIPT = "submit_daq.sh"
 SLURM_OUTPUT = "slurm_daq.log"
 MAX_RETRIES = 10
 
 
-def call_subprocess(*args):
+def silentremove(filename):
     try:
-        output = subprocess.check_output(args, stderr=PIPE).strip()
-        return output.decode("utf-8")
-    except subprocess.CalledProcessError as e:
-        logging.error("Subprocess call '%s' failed with error: %s", " ".join(args), e)
-        raise
+        os.remove(filename)
+    except OSError as e:
+        if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
+            raise
+
+
+def call_subprocess(*args):
+    return str(subprocess.check_output(args, stderr=PIPE).strip(), "utf-8")
 
 
 def call_sbatch(cmd, nodelist, scripts_dir):
     sb_script = "#!/bin/bash\n"
-    sb_script += f"#SBATCH --partition={SLURM_PARTITION}\n"
-    sb_script += f"#SBATCH --job-name={SLURM_JOBNAME}\n"
-    sb_script += f"#SBATCH --nodelist={nodelist}\n"
-    sb_script += f"#SBATCH --output={os.path.join(scripts_dir, SLURM_OUTPUT)}\n"
+    sb_script += f"#SBATCH --partition={SLURM_PARTITION}" + "\n"
+    sb_script += f"#SBATCH --job-name={SLURM_JOBNAME}" + "\n"
+    sb_script += f"#SBATCH --nodelist={nodelist}" + "\n"
+    sb_script += f"#SBATCH --output={os.path.join(scripts_dir, SLURM_OUTPUT)}" + "\n"
     sb_script += "#SBATCH --ntasks=1\n"
     sb_script += "unset PYTHONPATH\n"
     sb_script += "unset LD_LIBRARY_PATH\n"
     sb_script += cmd
-
-    try:
-        result = subprocess.run(
-            ["sbatch", "-"],
-            input=sb_script,
-            text=True,
-            stdout=PIPE,
-            stderr=PIPE,
-            check=True,
-        )
-        logging.debug("sbatch submission result: %s", result.stdout.strip())
-    except subprocess.CalledProcessError as e:
-        logging.error("sbatch submission failed: %s", e.stderr.strip())
-        raise
+    slurm_script = os.path.join(scripts_dir, SLURM_SCRIPT)
+    with open(slurm_script, "w") as f:
+        f.write(sb_script)
+    call_subprocess("sbatch", slurm_script)
+    silentremove(slurm_script)
 
 
 class SbatchManager:
@@ -60,175 +54,146 @@ class SbatchManager:
         self.user = user
 
     def get_job_info(self):
+        # Use squeue to get JobId, Comment, JobName, Status, and Reasons (Node List)
         format_string = '"%i %k %j %T %R"'
-        try:
-            output = call_subprocess(
-                "squeue", "-u", self.user, "-h", "-o", format_string
-            )
-            lines = output.splitlines()
-        except Exception as e:
-            logging.error("Failed to get job info from squeue: %s", e)
-            return {}
-
+        lines = call_subprocess(
+            "squeue", "-u", self.user, "-h", "-o", format_string
+        ).splitlines()
         job_details = {}
-        for job_info in lines:
+        for i, job_info in enumerate(lines):
             cols = job_info.strip('"').split()
-            if len(cols) >= 5:
+            success = True
+            if len(cols) == 5:
+                job_id, comment, job_name, state, nodelist = cols
+            elif len(cols) > 5:
                 job_id, comment, job_name, state = cols[:4]
-                nodelist = " ".join(cols[4:])
+                nodelist = " ".join(cols[5:])
             else:
-                logging.warning("Unexpected job info format: %s", job_info)
-                continue
-
-            try:
-                scontrol_output = call_subprocess("scontrol", "show", "job", job_id)
+                success = False
+            if success:
+                # Get logfile from job_id
+                scontrol_lines = call_subprocess(
+                    "scontrol", "show", "job", job_id
+                ).splitlines()
                 logfile = ""
-                for scontrol_line in scontrol_output.splitlines():
-                    if "StdOut" in scontrol_line:
-                        parts = scontrol_line.split("=")
-                        if len(parts) > 1:
-                            logfile = parts[1]
-            except Exception as e:
-                logging.error("Failed to get scontrol info for job %s: %s", job_id, e)
-                logfile = ""
+                for scontrol_line in scontrol_lines:
+                    if scontrol_line.find("StdOut") > -1:
+                        scontrol_cols = scontrol_line.split("=")
+                        logfile = scontrol_cols[1]
 
-            job_details[job_name] = {
-                "job_id": job_id,
-                "comment": comment,
-                "state": state,
-                "nodelist": nodelist,
-                "logfile": logfile,
-            }
+                job_details[job_name] = {
+                    "job_id": job_id,
+                    "comment": comment,
+                    "state": state,
+                    "nodelist": nodelist,
+                    "logfile": logfile,
+                }
         return job_details
 
 
 class DaqManager:
     def __init__(self, verbose=False, cnf=None):
         self.verbose = verbose
-        try:
-            self.hutch = call_subprocess("get_info", "--gethutch")
-        except Exception as e:
-            logging.error("Failed to get hutch info: %s", e)
-            raise
+        self.hutch = call_subprocess("get_info", "--gethutch")
         if len(self.hutch) != 3:
             raise ValueError(f"Invalid hutch name found (hutch: '{self.hutch}')")
 
         self.user = self.hutch + "opr"
         self.sbman = SbatchManager(self.user)
         self.scripts_dir = f"/reg/g/pcds/dist/pds/{self.hutch}/scripts"
-        self.cnf_file = f"{self.hutch}.py" if cnf is None else cnf
-
-        full_path_cnf_file = os.path.join(self.scripts_dir, self.cnf_file)
-        if os.path.isfile(full_path_cnf_file):
-            logging.debug("Using configuration file: %s", full_path_cnf_file)
+        if cnf is None:
+            self.cnf_file = f"{self.hutch}.py"
         else:
-            sys.exit("Exiting: Configuration file '' not found.")
+            self.cnf_file = cnf
 
-        logging.debug(
-            "DaqManager initialized for hutch %s with config %s",
-            self.hutch,
-            self.cnf_file,
-        )
+    def isdaqmgr(self, quiet=False):
+        if self.hutch in DAQMGR_HUTCHES:
+            if not quiet:
+                print("true")
+            return True
+        else:
+            if not quiet:
+                print("false")
+            return False
 
     def isvaliduser(self):
-        valid = getpass.getuser() == self.user
-        if not valid:
-            logging.error(
-                "Invalid user. Expected %s but got %s", self.user, getpass.getuser()
-            )
-        return valid
+        return getpass.getuser() == self.user
 
     def waitfor(self, subcmd):
         if subcmd == "stop":
-            daq_host = self.wheredaq_internal()
+            daq_host = self.wheredaq(quiet=True)
             if daq_host is not None:
-                if self.hutch in DAQMGR_HUTCHES:
+                if self.isdaqmgr(quiet=True):
                     for i_retry in range(MAX_RETRIES):
-                        daq_host = self.wheredaq_internal()
+                        daq_host = self.wheredaq(quiet=True)
                         if daq_host is None:
-                            logging.debug("DAQ has stopped after %d retries.", i_retry)
                             break
-                        logging.debug("Waiting for the DAQ to stop, retry #%d", i_retry)
+                        print(f"wait for the DAQ to stop #retry: {i_retry}")
                         time.sleep(1)
-                    else:
-                        logging.error(
-                            "DAQ did not stop after %d retries. Please try again or contact support.",
-                            MAX_RETRIES,
-                        )
                 else:
-                    logging.error(
-                        "The DAQ did not stop properly (DAQ HOST: %s).", daq_host
+                    print(
+                        f"the DAQ did not stop properly (DAQ HOST: {daq_host}), exit now and try again or call your POC or the DAQ phone"
                     )
 
-    def wheredaq_internal(self):
-        job_details = self.sbman.get_job_info()
+    def wheredaq(self, quiet=False):
+        """Locate where the daq is running.
+
+        We use slurm to check if the hutch user is running control_gui.
+        """
         daq_host = None
+        # Use control_gui job name to locate the running host for the daq
+        job_details = self.sbman.get_job_info()
         if "control_gui" in job_details:
             daq_host = job_details["control_gui"]["nodelist"]
-        return daq_host
 
-    def wheredaq(self):
-        daq_host = self.wheredaq_internal()
-        if daq_host is None:
-            msg = f"DAQ is not running in {self.hutch}"
-        else:
-            msg = f"DAQ is running on {daq_host}"
-        logging.debug("wheredaq: %s", msg)
-        print(msg)
+        if not quiet:
+            if daq_host is None:
+                print(f"DAQ is not running in {self.hutch}")
+            else:
+                print(f"DAQ is running on {daq_host}")
         return daq_host
 
     def calldaq(self, subcmd, daq_host=None):
-        # Determine where to run the command
+        prog = "daqmgr"
+        cmd = f"pushd {self.scripts_dir}" + " > /dev/null;"
+        cmd += f'source {os.path.join(self.scripts_dir, "setup_env.sh")}' + ";"
+        cmd += (
+            f"WHEREPROG=$(which {prog})"
+            "; set -x; "
+            f"$WHEREPROG {subcmd} {os.path.join(self.scripts_dir, self.cnf_file)}"
+            "; { set +x; } 2>/dev/null;"
+        )
+        cmd += "popd > /dev/null;"
+
         if subcmd == "restart":
             query_daq_host = self.wheredaq()
         else:
-            query_daq_host = self.wheredaq_internal()
+            query_daq_host = self.wheredaq(quiet=True)
 
         if daq_host is None:
-            daq_host = query_daq_host or LOCALHOST
+            daq_host = query_daq_host
+            if daq_host is None:
+                daq_host = LOCALHOST
 
-        logging.debug("Executing DAQ command on host: %s", daq_host)
-
-        # Build daq commad
-        env_setup = os.path.join(self.scripts_dir, "setup_env.sh")
-        try:
-            get_daqmgr_cmd = f"source {env_setup}; which daqmgr"
-            daqmgr_path = subprocess.check_output(get_daqmgr_cmd, shell=True, stderr=PIPE).strip().decode("utf-8")
-        except subprocess.CalledProcessError as e:
-            logging.error("Failed to locate 'daqmgr' after sourcing env: %s", e.stderr.decode())
-            return
-
-        daq_command = f"{daqmgr_path} {subcmd} {os.path.join(self.scripts_dir, self.cnf_file)}"
-        print(f"Running command: {daq_command}")
-
-        cmd = f"""
-pushd {self.scripts_dir} > /dev/null
-source {env_setup}
-{daq_command}
-popd > /dev/null
-"""
         if daq_host == LOCALHOST:
-            try:
-                ret = subprocess.run(cmd, stdout=PIPE, stderr=PIPE, shell=True, check=True)
-                logging.debug("Command stdout:\n%s", ret.stdout.decode())
-                logging.debug("Command stderr:\n%s", ret.stderr.decode())
-            except subprocess.CalledProcessError as e:
-                logging.error("Local command failed:\n%s", e.stderr.decode())
+            ret = subprocess.run(cmd, stdout=PIPE, shell=True)
+            print(ret.stdout.decode())
         else:
-            try:
-                call_sbatch(cmd, daq_host, self.scripts_dir)
-            except Exception as e:
-                logging.error("Failed to submit sbatch command: %s", e)
+            call_sbatch(cmd, daq_host, self.scripts_dir)
 
         self.waitfor(subcmd)
 
     def stopdaq(self):
+        """Stop the running daq for the current user.
+        Note that daq host is determined by querying slurm job status.
+        """
         self.calldaq("stop")
 
     def restartdaq(self, daq_host):
         if not self.isvaliduser():
-            logging.error("Please run the DAQ from the operator account!")
+            print("Please run the DAQ from the operator account!")
             return
+
         st = time.monotonic()
         self.calldaq("restart", daq_host=daq_host)
         en = time.monotonic()

--- a/scripts/get_info.py
+++ b/scripts/get_info.py
@@ -122,7 +122,7 @@ else:
         else:
             # then ask.....outside of python
             print('unknown_hutch')
-        sys.exit()
+            sys.exit()
     if args.getHutch:
         print(hutch.upper())
         sys.exit()

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -6,13 +6,9 @@ cat << EOF
 usage: $0 options
 
 OPTIONS:
--w sort windows after start
--d dss-test setup
--p select partition (same as used last)
--s silent (do not email jana)
--c enable core files
--C (LCLS2 DAQMGR Hutches ONLY!) Select a cnf to use.
--u UED .cnf file
+-w|--sortwindows sort windows after start
+-c|--coresize    enable core files
+-C|--cnf         (LCLS2 DAQMGR Hutches ONLY!) Select a cnf/py to use.
 EOF
 }
 
@@ -21,10 +17,7 @@ EOF
 
 NOTRUNNING='not running'
 AIMHOST=$HOSTNAME
-SELPART=''
 DOWIN=''
-#make it silent for now until done with testing and jana has been warned
-SILENT=1
 
 if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	usage
@@ -32,69 +25,47 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 CORESIZE=0
-while getopts "m:pwscdCu:v" OPTION
-do
-    case $OPTION in
-	p)
-	    SELPART='Select Partition'
-	    ;;
-	w)
-	    DOWIN='Sort Windows'
-	    ;;
-	s)
-	    SILENT=1
-	    ;;
-	m)
-	    AIMHOST=$OPTARG
-	    ;;
- 	c)
- 	    CORESIZE=2000000000
- 	    ;;
-	u)
-        UED_CNF=$OPTARG
-        ;;
-    C)
-        DAQMGR_CNF=$OPTARG
-        ;;
- 	d)
- 	    DSSTEST=1
- 	    ;;
-    v)
-        VERBOSE=1
-        ;;
-	?)
-	    usage
-	    exit 1
-	    ;;
 
-	esac
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+    -h|--help)
+        usage
+        exit
+        ;;
+    -c|--coresize)
+        CORESIZE=2000000000
+        shift
+        ;;
+    -w|--sortwindows)
+	DOWIN='Sort Windows'
+        shift
+        ;;
+    -C|--cnf)
+        DAQMGR_CNF=$2
+        shift
+        shift
+        ;;
+    esac
 done
 
-# Prevent ShellCheck SC2034 warning for unused vars passed to other scripts
-# shellcheck disable=SC2034
-: "$DAQMGR_CNF" "$VERBOSE"
+# Check if the current's user hutch uses daqmgr. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    if [[ -n "$DAQMGR_CNF" ]]; then
+        daqutils --cnf "$DAQMGR_CNF" "$(basename "$0")"
+    else
+        daqutils "$(basename "$0")" "$@"
+    fi
+    exit 0
+fi
 
 if [[ $(whoami) != *'opr'* ]]; then
     echo "Please run the DAQ from the operator account!"
     exit
 fi
-
-# Check if the current's user hutch uses daqmgr. If so,
-# use the python utilities to manage the daq.
-checkdaqroute "$(basename "$0")" "$@"
-case $? in
-    1)
-        # Not a daqmgr hutch — proceed with local fallback
-        ;;
-    2)
-        echo "Error: Unable to determine DAQ manager status." >&2
-        exit 2
-        ;;
-    *)
-        # Handled by checkdaqroute or failed internally — already exited
-        exit $?
-        ;;
-esac
 
 HUTCH=$(get_info --gethutch)
 CNFEXT=.cnf
@@ -107,10 +78,6 @@ elif [ "$HOSTNAME" == 'cxi-monitor' ]; then
     CNFFILE=$HUTCH$PEXT$CNFEXT
 fi
 
-if [[ "$DSSTEST" == 1 ]]; then
-    CNFFILE=dss.cnf
-fi
-
 #clean the enviroment before sourcing any conda env.
 unset PYTHONPATH
 unset LD_LIBRARY_PATH
@@ -119,22 +86,7 @@ unset LD_LIBRARY_PATH
 cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
 DAQNETWORK='fez'
-LCLS2_HUTCHES="ued"
-if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
-    # shellcheck disable=SC1090
-    source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
-    PROCMGR='procmgr'
-else
-    PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
-fi
-
-# If UED machine; bypass drp node requirement, else; check for drp node
-if [ "$HUTCH" == "ued" ]; then
-    IS_DAQ_HOST=1
-    CNFFILE=$UED_CNF
-else
-    IS_DAQ_HOST=$(netconfig search "$AIMHOST"-$DAQNETWORK --brief | grep -c $DAQNETWORK)
-fi
+PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 
 if [ "$IS_DAQ_HOST" == 0 ]; then
     HOSTS=$(netconfig search "$HUTCH"-*-$DAQNETWORK --brief | sed s/-$DAQNETWORK//g)
@@ -150,11 +102,7 @@ if [ "$IS_DAQ_HOST" == 0 ]; then
     exit
 fi
 
-if [[ $DSSTEST == 1 ]]; then
-    DAQHOST=$(wheredaq -d)
-else
-    DAQHOST=$(wheredaq)
-fi
+DAQHOST=$(wheredaq)
 
 PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" | awk '{print $NF}' | sed s/\'//g)
 if [[ "$DAQHOST" != *$NOTRUNNING* ]]; then
@@ -200,13 +148,8 @@ else
     ssh -Y "$AIMHOST" restartdaq
 fi
 
-if [[ $DSSTEST == 1 ]]; then
-    DAQHOST=$(wheredaq -d)
-    echo 'checked dss-node test DAQ....'
-    echo "$DAQHOST"
-else
-    DAQHOST=$(wheredaq)
-fi
+DAQHOST=$(wheredaq)
+
 
 if [[ "$DAQHOST" == *$NOTRUNNING* ]]; then
     echo 'We tried restarting the DAQ, but wheredaq says its still off!'
@@ -252,25 +195,6 @@ if [ ${#DOWIN} != 0 ]; then
     Sinter="$((Tdinter/1000000000))"
     Minter="$((Tdinter/1000000))"
     echo 'and '"$Sinter"'.'"$Minter"' extra seconds for windows'
-fi
-
-if [ ${#SELPART} != 0 ]; then
-    DAQC=$(xdotool search  --onlyvisible --name 'DAQ Control')
-    #echo $DAQC
-    xdotool mousemove --sync --window "$DAQC" 80 230
-    xdotool windowfocus "$DAQC"
-    xdotool click 1
-
-    PARTSEL=$(xdotool search  --onlyvisible --sync --name 'Partition Selection')
-    YLOW=$(xdotool search --name 'Partition Selection' getwindowgeometry %@ | grep Geometry | awk '{print $2}' | sed s/x/" "/g | awk '{print $2}')
-        #echo $PARTSEL
-    xdotool mousemove --sync --window "$PARTSEL" 80 $(("$YLOW"-28))
-    xdotool click 1
-fi
-
-if [ "$SILENT" == 0 ];then
-    /reg/g/pcds/dist/pds/scripts/txtjana.sh
-    printf 'email jana that we restarted the DAQ\n'
 fi
 
 exit

--- a/scripts/run_daq_utils.py
+++ b/scripts/run_daq_utils.py
@@ -1,143 +1,59 @@
 #!/usr/bin/env python3
 """
-daq-launcher script using DaqManager.
-This script demonstrates the DaqManager class that accepts
-verbose and configuration file arguments and provides commands.
+Enforce more checks and controls for running the DAQ.
 """
 
 import argparse
-import getpass
-import logging
-import shutil
-import socket
-import sys
 
-from daq_utils import DAQMGR_HUTCHES, DaqManager, call_subprocess
-
-# Setup logging for better output management
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+from daq_utils import LOCALHOST, DaqManager
 
 
-def check_isdaqmgr():
-    """
-    Determine if the current hutch uses daqmgr.
-
-    Returns:
-        True if the current hutch is in the list of DAQ manager hutches.
-        False if it's not.
-
-    Behavior:
-        - Uses 'get_info --gethutch' to determine the current hutch.
-        - Compares the result to the DAQMGR_HUTCHES list.
-        - If this check fails (e.g. get_info is missing or returns an error),
-          the function will print an error message to stderr and exit with code 2.
-
-    Exit codes (when called from main()):
-        0 => This is a DAQ manager hutch
-        1 => Not a DAQ manager hutch
-        2 => Unexpected error (e.g., get_info failed)
-    """
-    try:
-        hutch = call_subprocess("get_info", "--gethutch")
-        result = hutch in DAQMGR_HUTCHES
-        logging.debug("check_isdaqmgr: hutch=%s, result=%s", hutch, result)
-        return result
-    except Exception as e:
-        print(f"[isdaqmgr] Error: Failed to determine hutch: {e}", file=sys.stderr)
-        sys.exit(2)
+def restartdaq(daqmgr, args):
+    daqmgr.restartdaq(args.aimhost)
 
 
-def has_slurm():
-    slurm_cmds = ["squeue", "sbatch", "scancel"]
-    missing = [cmd for cmd in slurm_cmds if not shutil.which(cmd)]
-    if missing:
-        logging.error("Missing Slurm commands: %s", ", ".join(missing))
-        return False
-    return True
+def wheredaq(daqmgr, args):
+    daqmgr.wheredaq()
 
 
-def run_cmd(daq, cmd, aimhost=None):
-    try:
-        func = getattr(daq, cmd)
-    except AttributeError:
-        logging.error("Invalid daq command: %s", cmd)
-        return None
-
-    try:
-        if cmd == "restartdaq":
-            if aimhost:
-                logging.debug("Calling DaqManager.restartdaq('%s')", aimhost)
-                return func(aimhost)
-            else:
-                logging.debug("Calling DaqManager.restartdaq() without aimhost")
-                return func()
-        else:
-            logging.debug("Calling DaqManager.%s()", cmd)
-            return func()
-    except Exception as e:
-        logging.error("Error executing daq command '%s': %s", cmd, e)
-        return str(e)
+def stopdaq(daqmgr, args):
+    daqmgr.stopdaq()
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Dummy daq-launcher wrapper using DaqManager"
-    )
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increase output verbosity"
-    )
-    parser.add_argument("-C", "--cnf", type=str, help="Path to configuration file")
-    parser.add_argument(
-        "-m",
-        "--aimhost",
-        type=str,
-        default=socket.gethostname(),
-        help="Target hostname (only applicable for restartdaq). Default: local hostname",
-    )
-    parser.add_argument(
-        "cmd",
-        choices=["restartdaq", "stopdaq", "wheredaq", "isdaqmgr"],
-        help="Command to execute",
-    )
-    return parser.parse_args()
-
-
-def main():
-    args = parse_args()
-
-    if args.verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
-        logging.debug("Verbose mode enabled.")
-
-    # Handle `isdaqmgr` first: this command should not depend on SLURM,
-    # configuration files, or any external setup beyond `get_info` and `DAQMGR_HUTCHES`.
-    if args.cmd == "isdaqmgr":
-        if check_isdaqmgr():
-            print("true")
-            sys.exit()
-        else:
-            print("false")
-            sys.exit()
-
-    if not has_slurm():
-        sys.exit(
-            "Exiting: Slurm is required for launching daq processes. Please install Slurm and try again."
-        )
-
-    if not args.cnf:
-        logging.debug("No configuration file provided. Using default configuration.")
-
-    user = getpass.getuser()
-    hostname = socket.gethostname()
-    logging.debug("Running as %s on %s", user, hostname)
-
-    daq = DaqManager(args.verbose, args.cnf)
-
-    logging.debug("Executing command: %s", args.cmd)
-    run_cmd(daq, args.cmd, aimhost=args.aimhost)
+def isdaqmgr(daqmgr, args):
+    daqmgr.isdaqmgr()
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(prog="run_daq_utils", description=__doc__)
+
+    parser.add_argument("-v", "--verbose", action="store_false")
+    parser.add_argument("--cnf", default=None)
+    subparsers = parser.add_subparsers()
+    psr_restart = subparsers.add_parser(
+        "restartdaq",
+        help="Verify requirements for running the daq then stop and start it.",
+    )
+    psr_restart.add_argument("-m", "--aimhost", action="store_const", const=LOCALHOST)
+    psr_restart.set_defaults(func=restartdaq)
+
+    psr_where = subparsers.add_parser(
+        "wheredaq",
+        help="Discover what host is running the daq in the current hutch, if any.",
+    )
+    psr_where.set_defaults(func=wheredaq)
+
+    psr_stop = subparsers.add_parser(
+        "stopdaq", help="Stop the daq in the current hutch."
+    )
+    psr_stop.set_defaults(func=stopdaq)
+
+    psr_isdaqmgr = subparsers.add_parser(
+        "isdaqmgr", help="Determine if the current hutch uses daqmgr"
+    )
+    psr_isdaqmgr.set_defaults(func=isdaqmgr)
+
+    args = parser.parse_args()
+
+    daqmgr = DaqManager(args.verbose, args.cnf)
+    args.func(daqmgr, args)

--- a/scripts/startami
+++ b/scripts/startami
@@ -39,22 +39,12 @@ if [[ $(whoami) != *'opr'* ]]; then
     exit
 fi
 
-checkdaqroute "$(basename "$0")" "$@"
-case $? in
-    1)
-        # Not a daqmgr hutch — proceed with local fallback
-        ;;
-    2)
-        echo "Error: Unable to determine DAQ manager status." >&2
-        exit 2
-        ;;
-    *)
-        # Handled by checkdaqroute or failed internally — already exited
-        exit $?
-        ;;
-esac
-
 HUTCH=$(get_hutch_name)
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    daqutils --cnf "${HUTCH}"_ami.py restartdaq "$@"
+    exit 0
+fi
+
 EXPNAME=$(get_curr_exp)
 CNFEXT=.cnf
 

--- a/scripts/stopami
+++ b/scripts/stopami
@@ -13,22 +13,11 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-checkdaqroute "$(basename "$0")" "$@"
-case $? in
-    1)
-        # Not a daqmgr hutch — proceed with local fallback
-        ;;
-    2)
-        echo "Error: Unable to determine DAQ manager status." >&2
-        exit 2
-        ;;
-    *)
-        # Handled by checkdaqroute or failed internally — already exited
-        exit $?
-        ;;
-esac
-
 HUTCH=$(get_hutch_name)
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    daqutils --cnf "${HUTCH}"_ami.py stopdaq "$@"
+    exit 0
+fi
 DAQHOST=$(wheredaq)
 RESCNT=$(echo "$DAQHOST" |wc| awk '{print $2}')
 if [ "$RESCNT" -eq 1 ]; then

--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Check if the current's user hutch uses daqmgr. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    daqutils $(basename "$0") $@
+    exit 0
+fi
+
 usage()
 {
 cat << EOF
@@ -13,23 +20,6 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	usage
 	exit 0
 fi
-
-# Check if the current's user hutch uses daqmgr. If so,
-# use the python utilities to manage the daq.
-checkdaqroute "$(basename "$0")" "$@"
-case $? in
-    1)
-        # Not a daqmgr hutch — proceed with local fallback
-        ;;
-    2)
-        echo "Error: Unable to determine DAQ manager status." >&2
-        exit 2
-        ;;
-    *)
-        # Handled by checkdaqroute or failed internally — already exited
-        exit $?
-        ;;
-esac
 
 HUTCH=$(get_info --gethutch)
 DAQHOST=$(wheredaq)
@@ -51,13 +41,11 @@ fi
 unset PYTHONPATH
 unset LD_LIBRARY_PATH
 
-#go to hutches DAQ scripts directory
+#go to hutches DAQ scripts directory 
 #(puts pid file in consistent location - necessary for stopping for LCLS-II DAQ)
 cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
-#tmo, rix & mfx have fallen back (or stepped forward)
-#   on the daqutils check above. only UED is procmgr DAQ hutch
-LCLS2_HUTCHES="ued"
+LCLS2_HUTCHES="rix, tmo, ued"
 if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
     source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
     PROCMGR='procmgr'
@@ -69,7 +57,7 @@ PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFIL
 if [[ "$DAQHOST" != 'DAQ is not running' ]]; then
     T="$(date +%s%N)"
     echo stop the DAQ from "$HOSTNAME"
-    $PROCMGR stop /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE"
+    $PROCMGR stop /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE    
     if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM""$CNFEXT".running ]; then
 	echo 'the DAQ did not stop properly, exit now and try again or call your POC or the DAQ phone'
 	exit

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Check if the current's user hutch uses daqmgr. If so,
+# use the python utilities to manage the daq.
+if [ "$(daqutils isdaqmgr)" = "true" ]; then
+    daqutils $(basename "$0") $@
+    exit 0
+fi
+
 usage()
 {
 cat << EOF
@@ -13,28 +20,6 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	usage
 	exit 0
 fi
-
-#if compgen -G "/usr/bin/sinfo" > /dev/null; then
-
-# ---------------------------------------------------------------
-# Check if this hutch uses daqmgr and should be routed to daqutils.
-# If so, checkdaqroute will handle the command and exit.
-# Otherwise, continue with local logic for non-daqmgr hutches.
-# ---------------------------------------------------------------
-checkdaqroute "$(basename "$0")" "$@"
-case $? in
-    1)
-        # Not a daqmgr hutch — proceed with local fallback
-        ;;
-    2)
-        echo "Error: Unable to determine DAQ manager status." >&2
-        exit 2
-        ;;
-    *)
-        # Handled by checkdaqroute or failed internally — already exited
-        exit $?
-        ;;
-esac
 
 HUTCH=$(get_info --gethutch)
 CNFEXT=.cnf
@@ -61,6 +46,6 @@ if [[ ! -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running ]]; th
 	echo 'DAQ is not running in '"$HUTCH"
     fi
 else
-    DAQ_HOST=$(grep "'HOST'" /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running | awk '{print $3}' | sed "s/'//g")
+    DAQ_HOST=$(grep "'HOST'" /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running | awk {'print $3'} | sed s/\'//g)
     echo 'DAQ is running on '"$DAQ_HOST"
 fi


### PR DESCRIPTION
The commit reverts changes to the DAQ related scripts implemented after R3.13.4
## Description
There were significant changes to the DAQ related code that broke a fair number of scripts. 

## Motivation and Context
There were significant changes to the DAQ related code that broke a fair number of scripts. The plan is to re-introduce the desired changes slowly w/ detailed test.

## How Has This Been Tested?
calling DAQ related scripts in CXI, RIX & TXI. 
MFX has weird implementations of engineering tool in their hutch python, so this will be tested later.
UED still needs to finalize moving to a SLURM DAQ based on python files.