### PR TITLE
Trailing whitespace removal and quoting vars in ami_offline_psana

### DIFF
--- a/scripts/ami_offline_psana
+++ b/scripts/ami_offline_psana
@@ -44,7 +44,7 @@ if [ -z "$EXP" ]; then
     echo getting the experiment "$EXP"
     HUTCH=$(get_hutch_name)
     if [ "$HUTCH" == 'unknown_hutch' ]; then
-	read -pr 'please enter an experiment name: ' EXP
+	read -rp 'please enter an experiment name: ' EXP
     else
 	EXP=$(get_curr_exp)
     fi
@@ -68,8 +68,8 @@ fi
 #get executable
 ami_base_path=$(grep ami_base_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNF" | grep -v '#' | grep -v 'ami_base_path+' | tail -n 1 | awk 'BEGIN { FS = "=" }; { print $2}' | sed s/\'//g)
 ami_path=$ami_base_path$(grep ami_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CNF" | grep -v 'ami_path+' | grep -v '#' | awk 'BEGIN { FS = "= " }; { print $2}' | sed s/ami_base_path+//g | sed s/\'//g)
-
-if [[ ! -f  $ami_path/offline_ami ]]; then
+# shellcheck disable=SC2086
+if [ ! -f  $ami_path/offline_ami ]; then
     echo "could not find offline_ami executable in ""$ami_path"
     exit
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removed trailing whitespace
- Used -r flag to read in experiment
- Using double brackets for REBIN (1 or empty), ami_path (filepath), and NOPLUG (1 or empty)
- Quoting entire echo expression
- Disabling SC2086 for ami execution line. We cannot quote ARGSTR because it it has multiple arguments. It could be made an array but I thought this was easier

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
