### PR TITLE
Server stat expert edt 

### DIFF
--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -783,7 +783,7 @@ if [[ ( $HAVE_EPIX10K -ge 1 ) && ( $WANT_ZYLA -eq 0 ) && ( $WANT_OPAL -eq 0 ) &&
                     printf '#!/bin/bash\n' > "$tmpScript"
                     printf 'source %s/manage/bin/psconda.sh\n' "${SIT_ENV_DIR}" >> "$tmpScript"
                     printf '%s\n' "${CMD}" >> "$tmpScript"
-                    ep10kaCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 5 -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
+                    ep10kaCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 1 -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
                     echo "run in queue: $ep10kaCmd"
                     SUBMISSION=$($ep10kaCmd)
                     check_for_submit_error

--- a/scripts/makepeds_psana2
+++ b/scripts/makepeds_psana2
@@ -540,7 +540,7 @@ if [[ $HAVE_EPIX10K -ge 1 ]]; then
                     printf '#!/bin/bash\n' > "$tmpScript"
 			printf 'source %s/manage/bin/psconda.sh\n' "${SIT_ENV_DIR}" >> "$tmpScript"
                     printf '%s\n' "${CMDS}" >> "$tmpScript"
-                    ep10kaCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 5 -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
+                    ep10kaCmd="sbatch ${SBATCH_ARGS} --mem 8GB --cpus-per-task 1 -o $WORKDIR/${EPIX10K}_${EXP}_Run${RUN}_cycle${calibcycle}_%J.out $tmpScript"
 
                     echo "run in queue: $ep10kaCmd"
                     SUBMISSION=$($ep10kaCmd)
@@ -674,7 +674,7 @@ if [[ $HAVE_JUNGFRAU -ge 1 ]]; then
                     printf '#!/bin/bash\n' > "$tmpScript"
                     printf 'source %s/manage/bin/psconda.sh\n' "${SIT_ENV_DIR}" >> "$tmpScript"
                     printf '%s\n' "${CMDS}" >> "$tmpScript"
-                    jfCmd="sbatch ${SBATCH_ARGS} --mem ${MEM}GB --cpus-per-task 5 -o $WORKDIR/${JUNGFRAU}_${EXP}_Run${RUN}_cycle${calibcycle}_segment${segment}_%J.out $tmpScript"
+                    jfCmd="sbatch ${SBATCH_ARGS} --mem ${MEM}GB --cpus-per-task 1 -o $WORKDIR/${JUNGFRAU}_${EXP}_Run${RUN}_cycle${calibcycle}_segment${segment}_%J.out $tmpScript"
 
                     echo "run in queue: $jfCmd"
                     SUBMISSION=$($jfCmd)

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -223,11 +223,13 @@ elif [[ $CMD == "expert" ]]; then
     else
        echo "$NAME-ipmi does not ping."
     fi
-    ping -w 2 "$NAME"-fez >/dev/null 2>&1
-    if [[ $? == 0 ]]; then
-       echo "$NAME-fez pings."
-    else
-       echo "$NAME-fez does not ping."
+    if [[ $(netconfig search "$NAME"-fez --brief | wc -w) -gt 0 ]]; then
+	ping -w 2 "$NAME"-fez >/dev/null 2>&1
+        if [[ $? == 0 ]]; then
+           echo "$NAME-fez pings."
+        else
+           echo "$NAME-fez does not ping."
+        fi
     fi
     echo -e " "
     if [[ $CDS_ONLINE == 1 ]]; then
@@ -242,18 +244,17 @@ elif [[ $CMD == "expert" ]]; then
             echo -e "-------------------------------------------------"
             lspci | grep SLAC
             echo -e ""
+            echo -e "Serial PCI Hardware:"
+            echo -e "-------------------------------------------------"
+            lspci | grep -i serial
+            echo -e ""
+            echo -e "EDT cards"
+            echo -e "-------------------------------------------------"
+            lspci | grep -i 'Engineering Design Team'
+            echo -e ""
             echo -e "Network PCI Hardware:"
             echo -e "-------------------------------------------------"
             lspci | grep Ethernet
-            echo -e ""
-            echo -e "Leutron PCI Hardware:"
-            echo -e "-------------------------------------------------"
-            echo -e ""
-            if [[ -e /opt/EDTpdv/pciload ]]; then
-               echo -e "EDT Cards:"
-               echo -e "-------------------------------------------------"
-               /opt/EDTpdv/pciload
-            fi
             echo -e ""
             echo -e "IOC Processes:"
             echo -e "-------------------------------------------------"

--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -45,14 +45,7 @@ unset LD_LIBRARY_PATH
 #(puts pid file in consistent location - necessary for stopping for LCLS-II DAQ)
 cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
-LCLS2_HUTCHES="rix, tmo, ued"
-if echo "$LCLS2_HUTCHES" | grep -iw "$HUTCH" > /dev/null; then
-    source /reg/g/pcds/dist/pds/"$HUTCH"/scripts/setup_env.sh
-    PROCMGR='procmgr'
-else
-    PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
-fi
-
+PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE" | awk '{print $NF}' | sed s/\'//g)
 if [[ "$DAQHOST" != 'DAQ is not running' ]]; then
     T="$(date +%s%N)"


### PR DESCRIPTION
## Description
This pull request contains mostly changes to the 'expert' option of serverStat. 
stopdaq had a few lines removed that were no longer necessary and makepeds_psana no longer requests 5 CPUs where 1 suffices.
Other minor changes to the information displayed have been added and three other minor changes to other script have been packaged


## Motivation and Context
serverStat --expert
could lead to machines becoming unresponsive - which is not the expected behavior for a command that is simply supposed to show you some information about said server. The only recent change has been an update to the EDT code that was called to gain more information about those cards. Given that we have essentially discontinued the use of these cards, I have chosen to simple display that there _is_ one.

## How Has This Been Tested?
processed pedestals for the epixquad in MEC & the jungfrau 4M in MFX
ran serverStat ioc-xrt-rec06 expert without adverse effects
(host w/ EDT card)

## Where Has This Been Documented?
here