### PR TITLE
Update camViewer

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -291,7 +291,7 @@ if [ "$CAMNUM" -eq 0 ]; then
     elif [ "$hutch" = "xpp" ]; then
         CAMNAME=hx2_sb1_yag
     elif [ "$hutch" = "xcs" ]; then
-        CAMNAME=xcs_yag2
+        CAMNAME=xcs_yag5
     elif [ "$hutch" = "mfx" ]; then
         CAMNAME=mfx_dg1_yag
     elif [ "$hutch" = "cxi" ]; then


### PR DESCRIPTION
Change XCS default camera from xcs_yag2 to xcs_yag5

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Change XCS default camera from xcs_yag2 to xcs_yag5

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
XCS scientists requested yag5 to be the default camViewer camera.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested as xcsopr.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here.

<!--
## Screenshots (if appropriate):
-->
