### PR TITLE
Enh/revertdaq - MFX is treated as LCLS2 instrument & cleanup

### DIFF
--- a/scripts/checkcnf
+++ b/scripts/checkcnf
@@ -15,15 +15,14 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 HUTCH=$(get_info --gethutch)
+DAQTYPE=$(get_info --daq)
 
-LCLS2_HUTCHES="rix, tmo, ued"
-if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
-    # shellcheck disable=SC1090
-    source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
-    PROCMGR='procmgr'
-else
-    PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
+if [[ $DAQTYPE == 'LCLS2' ]]; then
+    echo 'LCLS2 no longer uses cnf files!'
+    exit 0
 fi
+
+PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 
 CNFEXT=.cnf
 CNFFILE="$HUTCH"$CNFEXT
@@ -38,7 +37,7 @@ fi
 STATUS=$($PROCMGR status /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" control_gui)
 ISOK=$(echo "$STATUS" | grep -c platform)
 if [[ $ISOK == 0 ]]; then
-    echo The cnf file for "$HUTCH" can be parsed
+    echo Good, the cnf file for "$HUTCH" can be parsed.
 else
     echo WARNING: the cnf file for "$HUTCH" cannot parsed!
 fi

--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from subprocess import PIPE
 
-DAQMGR_HUTCHES = ["tmo", "rix", "txi", "ued"]
+DAQMGR_HUTCHES = ["tmo", "rix", "txi", "ued", "mfx"]
 LOCALHOST = socket.gethostname()
 SLURM_PARTITION = "drpq"
 SLURM_JOBNAME = "submit_daq"

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -27,16 +27,14 @@ if [[ "$(daqutils isdaqmgr)" = "true" || ${HUTCH} =~ 'ued' ]]; then
     echo "This is an LCLS-II experiment"
     
     SIT_ENV_DIR='/cds/group/pcds/dist/pds/'$HUTCH'/scripts/'
+    source $SIT_ENV_DIR/setup_env.sh
     LCLS2=1
     if [[ ${HUTCH} =~ 'ued' ]]; then
-        source $SIT_ENV_DIR/setup_env.sh
         epixquad_pedestal_scan --record 1 --hutch ${HUTCH}
     elif [[ ${HUTCH} =~ 'mfx' ]]; then
-        source $SIT_ENV_DIR/setup_env.sh
         jungfrau_pedestal_scan --record 1 --hutch ${HUTCH} -p 0 -g 1 -v -t 10000 -C drp-srcf-cmp014
     elif [[ ${HUTCH} =~ 'rix' ]]; then
         echo "Running LCLS2 RIX specific pedestal acquisition..."
-        source /cds/group/pcds/dist/pds/rix/scripts/setup_env.sh
         timed_run --duration="60" --config="/cds/group/pcds/dist/pds/rix/scripts/rix.py" --record
     fi
 else

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -23,9 +23,8 @@ SIT_ENV_DIR="/cds/group/psdm/sw"
 
 HUTCH=$(get_info --gethutch)
 #UED is still using the LCLS2 DAQ w procmgr
-if [[ "$(daqutils isdaqmgr)" = "true" || ${HUTCH} =~ 'ued' ]]; then
+if [[ "$(daqutils isdaqmgr)" = "true" ]]; then
     echo "This is an LCLS-II experiment"
-    
     SIT_ENV_DIR='/cds/group/pcds/dist/pds/'$HUTCH'/scripts/'
     source $SIT_ENV_DIR/setup_env.sh
     LCLS2=1

--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -22,7 +22,6 @@ HUTCH=${EXP:0:3}
 SIT_ENV_DIR="/cds/group/psdm/sw"
 
 HUTCH=$(get_info --gethutch)
-#UED is still using the LCLS2 DAQ w procmgr
 if [[ "$(daqutils isdaqmgr)" = "true" ]]; then
     echo "This is an LCLS-II experiment"
     SIT_ENV_DIR='/cds/group/pcds/dist/pds/'$HUTCH'/scripts/'


### PR DESCRIPTION
## Description
During the initial 'revertdaq' pull request MFX became an LCLS1 hutch again. While they use that DAQ setup currently, we have discussed that they should be considered an LCLS2 hutch as far as engineering_tools goes.
At the same time, I have also removed a second definition of LCLS2 instruments in the checkcnf script.

## Motivation and Context
As discussed above.

## How Has This Been Tested?
I have used MEC, MFX & TXI to make sure the scripts I changed still work

## Where Has This Been Documented?
unfortunately, just here.