### PR TITLE
ENH: extend iocmanager, imgr wrappers to allow for R3.0.0

### DIFF
--- a/scripts/imgr
+++ b/scripts/imgr
@@ -21,7 +21,9 @@ done
 HUTCH=${ARGHUTCH:-$HUTCH}
 HUTCH=${HUTCH:-$(get_hutch_name)}
 
-: "${PYPS_ROOT:=/cds/group/pcds/pyps}"
+if [[ -z "${PYPS_ROOT}" ]]; then
+    PYPS_ROOT=/cds/group/pcds/pyps
+fi
 
 if [[ "$HUTCH" == "unknown_hutch" ]]; then
     IOCMANAGER="${PYPS_ROOT}/apps/iocmanager/latest-R3"

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -10,7 +10,9 @@ else
     HUTCH=${1:-$(get_hutch_name)}
 fi
 
-: "${PYPS_ROOT:=/cds/group/pcds/pyps}"
+if [[ -z "${PYPS_ROOT}" ]]; then
+    PYPS_ROOT=/cds/group/pcds/pyps
+fi
 
 if [[ "$HUTCH" == "unknown_hutch" ]]; then
     IOCMANAGER="${PYPS_ROOT}/apps/iocmanager/latest-R3"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The wrapper scripts for `iocmanager` and `imgr` have been modified to allow for either the "old" (py2, rhel7) or the "new" (py3, rhel7/rhel9) versions of `iocmanager` during this transition period.

The intention is to deploy this during the shutdown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows people to use the new `iocmanager` (R3.0.0+) when they are ready.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only
Probably it needs more testing

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
