### PR TITLE
configdb whitespace and shellcheck

### DIFF
--- a/scripts/configdb_readxtc
+++ b/scripts/configdb_readxtc
@@ -8,7 +8,7 @@ We will run configdb_readxtc
 
 OPTIONS:
 -u user (needs to be able to log into the psananeh/feh)
--e expnumber 
+-e expnumber
 EOF
 }
 
@@ -17,8 +17,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 	exit 0
 fi
 
-USER=`whoami`
-ARGSTR=''
+USER=$(whoami)
 
 while getopts "u:e:" OPTION
 do
@@ -37,10 +36,10 @@ do
 done
 
 if [[ $USER =~ "opr" ]]; then
-    printf "Please enter user name (cannot run as xppopr): \n"; read USER
+    printf "Please enter user name (cannot run as xppopr): \n"; read -r USER
 fi
 
-: ${EXP:=`get_curr_exp`}
+: "${EXP:=$(get_curr_exp)}"
 HUTCH=${EXP:0:3}
 
 # check if experiment is passed, then use that
@@ -54,14 +53,14 @@ HUTCH=${EXP:0:3}
 #
 
 opt_dir="/reg/g/pcds/dist/pds/$HUTCH/current/build/pdsapp/bin/x86_64-rhel7-opt"
-eval find $opt_dir/configdb_readxtc
+eval find "$opt_dir"/configdb_readxtc
 ret_code=$?
 if [ $ret_code == 0 ]; then
     EXE='/reg/g/pcds/dist/pds/'$HUTCH'/current/build/pdsapp/bin/x86_64-rhel7-opt/configdb_readxtc'
 else
     dir="/reg/g/pcds/dist/pds/xpp/current/build/pdsapp/bin/x86_64-rhel7"
     eval find $dir/configdb_readxtc
-    ret_code=$?
+    ret_code2=$?
     if [ $ret_code2 == 0 ]; then
 	EXE='/reg/g/pcds/dist/pds/'$HUTCH'/current/build/pdsapp/bin/x86_64-rhel7/configdb_readxtc'
     else
@@ -74,12 +73,10 @@ fi
 # check hostname,only ssh if on control machine.
 #
 if [[ $HOSTNAME =~ "psana" ]]; then
-    $EXE /reg/d/psdm/$HUTCH/$EXP/xtc
+    $EXE "/reg/d/psdm/$HUTCH/$EXP/xtc"
 elif  [[ $HOSTNAME =~ "psusr" ]]; then
-    ssh -Y $USER@psana "$EXE /reg/d/psdm/$HUTCH/$EXP/xtc"
+    ssh -Y "$USER"@psana "$EXE /reg/d/psdm/$HUTCH/$EXP/xtc"
 else
-    echo $EXE /reg/d/psdm/$HUTCH/$EXP/xtc
-    ssh -Y $USER@psdev ssh -Y psana "$EXE /reg/d/psdm/$HUTCH/$EXP/xtc"
+    echo "$EXE /reg/d/psdm/$HUTCH/$EXP/xtc"
+    ssh -Y "$USER"@psdev ssh -Y psana "$EXE /reg/d/psdm/$HUTCH/$EXP/xtc"
 fi
- 
-   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removed trailing whitespaced
- Replaced legacy backticks with $() notation
- Quoted these variables - opt_dir, USER, EXP, HUTCH, EXE
- Assigning ret_val2
- Added -r flag to read username
- Removed unused ARGSTR variable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively, opens the window and gives the same cli output as the last version of this

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
