### PR TITLE
local plugins no longer used at XPP & XCS

### DIFF
--- a/scripts/startami
+++ b/scripts/startami
@@ -97,11 +97,4 @@ fi
 
 echo "$ami_path""$amicmd"
 
-echo DEBUG
-echo "---""$ami_base_path""----"
-echo "-----"
-echo "---""$ami_path""----"
-echo "-----"
-echo "---""$amicmd""----"
-echo "-----"
 eval "$ami_path$amicmd &"


### PR DESCRIPTION
## Motivation and Context
startami stopped working in XCS as a directory that the script tried to 'pathmunge' no longer exists. As the XCS DAQ does only load plugins hosted in the release, the relevant lines of codes have been removed.

## How Has This Been Tested?
This has been tested in XCS. This will break MEC & CXI unless they change their cnf files to add ami_GUI_path for ami_client.
