### PR TITLE
MNT: restore background launch behavior (&) for iocmanager R3+

### DIFF
--- a/scripts/iocmanager
+++ b/scripts/iocmanager
@@ -24,10 +24,10 @@ fi
 # For newer IOC manager, use the built-in help and env setup
 if [[ -f "${IOCMANAGER}"/scripts/gui.sh ]]; then
   if [[ "$HUTCH" == "unknown_hutch" ]]; then
-    "${IOCMANAGER}"/scripts/gui.sh "$@"
+    "${IOCMANAGER}"/scripts/gui.sh "$@" &
     exit $?
   else
-    "${IOCMANAGER}"/scripts/gui.sh "${HUTCH,,}" "$@"
+    "${IOCMANAGER}"/scripts/gui.sh "${HUTCH,,}" "$@" &
     exit $?
   fi
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `&` to the iocmanager launcher script to make the GUI launch in the background instead of the foreground.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The old version of this script had this behavior and people like it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with tst and txi

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
