### PR TITLE
MNT: make pcds-6.0.1 the default conda environment

### DIFF
--- a/scripts/shared_conda_setup.sh
+++ b/scripts/shared_conda_setup.sh
@@ -58,8 +58,8 @@ version_ge () {
 # Based on the user's selection or non-selection, pick the correct env
 if [[ -z "${PCDS_CONDA_VER}" ]]; then
   # If env var unset, then default to latest
-  BASE_ENV="${CONDA_ROOT}/py39"
-  PYTHON_VER="3.9"
+  BASE_ENV="${CONDA_ROOT}/py312"
+  PYTHON_VER="3.12"
   PCDS_CONDA_VER="$(cat "${BASE_ENV}/latest_env")"
 else
   # Figure out which base to use


### PR DESCRIPTION
## Description
Our py 3.12 environment has been knocking around for a while now, it's time to make it the default environment. 

I also adjusted the "latest_env" file in the "py312" conda directory to contain "pcds-6.0.1"

I may have missed a file, but this worked well for me.

## Motivation and Context 
It's summer shutdown, and this is the least intrusive time to make this change.  (but on monday, no deployments on Friday)

## How Has This Been Tested?
I started a no-rc bash session and ran pcds_conda.  It successfully activated pcds-6.0.1

## Where Has This Been Documented?
This PR