### PR TITLE
skip intermediate hope which will stop working when MFA into s3dflogi…

### DIFF
--- a/scripts/makepeds
+++ b/scripts/makepeds
@@ -222,8 +222,8 @@ else
         DIR=`echo $DIR | sed 's/cds/sdf/g'`
     fi
 
-    echo ssh -Y "$USER"@s3dflogin ssh -Y psana "$DIR/$MAKEPEDSEXE $@"
-    ssh -Y "$USER"@s3dflogin ssh -Y psana "$DIR/$MAKEPEDSEXE $@"
+    echo ssh -Y "$USER"@psana.sdf "$DIR/$MAKEPEDSEXE $@"
+    ssh -Y "$USER"@psana.sdf "$DIR/$MAKEPEDSEXE $@"
     chk="$?"
 fi
 


### PR DESCRIPTION
## Description, Motivation and Context
S3DF will require MFA. To avoid this for running makepeds from already internal systems, we should skip the intermediate hop.

## How Has This Been Tested?
The ssh-hop has been tested from txi-control.
