### PR TITLE
fix for makepeds axis

### DIFF
--- a/scripts/makepeds_psana2
+++ b/scripts/makepeds_psana2
@@ -494,8 +494,8 @@ if [[ $HAVE_AXIS_SVLS -ge 1 ]]; then
         fi
 
         MYDET="${DETNAMES[i]// /}"
-	MYDETTYPE="${DETTYPES[i]// /}"
-        if [ "$MYDETTYPE" = 'pv' ]; then
+        MYDETTYPE="${DETTYPES[i]// /}"
+        if [ "$MYDETTYPE" = 'axis' ]; then
             echo 'now calibrate...'$MYDET
             CMD="det_dark_proc -d $MYDET -k exp=$EXP,run=$RUN,dir=$XTCDIR -L INFO $LOCARG"
             echo "$CMD"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Dettype for the axis cam at chemrixs has to be updated.
Tested for rix100836924 run 32

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
```
[opperman@sdfiana002 scripts]$ ./makepeds_psana2 -e rix100836924 -r 32 -q milano
XXXXXXXXXXXXXXXXX START MAKEPEDS at 09:33:16 on sdfiana002 XXXXXXXXXXXXXXXXXXXXXXXXXXXX
This is a LCLS-II experiment
Use XTC files from /sdf/data/lcls/ds/rix/rix100836924/xtc.
We will work from directory /sdf/data/lcls/ds/rix/rix100836924/results/calib_view/pedestal_workdir
Check for data files:
10
-r--r-----+ 1 psdatmgr ps-data      460970 May 18 21:24 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s008-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data    16642696 May 18 21:24 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s009-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data    89157461 May 18 21:24 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s004-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data   551205687 May 18 21:24 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s007-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  5894282986 May 18 21:24 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s005-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  5556317853 May 18 21:25 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s000-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  5894282986 May 18 21:25 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s006-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  5894282986 May 18 21:25 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s002-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  8353347315 May 18 21:25 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s001-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data 38812319556 May 18 21:25 /sdf/data/lcls/ds/rix/rix100836924/xtc/rix100836924-r0032-s003-c000.xtc2
Check detectors:
-----------------------
XTC files contain:
---------------------------------------------------------
Name                | Det Type      | Data Type | Version
---------------------------------------------------------
smdinfo             | offset        | offsetAlg | 0_0_0  
chunkinfo           | chunkinfo     | chunkinfo | 0_0_1  
runinfo             | runinfo       | runinfo   | 0_0_1  
c_piranha           | piranha4      | config    | 2_2_0  
c_piranha           | piranha4      | ttavg     | 1_0_0  
c_piranha           | piranha4      | ttfex     | 1_0_0  
c_piranha           | piranha4      | raw       | 2_1_0  
c_atmopal           | opal          | config    | 2_0_0  
c_atmopal           | opal          | ttproj    | 2_0_0  
c_atmopal           | opal          | ttfex     | 2_1_0  
c_atmopal           | opal          | raw       | 2_0_0  
epics_dontuse       | epics_dontuse | opaltt    | 2_0_0  
rix_fim0            | wave8         | config    | 2_0_0  
rix_fim0            | wave8         | fex       | 0_0_1  
rix_fim0            | wave8         | raw       | 0_0_1  
pvdetinfo_axis_svls | pvdetinfo     | pvdetinfo | 1_0_0  
axis_svls           | axis          | raw       | 1_0_0  
mono_hrencoder      | hrencoder     | config    | 0_1_0  
mono_hrencoder      | hrencoder     | raw       | 0_1_0  
rix_fim1            | wave8         | config    | 2_0_0  
rix_fim1            | wave8         | fex       | 0_0_1  
rix_fim1            | wave8         | raw       | 0_0_1  
crix_w8             | wave8         | config    | 2_0_0  
crix_w8             | wave8         | fex       | 0_0_1  
crix_w8             | wave8         | raw       | 0_0_1  
triginfo            | triginfo      | triginfo  | 0_0_1  
timing              | ts            | raw       | 2_1_0  
timing              | ts            | config    | 2_0_1  
epicsinfo           | epicsinfo     | epicsinfo | 1_0_0  
epics               | epics         | raw       | 2_0_0  
pvdetinfo_andor_vls | pvdetinfo     | pvdetinfo | 1_0_0  
andor_vls           | pv            | raw       | 1_0_0  
---------------------------------------------------------
-----------------------
now calibrate...axis_svls
det_dark_proc -d axis_svls -k exp=rix100836924,run=32,dir=/sdf/data/lcls/ds/rix/rix100836924/xtc -L INFO  -D  -o /sdf/data/lcls/ds/rix/rix100836924/results/calib_view
[I] RepoManager.py L0270 record: 
2025-05-19T09:33:32-0700 user:opperman@sdfiana002 cwd:/sdf/data/lcls/ds/rix/rix100836924/results/calib_view/pedestal_workdir dirrepo:/sdf/data/lcls/ds/rix/rix100836924/results/calib_view logfile:/sdf/data/lcls/ds/rix/rix100836924/results/calib_view/scripts/det_dark_proc/logs/2025/2025-05-19T093331_log_det_dark_proc_opperman.txt command:/sdf/group/lcls/ds/ana/sw/conda2/rel/lcls2_050725/install/bin/det_dark_proc -d axis_svls -k exp=rix100836924,run=32,dir=/sdf/data/lcls/ds/rix/rix100836924/xtc -L INFO -D -o /sdf/data/lcls/ds/rix/rix100836924/results/calib_view
saved in file: /sdf/group/lcls/ds/ana/detector/logs/atstart/2025/2025_lcls2_det_dark_proc.txt
[I] RepoManager.py L0311 optional parameters:
    <key>      <value>              <default>
    dskwargs   exp=rix100836924,run=32,dir=/sdf/data/lcls/ds/rix/rix100836924/xtc None                
    det        axis_svls            None                
    nrecs      500                  500                 
    nrecs1     50                   50                  
    dirrepo    /sdf/data/lcls/ds/rix/rix100836924/results/calib_view /sdf/group/lcls/ds/ana/detector/calib2/constants
    logmode    INFO                 INFO                
    errskip    True                 True                
    stepnum    None                 None                
    stepmax    1                    1                   
    evskip     0                    0                   
    events     1000000              1000000             
    datbits    0x3fff               0x3fff              
    dirmode    0o2775               0o2775              
    filemode   0o664                0o664               
    group      ps-users             ps-users            
    int_lo     1                    1                   
    int_hi     16000                16000               
    intnlo     6.0                  6.0                 
    intnhi     6.0                  6.0                 
    rms_lo     0.001                0.001               
    rms_hi     16000                16000               
    rmsnlo     6.0                  6.0                 
    rmsnhi     6.0                  6.0                 
    fraclm     0.1                  0.1                 
    fraclo     0.05                 0.05                
    frachi     0.95                 0.95                
    deploy     True                 False               
    tstamp     None                 None                
    version    V2025-03-28          V2025-03-28         
    run_end    end                  end                 
    comment    no comment           no comment          
    plotim     0                    0                   

[I] UtilsCalib.py L0654 DataSource kwargs: {'exp': 'rix100836924', 'run': 32, 'dir': '/sdf/data/lcls/ds/rix/rix100836924/xtc'}
[I] UtilsCalib.py L0680 
==== 00 run: 32 exp: rix100836924
[I] UtilsCalib.py L0681 run info:
    run.runnum    : 32
    run.expt      : rix100836924
    run.detnames  : c_atmopal triginfo timing pvdetinfo_axis_svls crix_w8 axis_svls andor_vls pvdetinfo_andor_vls rix_fim1 epicsinfo c_piranha mono_hrencoder rix_fim0
    run.timestamp : 4795230548668689501 -> 2025-05-18T21:23:35
    run.id        : 0
    run.dsparms.det_classes:
            epics : 
                    ('epics', 'raw') : <class 'psana.detector.envstore.epics_raw_2_0_0'>
             scan : 
                    
             step : 
                    
           normal : 
                    ('c_piranha', 'ttavg') : <class 'psana.detector.piranha4.piranha4_ttavg_1_0_0'>
                    ('c_piranha', 'ttfex') : <class 'psana.detector.piranha4.piranha4_ttfex_1_0_0'>
                    ('c_piranha', 'raw') : <class 'psana.detector.piranha4.piranha4_raw_2_1_0'>
                    ('c_atmopal', 'ttproj') : <class 'psana.detector.opal.opal_ttproj_2_0_0'>
                    ('c_atmopal', 'ttfex') : <class 'psana.detector.opal.opal_ttfex_2_1_0'>
                    ('c_atmopal', 'raw') : <class 'psana.detector.opal.opal_raw_2_0_0'>
                    ('rix_fim0', 'fex') : <class 'psana.detector.wave8.wave8_fex_0_0_1'>
                    ('rix_fim0', 'raw') : <class 'psana.detector.wave8.wave8_raw_0_0_1'>
                    ('pvdetinfo_axis_svls', 'pvdetinfo') : <class 'psana.detector.misc_detectors.pvdetinfo_pvdetinfo_1_0_0'>
                    ('axis_svls', 'raw') : <class 'psana.detector.axis.axis_raw_1_0_0'>
                    ('mono_hrencoder', 'raw') : <class 'psana.detector.misc_detectors.hrencoder_raw_0_1_0'>
                    ('rix_fim1', 'fex') : <class 'psana.detector.wave8.wave8_fex_0_0_1'>
                    ('rix_fim1', 'raw') : <class 'psana.detector.wave8.wave8_raw_0_0_1'>
                    ('crix_w8', 'fex') : <class 'psana.detector.wave8.wave8_fex_0_0_1'>
                    ('crix_w8', 'raw') : <class 'psana.detector.wave8.wave8_raw_0_0_1'>
                    ('triginfo', 'triginfo') : <class 'psana.detector.ts.triginfo_triginfo_0_0_1'>
                    ('timing', 'raw') : <class 'psana.detector.ts.ts_raw_2_1_0'>
                    ('epicsinfo', 'epicsinfo') : <class 'psana.detector.misc_detectors.epicsinfo_epicsinfo_1_0_0'>
                    ('pvdetinfo_andor_vls', 'pvdetinfo') : <class 'psana.detector.misc_detectors.pvdetinfo_pvdetinfo_1_0_0'>
                    ('andor_vls', 'raw') : <class 'psana.detector.misc_detectors.pv_raw_1_0_0'>
[I] UtilsCalib.py L0688 created axis_svls detector object
[I] UtilsCalib.py L0689   detector info:
      det.raw._det_name   : axis_svls
      det.raw._dettype    : axis
      _sorted_segment_inds: [0]
      _segment_numbers    : [0]
      det.raw._uniqueid   : axis_
      det.raw._uniqueid.split("_"):
           axis
           
      det methods vbisible: calibconst raw
                   _hidden: _configs _det_name _detid _dettype
      det.raw     vbisible: calib config image raw
                   _hidden: _add_fields _args _arr_for_daq_segments _calibc_ _calibconst _calibconstants _common_mode _configs _det_calibconst _det_geo _det_geotxt_and_meta _det_geotxt_default _det_name _dettype _drp_class_name _env_store _fname_geotxt_default _gain _gain_factor _geo _info _init_geometry _kwargs _mask _mask_calib _mask_calib_or_default _mask_center _mask_comb _mask_default _mask_edges _mask_from_status _mask_neighbors _maskalgos _maskalgos_ _number_of_segments_daq _number_of_segments_total _pedestals _pixel_coord_indexes _pixel_coords _pixel_xy_at_z _return_types _rms _seg_configs _seg_geo _segment_ids _segment_numbers _segments _shape_as_daq _shape_total _sorted_segment_inds _status _store_ _substitute_value_for_missing_segments _uniqueid _var_name
      det.raw._calibconst.keys(): pixel_max, pixel_rms, pedestals, pixel_min, pixel_status
[I] UtilsCalib.py L0697 Step 0
[I] UtilsCalib.py L0432 created empty data block shape:(50, 796, 6144) size:244531200 dtype:uint16 [0 0 0 0 0...]
[I] UtilsCalib.py L0115 begin processing of the data block shape:(50, 796, 6144) size:244531200 dtype:uint16 [1616 1580 1569 1624 1615...]
[I] UtilsCalib.py L0158 proc_block pre-processing time 54.256 sec
    results for median over pixels intensities:
    0.500 fraction of the event spectrum is below 1601.000 ADU - pedestal estimator
    0.050 fraction of the event spectrum is below 1566.000 ADU - gate low limit
    0.950 fraction of the event spectrum is below 1637.000 ADU - gate upper limit
    event spectrum spread median(abs(raw-med))      16.000 ADU - spectral peak width estimator
[I] UtilsCalib.py L0267 data block processing total time 56.676 sec
  arr_med[100:105] shape:(796, 6144) size:4890624 dtype:float64 [1600. 1596. 1569. 1624. 1615....]
  abs_dev[100:105] shape:(796, 6144) size:4890624 dtype:float64 [16. 16. 16. 16. 17....]
  gate_lo[100:105] shape:(796, 6144) size:4890624 dtype:uint16 [1552 1564 1521 1575 1566...]
  gate_hi[100:105] shape:(796, 6144) size:4890624 dtype:uint16 [1632 1612 1633 1657 1647...]
[I] UtilsCalib.py L0279 Stage 2 initialization for raw shape (796, 6144) and dtype uint16
[I] UtilsCalib.py L0417 add to gated average statistics the block of initial data shape:(50, 796, 6144) size:244531200 dtype:uint16 [1603 1599 1598 1600 1646...]
1st stage event block processing is completed
[I] UtilsCalib.py L0449 record 499 event loop is terminated, --nrecs=500
[I] UtilsCalib.py L0758 requested statistics --nrecs=500 is collected - terminate loops
[I] UtilsCalib.py L0763 ==== Ev:167751 end of events in run 32 step 0
[I] UtilsCalib.py L0306 summary
[I] UtilsCalib.py L0307 ________________________________________________________________________________
raw data found/selected in 500 events
[I] UtilsCalib.py L0310 begin data summary stage
[I] UtilsCalib.py L0356 bad pixel status:
  status  1:     1992 pixel rms       > 45.391
  status  2:        1 pixel rms       < 0.001
  status  4:        0 pixel intensity > 16000 in more than 0.1 fraction (49/499) of non-empty events
  status  8:        1 pixel intensity < 1 in more than 0.1 fraction (49/499) of non-empty events
  status 16:      402 pixel average   > 1704.74
  status 32:       18 pixel average   < 1495.85
[I] UtilsCalib.py L0388 summary consumes 2.145 sec
[I] UtilsCalib.py L0774 evaluated constants: 
  arr_av1 shape:(796, 6144) size:4890624 dtype:float64 [1620.89496718 1595.375      1604.55720339 1596.41152263 1624.13441955...]
  arr_rms shape:(796, 6144) size:4890624 dtype:float64 [14.65048363 20.47846938 14.5382645  17.0294888  17.17877298...]
  arr_sta shape:(796, 6144) size:4890624 dtype:uint64 [0 0 0 0 0...]
  arr_max shape:(796, 6144) size:4890624 dtype:uint16 [1684 1696 1645 1648 1678...]
  arr_min shape:(796, 6144) size:4890624 dtype:uint16 [1571 1535 1534 1535 1581...]
[I] UtilsCalib.py L0594 use panelid: 
[I] UtilsCalib.py L0606 preserve constants in repository: /sdf/data/lcls/ds/rix/rix100836924/results/calib_view/axis/pedestals/axis_-s00-20250518212335-rix100836924-r0032-pedestals.data
[I] UtilsCalib.py L0619 constants loaded from file shape:(796, 6144) size:4890624 dtype:float64 [1620.895 1595.375 1604.557 1596.412 1624.134 1615.549 1596.883 1616.352
 1632.083 1627.79 ...]
[I] MDBWebUtils.py L0414 add_data_and_two_docs save constants: pedestals in DBs: cdb_rix100836924 and cdb_axis_ collection: axis_
[W] MDBWebUtils.py L0748 KerberosTicket error: (('Unspecified GSS failure.  Minor code may provide more information', 851968), ('Ticket expired', -1765328352))
[W] MDBWebUtils.py L0749 BEFORE RUNNING THIS SCRIPT TRY COMMAND: kinit
[I] UtilsCalib.py L0624 partial metadata: OrderedDict([('experiment', 'rix100836924'), ('run_orig', 32), ('run', 32), ('detname', 'axis_svls'), ('shortname', 'axis_'), ('ctype', 'pedestals'), ('tsshort', '20250518212335'), ('dettype', 'axis'), ('version', 'V2025-03-28')])
[I] UtilsCalib.py L0629 constants are not deployed
xxxxxxxxxxxxxxxxx END MAKEPEDS at 09:45:54 after  757.757555 XXXXXXXXXXXXXXXXXXXXXXX


```