### PR TITLE
added "detectors" option in kwarg for det_dark_proc, do just select the event archon and svls to speed it up.

### DIFF
--- a/scripts/makepeds_psana2
+++ b/scripts/makepeds_psana2
@@ -13,33 +13,33 @@ usage: $0 options
 Make a pedestal file for offline use
 
 OPTIONS:
-        -r|--run         
+        -r|--run
                runnumber for pedestal
-        -e|--experiment <expname> 
+        -e|--experiment <expname>
                in case you do not want pedestals for the ongoing experiment
         -q|--queue <queue>
                queue for batch submisson
-        -O|--opal         
+        -O|--opal
                make pedestals for Opals (default only cspad/EPIX detectors)
-        -Z|--zyla         
+        -Z|--zyla
                make pedestals for Zyla (default only cspad/EPIX detectors)
-        -A|--alvium         
+        -A|--alvium
                make pedestals for Alvium (default only cspad/EPIX detectors)
         --reservation <reservation>
                reservation for batch submisson
         -v|--validity_start <val_run>
                validity range (set to <val_run>-end)
-        -N|--nevents <#>  
+        -N|--nevents <#>
                 use this number of events (default 1000). Needed when using -c as original events are counted
-        -c|--eventcode <evtcode x> 
+        -c|--eventcode <evtcode x>
                 use events with eventcode <x> set
-        -n|--noise_max <#> 
+        -n|--noise_max <#>
                 if you have created a noise file, then write pixel mask file for pixels with noise above #sigmas
-        -C|--noise_min <#> 
+        -C|--noise_min <#>
                 if noise filecreated, write pixel mask file for pixels with noise below xxx (currently integer only)
-        -m|--adu_min <#> 
+        -m|--adu_min <#>
                 write pixel mask file for pixels with pedestal below xxx (currently integer only)
-        -x|--adu_max <#>  
+        -x|--adu_max <#>
                 write pixel mask file for pixels with pedestal above xxx )currently integer only)
         -d|--calibdir
                 give path for alternative calibdir
@@ -108,7 +108,7 @@ check_running_jobs()
     return $NJOBS
 }
 
-# Arg: DETECTOR class.  This could be a comma-separated list, but we're 
+# Arg: DETECTOR class. This could be a comma-separated list, but we're
 # matching it in the config file as a string.
 get_config()
 {
@@ -191,7 +191,7 @@ do
         --noseg)
             NOSEG=1
             shift
-            ;;     
+            ;;
         -v|--validity_start)
             VALSTR=("$2")
             shift
@@ -289,11 +289,11 @@ fi
 
 # set the umask so all the files create are group writeable
 #umask 002
-echo "This is a LCLS-II experiment"    
+echo "This is a LCLS-II experiment"
 SIT_ENV_DIR=$SIT_ENV_DIR'/conda2/'
 source $SIT_ENV_DIR/manage/bin/psconda.sh
 
-#if you don't pass the queue, it'll run interactively 
+#if you don't pass the queue, it'll run interactively
 if [ -v QUEUE ]; then
     USER=$(whoami)
     SBATCH_ARGS="-p $QUEUE --account lcls:$EXP"
@@ -363,7 +363,7 @@ fi
 if [ ! -w "$WORKDIR" ]; then
     echo 'Typical directory to store calib logfiles & results is not writeable, will attempt to work from /tmp, but things may fail'
     WORKDIR='/tmp'
-fi 
+fi
 cd "$WORKDIR" || exit
 echo We will work from directory "$WORKDIR"
 
@@ -390,7 +390,7 @@ while [[ $MINWAIT -lt 5 ]]; do
 	echo 'Files are not present yet, wait a minute'
 	sleep 60
 	MINWAIT=$((MINWAIT+1))
-    else 
+    else
 	HAVEFILES=1
 	MINWAIT=6
     fi
@@ -402,7 +402,7 @@ fi
 
 ls -ltr "$XTCDIR"/*r"$RUNSTR"*s*xtc*
 
-echo Check detectors: 
+echo Check detectors:
 
 detnames -r exp="${EXP}",run="${RUN}",dir="${XTCDIR}" > /tmp/detnames_"$EXP"_"$CREATE_TIME"
 if [[ $? != 0 ]]; then
@@ -417,7 +417,7 @@ cat /tmp/detnames_"$EXP"_"$CREATE_TIME"
 echo "-----------------------"
 
 ####
-# epix100 in LCLS2 related stuff. 
+# epix100 in LCLS2 related stuff.
 ####
 #DEBUG test mfxdaq23 run 5
 #check if epix100 detectors are present
@@ -430,7 +430,7 @@ if [[ $HAVE_EPIX100 -ge 1 ]]; then
     echo "***** have epix100 ***"
     DETNAMES=$(grep epix100 /tmp/detnames_"$EXP"_"$CREATE_TIME" | grep raw | awk  'BEGIN { FS = "|"}; {print $1}' | paste -d " " -s)
     for MYDET in ${DETNAMES}; do
-        LOCARG=$ARG' -o '$CALIBDIR 
+        LOCARG=$ARG' -o '$CALIBDIR
         if [[ -v VALSTR ]]; then
             LOCARG=$LOCARG' -t '$VALSTR
         fi
@@ -469,7 +469,8 @@ if [[ $HAVE_ARCHON -ge 1 ]]; then
 	MYDETTYPE="${DETTYPES[i]// /}"
         if [ "$MYDETTYPE" = 'archon' ]; then
             echo "now calibrate ${MYDET}"
-            CMD="det_dark_proc -d $MYDET -k exp=$EXP,run=$RUN,dir=$XTCDIR -L INFO $LOCARG"
+            KARG="{'exp':'$EXP','run':$RUN,'detectors':['$MYDET'],'dir':'$XTCDIR'}"
+            CMD="det_dark_proc -d $MYDET -k $KARG -L INFO $LOCARG"
             echo "$CMD"
             $CMD
         fi
@@ -493,7 +494,8 @@ if [[ $HAVE_AXIS_SVLS -ge 1 ]]; then
         MYDETTYPE="${DETTYPES[i]// /}"
         if [ "$MYDETTYPE" = 'axis' ]; then
             echo "now calibrate ${MYDET}"
-            CMD="det_dark_proc -d $MYDET -k exp=$EXP,run=$RUN,dir=$XTCDIR -L INFO $LOCARG"
+            KARG="{'exp':'$EXP','run':$RUN,'detectors':['$MYDET'],'dir':'$XTCDIR'}"
+            CMD="det_dark_proc -d $MYDET -k $KARG -L INFO $LOCARG"
             echo "$CMD"
             $CMD
         fi
@@ -517,9 +519,9 @@ if [[ $HAVE_EPIX10K -ge 1 ]]; then
         echo "Epix10ka name for ${EXP} is: ${EPIX10K}"
 	NSEG=1
         if [[ $EPIX10K =~ "2M" ]]; then
-	    NSEG=16; 
+	    NSEG=16;
         elif [[ $EPIX10K =~ "uad" ]]; then
-	    NSEG=4; 
+	    NSEG=4;
 	fi
         for calibcycle in {0..4}; do
             nextcycle=$(( calibcycle + 1 ))
@@ -548,14 +550,14 @@ if [[ $HAVE_EPIX10K -ge 1 ]]; then
                     JOBIDS+=( "$THISJOBID" )
                     NJOBS=$((NJOBS+1))
 		    done
-            else            
+            else
                 echo "$CMD"
                 $CMD
             fi
         done
     done
     ALLJOBIDS=("${JOBIDS[@]}")
-       
+
 
     NFAILEDJOBS=0
     if [[ $RUNLOCAL != 1 ]]; then
@@ -570,7 +572,7 @@ if [[ $HAVE_EPIX10K -ge 1 ]]; then
         done
         echo 'All jobs finished'
         # and now check that none of the jobs have existed with an error code:
-        # currently, the epix10k jobs print DONE at the end. 
+        # currently, the epix10k jobs print DONE at the end.
         # Second check necessary as jobs can fail without printing an exit code to the logfile
         for JOBID in "${ALLJOBIDS[@]}"; do
             echo "Checking job $JOBID"
@@ -606,12 +608,12 @@ if [[ $HAVE_EPIX10K -ge 1 ]]; then
     	    return 1
     	fi
         done
-        
+
         if [[ $RUNLOCAL != 1 ]]; then
             echo 'Print Information about batch jobs'
             JOBIDSTR=''
             for JOBID in "${ALLJOBIDS[@]}"; do
-                if [[ $JOBIDSTR != '' ]]; then 
+                if [[ $JOBIDSTR != '' ]]; then
     		JOBIDSTR=$JOBIDSTR','
     	    fi
             JOBIDSTR=$JOBIDSTR$JOBID
@@ -620,7 +622,7 @@ if [[ $HAVE_EPIX10K -ge 1 ]]; then
         fi
     else
         echo "---------------EPIX10K PEDESTALS CALCULATED     --------------------"
-    fi	
+    fi
     echo "-------------------- STOP EPIX10K PEDESTALS at $(date +'%T') ----------------------------"
 fi
 
@@ -682,7 +684,7 @@ if [[ $HAVE_JUNGFRAU -ge 1 ]]; then
                     JOBIDS+=( "$THISJOBID" )
                     NJOBS=$((NJOBS+1))
 		    done
-            else            
+            else
                 echo "$CMD"
                 $CMD
             fi
@@ -703,7 +705,7 @@ if [[ $HAVE_JUNGFRAU -ge 1 ]]; then
         done
         echo 'All jobs finished'
         # and now check that none of the jobs have existed with an error code:
-        # currently, the jungfrau jobs print DONE at the end. 
+        # currently, the jungfrau jobs print DONE at the end.
         # Second check necessary as jobs can fail without printing an exit code to the logfile
         for JOBID in "${ALLJOBIDS[@]}"; do
             echo "Checking job $JOBID"
@@ -747,12 +749,12 @@ if [[ $HAVE_JUNGFRAU -ge 1 ]]; then
 	        exit 1
      	    fi
         done
-	
+
         if [[ $RUNLOCAL != 1 ]]; then
             echo 'Print Information about batch jobs'
             JOBIDSTR=''
             for JOBID in "${ALLJOBIDS[@]}"; do
-                if [[ $JOBIDSTR != '' ]]; then 
+                if [[ $JOBIDSTR != '' ]]; then
 			JOBIDSTR=$JOBIDSTR','
 		    fi
             JOBIDSTR=$JOBIDSTR$JOBID
@@ -761,7 +763,7 @@ if [[ $HAVE_JUNGFRAU -ge 1 ]]; then
         fi
      else
 	echo "---------------JUNGFRAU PEDESTALS CALCULATED     --------------------"
-    fi	
+    fi
     echo "-------------------- STOP JUNGFRAU PEDESTALS at $(date +'%T') ----------------------------"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add $KARG to makepeds_psana2 for Archon and SVLS do just use the events for the slow detectors,
and delete some spaces.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
run on S3df with makepeds

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
```
[opperman@sdfiana001 scripts]$ ./makepeds -q milano -e rix101333324 -r 70
This is a LCLS-II experiment
/sdf/home/o/opperman/ET/engineering_tools/scripts/makepeds_psana2 --queue milano --experiment rix101333324 --run 70
XXXXXXXXXXXXXXXXX START MAKEPEDS at 09:46:57 on sdfiana001 XXXXXXXXXXXXXXXXXXXXXXXXXXXX
This is a LCLS-II experiment
Use XTC files from /sdf/data/lcls/ds/rix/rix101333324/xtc.
We will work from directory /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/pedestal_workdir
Check for data files:
11
-r--r-----+ 1 psdatmgr ps-data      403562 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s009-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data    34642576 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s005-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data    15410568 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s010-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data   115775064 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s003-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data   216061676 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s004-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  2158488285 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s001-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  2289791336 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s007-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data  2289791336 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s000-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data 12344746208 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s006-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data 12344746208 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s008-c000.xtc2
-r--r-----+ 1 psdatmgr ps-data 12849804863 May 22 09:31 /sdf/data/lcls/ds/rix/rix101333324/xtc/rix101333324-r0070-s002-c000.xtc2
Check detectors:
-----------------------
XTC files contain:
--------------------------------------------------
Name             | Det Type  | Data Type | Version
--------------------------------------------------
smdinfo          | offset    | offsetAlg | 0_0_0  
chunkinfo        | chunkinfo | chunkinfo | 0_0_1  
runinfo          | runinfo   | runinfo   | 0_0_1  
rix_fim0         | wave8     | config    | 2_0_0  
rix_fim0         | wave8     | fex       | 0_0_1  
rix_fim0         | wave8     | raw       | 0_0_1  
q_piranha        | piranha4  | config    | 2_2_0  
q_piranha        | piranha4  | raw       | 2_1_0  
q_atmopal        | opal      | config    | 2_0_0  
q_atmopal        | opal      | raw       | 2_0_0  
pcav             | scbld     | raw       | 1_0_0  
xgmd             | scbld     | raw       | 1_0_0  
gmd              | scbld     | raw       | 1_0_0  
triginfo         | triginfo  | triginfo  | 0_0_1  
timing           | ts        | raw       | 2_1_0  
timing           | ts        | config    | 2_0_1  
mono_hrencoder   | hrencoder | config    | 0_1_0  
mono_hrencoder   | hrencoder | raw       | 0_1_0  
hsd              | hsd       | raw       | 3_0_0  
hsd              | hsd       | config    | 3_1_0  
rix_fim1         | wave8     | config    | 2_0_0  
rix_fim1         | wave8     | fex       | 0_0_1  
rix_fim1         | wave8     | raw       | 0_0_1  
epicsinfo        | epicsinfo | epicsinfo | 1_0_0  
epics            | epics     | raw       | 2_0_0  
pvdetinfo_archon | pvdetinfo | pvdetinfo | 1_0_0  
archon           | archon    | raw       | 1_0_1  
--------------------------------------------------
-----------------------
now calibrate archon
det_dark_proc -d archon -k {'exp':'rix101333324','run':70,'detectors':['archon'],'dir':'/sdf/data/lcls/ds/rix/rix101333324/xtc'} -L INFO  -D  -o /sdf/data/lcls/ds/rix/rix101333324/results/calib_view
[I] RepoManager.py L0270 record: 
2025-06-24T09:47:07-0700 user:opperman@sdfiana001 cwd:/sdf/data/lcls/ds/rix/rix101333324/results/calib_view/pedestal_workdir dirrepo:/sdf/data/lcls/ds/rix/rix101333324/results/calib_view logfile:/sdf/data/lcls/ds/rix/rix101333324/results/calib_view/scripts/det_dark_proc/logs/2025/2025-06-24T094707_log_det_dark_proc_opperman.txt command:/sdf/group/lcls/ds/ana/sw/conda2/rel/lcls2_050725/install/bin/det_dark_proc -d archon -k {'exp':'rix101333324','run':70,'detectors':['archon'],'dir':'/sdf/data/lcls/ds/rix/rix101333324/xtc'} -L INFO -D -o /sdf/data/lcls/ds/rix/rix101333324/results/calib_view
saved in file: /sdf/group/lcls/ds/ana/detector/logs/atstart/2025/2025_lcls2_det_dark_proc.txt
[I] RepoManager.py L0311 optional parameters:
    <key>      <value>              <default>
    dskwargs   {'exp':'rix101333324','run':70,'detectors':['archon'],'dir':'/sdf/data/lcls/ds/rix/rix101333324/xtc'} None                
    det        archon               None                
    nrecs      500                  500                 
    nrecs1     50                   50                  
    dirrepo    /sdf/data/lcls/ds/rix/rix101333324/results/calib_view /sdf/group/lcls/ds/ana/detector/calib2/constants
    logmode    INFO                 INFO                
    errskip    True                 True                
    stepnum    None                 None                
    stepmax    1                    1                   
    evskip     0                    0                   
    events     1000000              1000000             
    datbits    0x3fff               0x3fff              
    dirmode    0o2775               0o2775              
    filemode   0o664                0o664               
    group      ps-users             ps-users            
    int_lo     1                    1                   
    int_hi     16000                16000               
    intnlo     6.0                  6.0                 
    intnhi     6.0                  6.0                 
    rms_lo     0.001                0.001               
    rms_hi     16000                16000               
    rmsnlo     6.0                  6.0                 
    rmsnhi     6.0                  6.0                 
    fraclm     0.1                  0.1                 
    fraclo     0.05                 0.05                
    frachi     0.95                 0.95                
    deploy     True                 False               
    tstamp     None                 None                
    version    V2025-03-28          V2025-03-28         
    run_end    end                  end                 
    comment    no comment           no comment          
    plotim     0                    0                   

[I] UtilsCalib.py L0686 DataSource kwargs: {'exp': 'rix101333324', 'run': 70, 'detectors': ['archon'], 'dir': '/sdf/data/lcls/ds/rix/rix101333324/xtc'}
[I] UtilsCalib.py L0712 
==== 00 run: 70 exp: rix101333324
[I] UtilsCalib.py L0713 run info:
    run.runnum    : 70
    run.expt      : rix101333324
    run.detnames  : pvdetinfo_archon archon
    run.timestamp : 4796531107464273970 -> 2025-05-22T09:30:25
    run.id        : 0
    run.dsparms.det_classes:
            epics : 
                    
             scan : 
                    
             step : 
                    
           normal : 
                    ('pvdetinfo_archon', 'pvdetinfo') : <class 'psana.detector.misc_detectors.pvdetinfo_pvdetinfo_1_0_0'>
                    ('archon', 'raw') : <class 'psana.detector.archon.archon_raw_1_0_0'>
[I] UtilsCalib.py L0720 created archon detector object
[I] UtilsCalib.py L0721   detector info:
      det.raw._det_name   : archon
      det.raw._dettype    : archon
      _sorted_segment_inds: [0]
      _segment_numbers    : [0]
      det.raw._uniqueid   : archon_1
      det.raw._uniqueid.split("_"):
           archon
           1
      det methods vbisible: calibconst raw
                   _hidden: _configs _det_name _detid _dettype
      det.raw     vbisible: calib config image raw
                   _hidden: _add_fields _args _arr_for_daq_segments _arr_to_image _arr_to_image_v0 _calibc_ _calibconst _calibconstants _cmpars _common_mode _common_mode_v0 _common_mode_v1 _configs _det_calibconst _det_geo _det_geotxt_and_meta _det_geotxt_default _det_name _dettype _drp_class_name _env_store _fakePixelsPerBank _fname_geotxt_default _gain _gain_factor _gainfact _geo _info _kwargs _mask _mask_calib _mask_calib_or_default _mask_center _mask_comb _mask_default _mask_edges _mask_fake _mask_from_status _mask_neighbors _maskalgos _maskalgos_ _nbanks _number_of_segments_daq _number_of_segments_total _path_geo_default _pedestals _pixel_coord_indexes _pixel_coords _pixel_xy_at_z _realPixelsPerBank _return_types _rms _seg_configs _seg_geo _segment_ids _segment_numbers _segments _set_tstamp_pixel_values _shape_as_daq _shape_total _sorted_segment_inds _status _store_ _substitute_value_for_missing_segments _totPixelsPerBank _totRealPixels _tstamp _tstamp_raw _uniqueid _var_name
      det.raw._calibconst.keys(): pixel_max, pixel_min, pedestals, pixel_rms, pixel_status
[I] UtilsCalib.py L0729 Step 0
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:    1/   1/   1/   1/   0  time=  0.182 sec dt=0.182 sec
[I] UtilsCalib.py L0464 created empty data block shape:(50, 1, 4800) size:240000 dtype:uint16 [0 0 0 0 0...]
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:    2/   2/   2/   2/   0  time=  0.182 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:    3/   3/   3/   3/   0  time=  0.182 sec dt=0.000 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:    4/   4/   4/   4/   0  time=  0.182 sec dt=0.000 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:   10/  10/  10/  10/   0  time=  0.183 sec dt=0.000 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:   20/  20/  20/  20/   0  time=  0.184 sec dt=0.000 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:   30/  30/  30/  30/   0  time=  0.184 sec dt=0.000 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:   40/  40/  40/  40/   0  time=  0.184 sec dt=0.000 sec
[I] UtilsCalib.py L0114 begin processing of the data block shape:(50, 1, 4800) size:240000 dtype:uint16 [2486 2478 2481 2483 2483...]
[I] UtilsCalib.py L0158 proc_block pre-processing time 0.018 sec
    results for median over pixels intensities:
    0.500 fraction of the event spectrum is below 2793.000 ADU - pedestal estimator
    0.050 fraction of the event spectrum is below 2787.000 ADU - gate low limit
    0.950 fraction of the event spectrum is below 2798.000 ADU - gate upper limit
    event spectrum spread median(abs(raw-med))      2.000 ADU - spectral peak width estimator
[I] UtilsCalib.py L0299 data block processing total time 0.020 sec
  arr_med[100:105] shape:(1, 4800) size:4800 dtype:float64 [2483. 2483. 2482. 2482. 2483....]
  abs_dev[100:105] shape:(1, 4800) size:4800 dtype:float64 [2. 2. 2. 3. 3....]
  gate_lo[100:105] shape:(1, 4800) size:4800 dtype:uint16 [2478 2478 2475 2475 2476...]
  gate_hi[100:105] shape:(1, 4800) size:4800 dtype:uint16 [2488 2489 2491 2489 2488...]
[I] UtilsCalib.py L0311 Stage 2 initialization for raw shape (1, 4800) and dtype uint16
[I] UtilsCalib.py L0449 add to gated average statistics the block of initial data shape:(50, 1, 4800) size:240000 dtype:uint16 [ 8173 20969 65527     2  2468...]
1st stage event block processing is completed
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:   60/  60/  60/  60/   0  time=  0.236 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:   80/  80/  80/  80/   0  time=  0.250 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  100/ 100/ 100/ 100/   0  time=  0.261 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  120/ 120/ 120/ 120/   0  time=  0.277 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  140/ 140/ 140/ 140/   0  time=  0.291 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  160/ 160/ 160/ 160/   0  time=  0.304 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  180/ 180/ 180/ 180/   0  time=  0.318 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  200/ 200/ 200/ 200/   0  time=  0.331 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  300/ 300/ 300/ 300/   0  time=  0.399 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  400/ 400/ 400/ 400/   0  time=  0.462 sec dt=0.001 sec
[I] UtilsCalib.py L0786 run[0] 70  step 0  events total/run/step/selected/none:  500/ 500/ 500/ 500/   0  time=  0.520 sec dt=0.001 sec
[I] UtilsCalib.py L0481 record 499 event loop is terminated, --nrecs=500
[I] UtilsCalib.py L0790 requested statistics --nrecs=500 is collected - terminate loops
[I] UtilsCalib.py L0795 ==== Ev:0499 end of events in run 70 step 0
[I] UtilsCalib.py L0338 summary
[I] UtilsCalib.py L0339 ________________________________________________________________________________
raw data found/selected in 500 events
[I] UtilsCalib.py L0342 begin data summary stage
[I] UtilsCalib.py L0388 bad pixel status:
  status  1:        1 pixel rms       > 367.876
  status  2:        2 pixel rms       < 0.001
  status  4:        1 pixel intensity > 16000 in more than 0.1 fraction (49/499) of non-empty events
  status  8:        0 pixel intensity < 1 in more than 0.1 fraction (49/499) of non-empty events
  status 16:        2 pixel average   > 4246.6
  status 32:        2 pixel average   < 1174.66
[I] UtilsCalib.py L0420 summary consumes 0.003 sec
[I] UtilsCalib.py L0806 evaluated constants: 
  arr_av1 shape:(1, 4800) size:4800 dtype:float64 [8.36436937e+03 4.95097826e+03 0.00000000e+00 2.00000000e+00
 2.46744350e+03...]
  arr_rms shape:(1, 4800) size:4800 dtype:float64 [4.20232558e+03 1.98596980e+02 0.00000000e+00 0.00000000e+00
 3.00736575e+00...]
  arr_sta shape:(1, 4800) size:4800 dtype:uint64 [17 16 38 34  0...]
  arr_max shape:(1, 4800) size:4800 dtype:uint16 [16290 12046 16375     2  2478...]
  arr_min shape:(1, 4800) size:4800 dtype:uint16 [   24  4585 16375     2  2458...]
[I] UtilsCalib.py L0626 use panelid: 1
[I] UtilsCalib.py L0638 preserve constants in repository: /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/archon/1/pedestals/archon_1-s00-20250522093025-rix101333324-r0070-pedestals.data
[I] UtilsCalib.py L0651 constants loaded from file shape:(1, 4800) size:4800 dtype:float64 [8.364369e+03 4.950978e+03 0.000000e+00 2.000000e+00 2.467443e+03
 2.471807e+03 2.474122e+03 2.476249e+03 2.477828e+03 2.479514e+03...]
[I] MDBWebUtils.py L0420 add_data_and_two_docs save constants: pedestals in DBs: cdb_rix101333324 and cdb_archon_1 collection: archon_1
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_rix101333324/gridfs/ resp: {"_id": "685ad68cbb8b0bac73a703d8"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/archon_1/
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_archon_1/gridfs/ resp: {"_id": "685ad68c73621fb919c96f99"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/archon_1/
[I] UtilsCalib.py L0656 partial metadata: OrderedDict([('experiment', 'rix101333324'), ('run_orig', 70), ('run', 70), ('detname', 'archon'), ('shortname', 'archon_1'), ('ctype', 'pedestals'), ('tsshort', '20250522093025'), ('dettype', 'archon'), ('version', 'V2025-03-28')])
[I] UtilsCalib.py L0638 preserve constants in repository: /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/archon/1/pixel_rms/archon_1-s00-20250522093025-rix101333324-r0070-pixel_rms.data
[I] UtilsCalib.py L0651 constants loaded from file shape:(1, 4800) size:4800 dtype:float64 [4.202326e+03 1.985970e+02 0.000000e+00 0.000000e+00 3.007000e+00
 2.820000e+00 3.256000e+00 3.120000e+00 2.970000e+00 2.749000e+00...]
[I] MDBWebUtils.py L0420 add_data_and_two_docs save constants: pixel_rms in DBs: cdb_rix101333324 and cdb_archon_1 collection: archon_1
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_rix101333324/gridfs/ resp: {"_id": "685ad68d2f65db1c0b650caf"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/archon_1/
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_archon_1/gridfs/ resp: {"_id": "685ad68dae6c20b6e5ee1c53"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/archon_1/
[I] UtilsCalib.py L0656 partial metadata: OrderedDict([('experiment', 'rix101333324'), ('run_orig', 70), ('run', 70), ('detname', 'archon'), ('shortname', 'archon_1'), ('ctype', 'pixel_rms'), ('tsshort', '20250522093025'), ('dettype', 'archon'), ('version', 'V2025-03-28')])
[I] UtilsCalib.py L0638 preserve constants in repository: /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/archon/1/pixel_status/archon_1-s00-20250522093025-rix101333324-r0070-pixel_status.data
[I] UtilsCalib.py L0651 constants loaded from file shape:(1, 4800) size:4800 dtype:uint64 [17 16 38 34  0  0  0  0  0  0...]
[I] MDBWebUtils.py L0420 add_data_and_two_docs save constants: pixel_status in DBs: cdb_rix101333324 and cdb_archon_1 collection: archon_1
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_rix101333324/gridfs/ resp: {"_id": "685ad68dd7a7cb1e537bf283"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/archon_1/
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_archon_1/gridfs/ resp: {"_id": "685ad68ebb8b0bac73a703db"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/archon_1/
[I] UtilsCalib.py L0656 partial metadata: OrderedDict([('experiment', 'rix101333324'), ('run_orig', 70), ('run', 70), ('detname', 'archon'), ('shortname', 'archon_1'), ('ctype', 'pixel_status'), ('tsshort', '20250522093025'), ('dettype', 'archon'), ('version', 'V2025-03-28')])
[I] UtilsCalib.py L0638 preserve constants in repository: /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/archon/1/pixel_max/archon_1-s00-20250522093025-rix101333324-r0070-pixel_max.data
[I] UtilsCalib.py L0651 constants loaded from file shape:(1, 4800) size:4800 dtype:uint16 [16290 12046 16375     2  2478  2482  2485  2489  2492  2490...]
[I] MDBWebUtils.py L0420 add_data_and_two_docs save constants: pixel_max in DBs: cdb_rix101333324 and cdb_archon_1 collection: archon_1
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_rix101333324/gridfs/ resp: {"_id": "685ad68ed7a7cb1e537bf285"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/archon_1/
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_archon_1/gridfs/ resp: {"_id": "685ad68eea5ed3e2c04d297f"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/archon_1/
[I] UtilsCalib.py L0656 partial metadata: OrderedDict([('experiment', 'rix101333324'), ('run_orig', 70), ('run', 70), ('detname', 'archon'), ('shortname', 'archon_1'), ('ctype', 'pixel_max'), ('tsshort', '20250522093025'), ('dettype', 'archon'), ('version', 'V2025-03-28')])
[I] UtilsCalib.py L0638 preserve constants in repository: /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/archon/1/pixel_min/archon_1-s00-20250522093025-rix101333324-r0070-pixel_min.data
[I] UtilsCalib.py L0651 constants loaded from file shape:(1, 4800) size:4800 dtype:uint16 [   24  4585 16375     2  2458  2462  2465  2465  2468  2466...]
[I] MDBWebUtils.py L0420 add_data_and_two_docs save constants: pixel_min in DBs: cdb_rix101333324 and cdb_archon_1 collection: archon_1
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_rix101333324/gridfs/ resp: {"_id": "685ad68fae6c20b6e5ee1c55"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_rix101333324/archon_1/
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/gridfs/
[I] MDBWebUtils.py L0355 add_data: to cdb_archon_1/gridfs/ resp: {"_id": "685ad68fbb8b0bac73a703de"}
XXX MDBWebUtils: post url:https://psdmint.sdf.slac.stanford.edu/ws-kerb/calib_ws/cdb_archon_1/archon_1/
[I] UtilsCalib.py L0656 partial metadata: OrderedDict([('experiment', 'rix101333324'), ('run_orig', 70), ('run', 70), ('detname', 'archon'), ('shortname', 'archon_1'), ('ctype', 'pixel_min'), ('tsshort', '20250522093025'), ('dettype', 'archon'), ('version', 'V2025-03-28')])
[I] UtilsCalib.py L0820 terminate_steps
[I] UtilsCalib.py L0824 terminate_runs
[I] RepoManager.py L0250 
  move logfile: /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/scripts/det_dark_proc/logs/2025/2025-06-24T094707_log_det_dark_proc_opperman.txt
  to:           /sdf/data/lcls/ds/rix/rix101333324/results/calib_view/archon/logs/2025/2025-06-24T094707_log_det_dark_proc_opperman.txt
  and create link
[I] det_dark_proc.py L0151 DONE, consumed time 4.425 sec
xxxxxxxxxxxxxxxxx END MAKEPEDS at 09:47:12 after  14.14918 XXXXXXXXXXXXXXXXXXXXXXX
pedestal rix101333324 70
{'pedestal': 'done'}
URL: https://pswww.slac.stanford.edu/ws-auth/lgbk//run_control/rix101333324/ws/add_run_params
<Response [403]>
---- Done processing pedestals for Run 70 -----
```
