### PR TITLE
FIX: imgr, iocmanager when hutch is passed explicitly

### DIFF
--- a/scripts/imgr
+++ b/scripts/imgr
@@ -33,11 +33,11 @@ fi
 
 # For newer IOC manager, use the built-in help and env setup
 if [[ -f "${IOCMANAGER}"/scripts/imgr ]]; then
-  if [[ "$HUTCH" == "unknown_hutch" ]]; then
+  if [[ ("$HUTCH" == "unknown_hutch") || (-n $ARGHUTCH) ]]; then
     "${IOCMANAGER}"/scripts/imgr "$@"
     exit $?
   else
-    "${IOCMANAGER}"/scripts/imgr --hutch "${HUTCH}" "$@"
+    "${IOCMANAGER}"/scripts/imgr --hutch "${HUTCH,,}" "$@"
     exit $?
   fi
 fi

--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -4,10 +4,11 @@
 # Add engineering_tools to PATH for get_hutch_name
 DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 PATH=$PATH:$DIR
-if [[ ($1 == "--help") || ($1 == "-h") ]]; then
+if [[ ($1 == "--help") || ($1 == "-h") || (-z $1) ]]; then
 	HUTCH="$(get_hutch_name)"
 else
-    HUTCH=${1:-$(get_hutch_name)}
+    HUTCH=${1}
+    shift
 fi
 
 if [[ -z "${PYPS_ROOT}" ]]; then
@@ -26,7 +27,7 @@ if [[ -f "${IOCMANAGER}"/scripts/gui.sh ]]; then
     "${IOCMANAGER}"/scripts/gui.sh "$@"
     exit $?
   else
-    "${IOCMANAGER}"/scripts/gui.sh "${HUTCH}" "$@"
+    "${IOCMANAGER}"/scripts/gui.sh "${HUTCH,,}" "$@"
     exit $?
   fi
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- Fix an issue where the imgr and iocmanager wrapper scripts didn't launch properly when any specific hutch was chosen.
  - Launching for "the current hutch I'm in" was unaffected.
- Ensure hutch is lowercase

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'd previously missed this in my testing. Ilia was trying to use these as documented and ran into an issue where the parser was passing the hutch name twice to the underlying iocmanager parser.

In the future when everyone updates to the R3 series these scripts will want some revisions to simplify the handling even further.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I re-ran these scripts as multiple hutches with various input arguments and everything behaved as expected.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only
<!--
## Screenshots (if appropriate):
-->
