### PR TITLE
takepeds for MFX fix.

### DIFF
--- a/scripts/takepeds
+++ b/scripts/takepeds
@@ -51,9 +51,10 @@ fi
 
 if [ $? -eq 0 ]; then
     echo 'Finished taking the pedestals, now posting to the elog'
+    # changing to the LCLS2 DAQ enviroment breaks get_info based scripts
+    source pcds_conda
     echo 'Please call: makepeds -q milano -r '`get_lastRun`' -u <userID>'
     elogMessage="DARK"
-    source pcds_conda
     PYCMD=LogBookPost
 
     RUN=`get_lastRun`


### PR DESCRIPTION
need to source pcds_conda for get_info based scripts after having to source the LCLS2 DAQ environment

## Description
changed when to source pcds_conda in takepeds.

## Motivation and Context
because takepeds fails when trying to post to the elog. This is as get_lastRun does not work in the LCLS2 DAQ environment. The LCLS1 setup does not need this.

## How Has This Been Tested?
Unfortunately not, but this is so minor.