### PR TITLE
Shellcheck motor info

### DIFF
--- a/scripts/motorInfo
+++ b/scripts/motorInfo
@@ -72,7 +72,7 @@ fi
 if [[ $2 == 'autosave' ]]; then
     IOC_DIR='/reg/d/iocData/'$(find_pv "$MOTOR_PV" | grep IOC: | head -n 1 | awk '{print $2}')'/autosave'
 
-    files=$(ls -t "$IOC_DIR"/*sav_1*)
+    files=$(ls -t "$IOC_DIR"/*sav_*)
     for field in $PVFIELDS; do
 	if [[ "$field" == *RBV* ]] || [[ "$field" == *VAL* ]] || [[ "$field" == *DESC* ]]; then
 	    continue
@@ -104,14 +104,14 @@ elif [[ "$2" == *pmgr* ]]; then
     hutch=${HUTCH,,}
     ACTION=$(echo "$2" | cut -d _ -f 2)
     if [[ $ACTION == 'diff' ]]; then
-	/reg/g/pcds/config/"$hutch"/pmgr/pmgrUtils.sh "$ACTION" "$MOTOR_PV"
+	/reg/g/pcds/config/"$hutch"/pmgr/bin/pmgrUtils.sh "$ACTION" "$MOTOR_PV"
     elif [[ $ACTION == 'save' ]]; then
 	echo "Differences of $MOTOR_PV to saved config:"
-	/reg/g/pcds/config/"$hutch"/pmgr/pmgrUtils.sh diff "$MOTOR_PV"
+	/reg/g/pcds/config/"$hutch"/pmgr/bin/pmgrUtils.sh diff "$MOTOR_PV"
 	echo 'Save current config (yes/no)? '; read -r ANSWER
 	if [[ $ANSWER == 'yes' ]]; then
 	    echo 'Save now...'
-	    /reg/g/pcds/config/"$hutch"/pmgr/pmgrUtils.sh save "$MOTOR_PV"
+	    /reg/g/pcds/config/"$hutch"/pmgr/bin/pmgrUtils.sh save "$MOTOR_PV"
 	    echo 'Saved.'
 	fi
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removed trailing whitespace
- Using parameter expansion instead of sed to replace comma with space
- disabling unused var warnings for START and TIME (supposedly to be used when the archiver option is implemented), and FIELD in case it's ever used
- Handling unknown flags by exiting and showing usage
- Removing unnecessary from $ from an arithmetic expression
- Replacing legacy backticks with $(...)
- Using -gt instead of > for arithmetic comparisons
- Using -r to read ANSWER (yes or no from user input)
- Quoting many vars - $1, MOTOR_PV, IOC_DIR, pv (in PVLIST), $2, field (in PVFIELDS), file (in files), currValN, autoVal, file_date, same_value_dat, hutch, ACTION, ADD_MOTOR_PV, newval, value_mot1, values. Most are PVs, filepaths, filenames, or numbers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5216

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo -h
./motorInfo <motor_pv> <motor_pv_2|autosave|archive|pmgr_diff|pmgr_save> [opt]

If given two motors, compare their settings
If given autosave as second argument, compare the current settings to the autosaved values: differences will be printed
If given archive, the archive values will be printed for the last week. If only the base PV is given, extra arguments will be needed

OPTIONS:
-h shows the usage information
-f fields to use as a comma separated list <default: use all autosave values>
-s start time for archiver info <YYYY/MM/DD HH:MM:SS>
-e end time for archiver info <YYYY/MM/DD HH:MM:SS>
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ echo $?
0
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo -z
./motorInfo: illegal option -- z
Unknown flag used
./motorInfo <motor_pv> <motor_pv_2|autosave|archive|pmgr_diff|pmgr_save> [opt]

If given two motors, compare their settings
If given autosave as second argument, compare the current settings to the autosaved values: differences will be printed
If given archive, the archive values will be printed for the last week. If only the base PV is given, extra arguments will be needed

OPTIONS:
-h shows the usage information
-f fields to use as a comma separated list <default: use all autosave values>
-s start time for archiver info <YYYY/MM/DD HH:MM:SS>
-e end time for archiver info <YYYY/MM/DD HH:MM:SS>
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ echo $?
1
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo CXI:DG3:MMS:01
./motorInfo <motor_pv> <motor_pv_2|autosave|archive|pmgr_diff|pmgr_save> [opt]

If given two motors, compare their settings
If given autosave as second argument, compare the current settings to the autosaved values: differences will be printed
If given archive, the archive values will be printed for the last week. If only the base PV is given, extra arguments will be needed

OPTIONS:
-h shows the usage information
-f fields to use as a comma separated list <default: use all autosave values>
-s start time for archiver info <YYYY/MM/DD HH:MM:SS>
-e end time for archiver info <YYYY/MM/DD HH:MM:SS>
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo CXI:DG3:MMS:01 autosave
ls: cannot access /reg/d/iocData/ioc-cxi-dg3-ipm-ims/autosave/*sav_1*: No such file or directory
Looking at the autosave history for: CXI:DG3:MMS:01:CFG_FILE

Looking at the autosave history for: CXI:DG3:MMS:01:REV_MEANS

Looking at the autosave history for: CXI:DG3:MMS:01:FW_MEANS

Looking at the autosave history for: CXI:DG3:MMS:01.HCSV

Looking at the autosave history for: CXI:DG3:MMS:01.DLVL

Looking at the autosave history for: CXI:DG3:MMS:01.ESKL

Looking at the autosave history for: CXI:DG3:MMS:01.ERBL

Looking at the autosave history for: CXI:DG3:MMS:01.EGAG

Looking at the autosave history for: CXI:DG3:MMS:01.HOMD

Looking at the autosave history for: CXI:DG3:MMS:01.TWV

Looking at the autosave history for: CXI:DG3:MMS:01.HACC

Looking at the autosave history for: CXI:DG3:MMS:01.BACC

Looking at the autosave history for: CXI:DG3:MMS:01.ACCL

Looking at the autosave history for: CXI:DG3:MMS:01.HS

Looking at the autosave history for: CXI:DG3:MMS:01.BS

Looking at the autosave history for: CXI:DG3:MMS:01.S

Looking at the autosave history for: CXI:DG3:MMS:01.SMAX

Looking at the autosave history for: CXI:DG3:MMS:01.SBAS

Looking at the autosave history for: CXI:DG3:MMS:01.PREC

Looking at the autosave history for: CXI:DG3:MMS:01.PDBD

Looking at the autosave history for: CXI:DG3:MMS:01.RDBD

Looking at the autosave history for: CXI:DG3:MMS:01.RTRY

Looking at the autosave history for: CXI:DG3:MMS:01.HLM

Looking at the autosave history for: CXI:DG3:MMS:01.LLM

Looking at the autosave history for: CXI:DG3:MMS:01.DHLM

Looking at the autosave history for: CXI:DG3:MMS:01.DLLM

Looking at the autosave history for: CXI:DG3:MMS:01.HDST

Looking at the autosave history for: CXI:DG3:MMS:01.BDST

Looking at the autosave history for: CXI:DG3:MMS:01.HEGE

Looking at the autosave history for: CXI:DG3:MMS:01.HTYP

Looking at the autosave history for: CXI:DG3:MMS:01.FOFF

Looking at the autosave history for: CXI:DG3:MMS:01.OFF

Looking at the autosave history for: CXI:DG3:MMS:01.DIR

Looking at the autosave history for: CXI:DG3:MMS:01.ERES

Looking at the autosave history for: CXI:DG3:MMS:01.MRES

Looking at the autosave history for: CXI:DG3:MMS:01.SREV

Looking at the autosave history for: CXI:DG3:MMS:01.FREV

Looking at the autosave history for: CXI:DG3:MMS:01.UREV

Looking at the autosave history for: CXI:DG3:MMS:01.EGU

Looking at the autosave history for: CXI:DG3:MMS:01.MODE

Looking at the autosave history for: CXI:DG3:MMS:01.HC

Looking at the autosave history for: CXI:DG3:MMS:01.HCMX

Looking at the autosave history for: CXI:DG3:MMS:01.RC

Looking at the autosave history for: CXI:DG3:MMS:01.RCMX

Looking at the autosave history for: CXI:DG3:MMS:01.HT

Looking at the autosave history for: CXI:DG3:MMS:01.MT

Looking at the autosave history for: CXI:DG3:MMS:01.ME

Looking at the autosave history for: CXI:DG3:MMS:01.EL

Looking at the autosave history for: CXI:DG3:MMS:01.EE

Looking at the autosave history for: CXI:DG3:MMS:01.ERSV

Looking at the autosave history for: CXI:DG3:MMS:01.STSV

Looking at the autosave history for: CXI:DG3:MMS:01.SF

Looking at the autosave history for: CXI:DG3:MMS:01.SM

Looking at the autosave history for: CXI:DG3:MMS:01.LM

Looking at the autosave history for: CXI:DG3:MMS:01.PORT

Looking at the autosave history for: CXI:DG3:MMS:01.TYPE

(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo -f .EE,.SF CXI:DG3:MMS:01 autosave
ls: cannot access /reg/d/iocData/ioc-cxi-dg3-ipm-ims/autosave/*sav_1*: No such file or directory
Looking at the autosave history for: CXI:DG3:MMS:01.EE

Looking at the autosave history for: CXI:DG3:MMS:01.SF

(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo CXI:DG3:MMS:01 archive
Command-line archiver is not implemented yet
(pcds-5.9.1) [kaushikm@psbuild-rhel7-01 scripts]$ ./motorInfo CXI:DG3:MMS:01 CXI:DG3:MMS:02
MOTORS DIFF 2 CXI:DG3:MMS:02
Field :  CXI:DG3:MMS:01 -- CXI:DG3:MMS:02
:REV_MEANS :  X- --  - Y-
:FW_MEANS :  X+ --  - Y+
.HCSV :  5 --  - 20
.BACC :  0.1 --  - 0.0014
.ACCL :  0.1 --  - 0.0014
.HS :  2 --  - 0.4
.S :  0.125945 --  - 0.5
.SMAX :  2 --  - 1
.RDBD :  0.004 --  - 0.01
.HLM :  4 --  - 200
.LLM :  -4 --  - -200
.DHLM :  4 --  - 200
.DLLM :  -4 --  - -200
.BDST :  0 --  - -0.1
.HTYP :  N/A --  - E Mark
.FOFF :  Variable --  - Frozen
.ERES :  0.000387695 --  - 0.00244141
.MRES :  1.55078e-05 --  - 9.76563e-05
.UREV :  0.794 --  - 5
.HC :  5 --  - 20
.HCMX :  5 --  - 20
.RC :  50 --  - 75
.RCMX :  50 --  - 75
.SF :  1000 --  - 600
.PORT :  digi-cxi-28:2101 --  - digi-cxi-28:2102
.DESC :  DG3 IPM Diode X --  - DG3 IPM Diode Y
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
