### PR TITLE
Shellcheck stopdaq and wheredaq

### DIFF
--- a/scripts/stopdaq
+++ b/scripts/stopdaq
@@ -3,7 +3,8 @@
 # Check if the current's user hutch uses daqmgr. If so,
 # use the python utilities to manage the daq.
 if [ "$(daqutils isdaqmgr)" = "true" ]; then
-    daqutils $(basename "$0") $@
+    # shellcheck disable=SC2068
+    daqutils "$(basename "$0")" $@
     exit 0
 fi
 
@@ -41,7 +42,7 @@ fi
 unset PYTHONPATH
 unset LD_LIBRARY_PATH
 
-#go to hutches DAQ scripts directory 
+#go to hutches DAQ scripts directory
 #(puts pid file in consistent location - necessary for stopping for LCLS-II DAQ)
 cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 
@@ -50,7 +51,7 @@ PLATFORM=$(grep 'if not platform' /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFIL
 if [[ "$DAQHOST" != 'DAQ is not running' ]]; then
     T="$(date +%s%N)"
     echo stop the DAQ from "$HOSTNAME"
-    $PROCMGR stop /reg/g/pcds/dist/pds/"$HUTCH"/scripts/$CNFFILE    
+    $PROCMGR stop /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNFFILE"
     if [ -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM""$CNFEXT".running ]; then
 	echo 'the DAQ did not stop properly, exit now and try again or call your POC or the DAQ phone'
 	exit

--- a/scripts/wheredaq
+++ b/scripts/wheredaq
@@ -3,7 +3,8 @@
 # Check if the current's user hutch uses daqmgr. If so,
 # use the python utilities to manage the daq.
 if [ "$(daqutils isdaqmgr)" = "true" ]; then
-    daqutils $(basename "$0") $@
+    # shellcheck disable=SC2068
+    daqutils "$(basename "$0")" $@
     exit 0
 fi
 
@@ -46,6 +47,6 @@ if [[ ! -f /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running ]]; th
 	echo 'DAQ is not running in '"$HUTCH"
     fi
 else
-    DAQ_HOST=$(grep "'HOST'" /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running | awk {'print $3'} | sed s/\'//g)
+    DAQ_HOST=$(grep "'HOST'" /reg/g/pcds/dist/pds/"$HUTCH"/scripts/p"$PLATFORM".cnf.running | awk '{print $3}' | sed s/\'//g)
     echo 'DAQ is running on '"$DAQ_HOST"
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removed trailing whitespace in stopdaq
- Fixed braces in wheredaq awk (https://www.shellcheck.net/wiki/SC1083)
- Quoted CNFFILE in stopdaq (file name)
- In both, quoted $(basename "$0") argument to daqutils (evaluates to stopdaq or wheredaq respectively)
- In both, disabled SC2068 for $@ argument(s) to daqutils (https://www.shellcheck.net/wiki/SC2068). Not sure if there are any globbed arguments you would intentionally provide, like a path to multiple cnf files. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
