### PR TITLE
MNT: remove references to netconfig from engineering_tools

### DIFF
--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -88,21 +88,21 @@ cd /reg/g/pcds/dist/pds/"$HUTCH"/scripts/ || exit
 DAQNETWORK='fez'
 PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 
-if [ "$IS_DAQ_HOST" == 0 ]; then
-    # There is currently no suitable way to find daq-compatible hosts in sdfconfig
-    # Maybe this will work in the future, disable for now and have worse UX
-    # HOSTS=$(sdfconfig search --type subnet PCDSN-${DAQNETWORK^^}-${HUTCH^^} --brief)
-    # WORKINGHOSTS=''
-    # #make sure at least cds is up.
-    # for HOST in $HOSTS; do
-	#       if [[ $(ping -w 2 "$HOST" >/dev/null 2>&1) == 0 ]]; then
-	#     WORKINGHOSTS=$WORKINGHOSTS' '$HOST
-	# fi
-    # done
-    # Placeholder less useful message:
-    echo "$AIMHOST" does not have "$DAQNETWORK", please choose a server with "$DAQNETWORK"
-    # echo "$AIMHOST" does not have "$DAQNETWORK", please choose one of the following machines to run the DAQ: "$WORKINGHOSTS"
-    echo "restartdaq -m <machine_with_$DAQNETWORK>"
+if [ "${IS_DAQ_HOST}" == 0 ]; then
+    HOSTS="$(sdfconfig search --brief --type subnet PCDSN-"${DAQNETWORK^^}"-"${HUTCH^^}")"
+    WORKINGHOSTS=""
+    for HOST in $HOSTS; do
+        # Only consider hosts that start with hutch-, e.g. xpp-control, xcs-daq
+	    if [[ "${HOST}" == "${HUTCH}"-* ]]; then
+            # Make sure cds intf is up via ping
+            # Remove trailing .pcdsn to switch from fqdn to hostname
+            if ping -w 2 "${HOST%.pcdsn}" &> /dev/null; then
+                WORKINGHOSTS="${WORKINGHOSTS} ${HOST%.pcdsn}"
+            fi
+	    fi
+    done
+    echo "${AIMHOST} does not have ${DAQNETWORK}, please choose one of the following machines to run the DAQ:${WORKINGHOSTS}"
+    echo "restartdaq -m <machine_with_${DAQNETWORK}>"
     exit
 fi
 

--- a/scripts/restartdaq
+++ b/scripts/restartdaq
@@ -89,15 +89,19 @@ DAQNETWORK='fez'
 PROCMGR="/reg/g/pcds/dist/pds/$HUTCH/current/tools/procmgr/procmgr"
 
 if [ "$IS_DAQ_HOST" == 0 ]; then
-    HOSTS=$(netconfig search "$HUTCH"-*-$DAQNETWORK --brief | sed s/-$DAQNETWORK//g)
-    WORKINGHOSTS=''
-    #make sure at least cds is up.
-    for HOST in $HOSTS; do
-	      if [[ $(ping -w 2 "$HOST" >/dev/null 2>&1) == 0 ]]; then
-	    WORKINGHOSTS=$WORKINGHOSTS' '$HOST
-	fi
-    done
-    echo "$AIMHOST" does not have "$DAQNETWORK", please choose one of the following machines to run the DAQ: "$WORKINGHOSTS"
+    # There is currently no suitable way to find daq-compatible hosts in sdfconfig
+    # Maybe this will work in the future, disable for now and have worse UX
+    # HOSTS=$(sdfconfig search --type subnet PCDSN-${DAQNETWORK^^}-${HUTCH^^} --brief)
+    # WORKINGHOSTS=''
+    # #make sure at least cds is up.
+    # for HOST in $HOSTS; do
+	#       if [[ $(ping -w 2 "$HOST" >/dev/null 2>&1) == 0 ]]; then
+	#     WORKINGHOSTS=$WORKINGHOSTS' '$HOST
+	# fi
+    # done
+    # Placeholder less useful message:
+    echo "$AIMHOST" does not have "$DAQNETWORK", please choose a server with "$DAQNETWORK"
+    # echo "$AIMHOST" does not have "$DAQNETWORK", please choose one of the following machines to run the DAQ: "$WORKINGHOSTS"
     echo "restartdaq -m <machine_with_$DAQNETWORK>"
     exit
 fi

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -13,17 +13,17 @@ names_from_name(){
         INNAME=${INNAME//-ana/}
     fi
     CDSNAME=$INNAME
-    CDSIP=$(netconfig search "$CDSNAME" | grep IP: | awk '{print $2}')
-    if [[ -z $CDSIP ]]; then
-        echo "Host ($CDSNAME) not found in netconfig, exiting..." >&2
+    if ! host "$CSDNAME" &> /dev/null; then
+        echo "Host ($CDSNAME) not found in DNS, exiting..." >&2
         exit 1
     fi
-    if [[ $(netconfig search "$NAME"-ipmi --brief | wc -w) -gt 0 ]]; then
+    CDSIP=$(host "$CDSNAME" | awk '{print $4}')
+    if host "$NAME"-ipmi &> /dev/null; then
         NAMEIPMI=$INNAME-ipmi
     fi
-    if [[ $(netconfig search "$NAME"-fez --brief | wc -w) -gt 0 ]]; then
+    if host "$NAME"-fez &> /dev/null; then
         FEZNAME=$INNAME-fez
-        FEZIP=$(netconfig search "$FEZNAME" | grep IP: | awk '{print $2}')
+        FEZIP=$(host "$FEZNAME" | awk '{print $4}')
     fi
 }
 
@@ -77,9 +77,11 @@ for name in "tmo" "rix" "txi" "xpp" "xcs" "mfx" "cxi" "mec" "det"; do
     fi
 done
 
-
-HOST_HAS_FEZ=$(netconfig search "$HOSTNAME"-fez --brief | wc -l)
-
+if host "$HOSTNAME"-fez $> /dev/null; then
+    HOST_HAS_FEZ=1
+else
+    HOST_HAS_FEZ=0
+fi
 
 if [[ $# -lt 2 ]]; then
     if [[ $# -lt 1 ]]; then
@@ -110,10 +112,11 @@ fi
 
 if [[ $NAME == *'172.21'* ]]; then
     ISSRV=1
-    NAME=$(netconfig search "$NAME" --brief | awk '{print $1}')
+    NAME=$(host "$NAME" | awk '{print $5}' | cut -d "." -f 1)
     echo "$DEV is an IP for $NAME"
 else
-    ISSRV=$(netconfig search "$NAME" | grep 'Found' | awk '{print $2}')
+    host "$NAME" $> /dev/null
+    ISSRV=$?
 fi
 
 if [[ $NAME == *'-ipmi'* ]]; then
@@ -182,17 +185,17 @@ if [[ $ISSRV -lt 1 ]] && [[ $HUTCH != 'unknown_hutch' ]]; then
         fi
     fi
     if [[ $NAME ]]; then
-        ISSRV=$(netconfig search "$NAME" | grep 'Found' | awk '{print $2}')
+        host "$NAME" $> /dev/null
+        ISSRV=$?
     fi
     if [[ $ISSRV -lt 1 ]]; then
-        echo "Host ($NAME) not found in netconfig, exiting..." >&2
+        echo "Host ($NAME) not found in DNS, exiting..." >&2
         exit 1
     fi
-
-    SRVIP=$(netconfig search "$NAME" | grep IP: | awk '{print $2}')
+    SRVIP=host "$NAME" | awk '{print $4}'
     echo "server for $DEV is: $NAME"
 else
-    SRVIP=$(netconfig search "$DEV" | grep IP: | awk '{print $2}')
+    SRVIP=host "$DEV" | awk '{print $4}'
 fi
 
 
@@ -210,9 +213,11 @@ elif [[ $CMD == "console" ]]; then
 elif [[ $CMD == "reset" ]]; then
     psipmi "$NAMEIPMI" power reset
 elif [[ $CMD == "expert" ]]; then
-    echo "Host netconfig entry:"
+    echo "Host sdfconfig entry:"
     echo -e "-------------------------------------------------"
-    netconfig view "$NAME"
+    # sdfconfig view currently broken, use search and hope for one entry only
+    # sdfconfig --domain pcdsn view "$NAME"
+    sdfconfig search "$NAME"
     echo -e ""
     echo -e "Checking IPMI power status:"
     echo -e "-------------------------------------------------"
@@ -232,7 +237,7 @@ elif [[ $CMD == "expert" ]]; then
     else
        echo "$NAME-ipmi does not ping."
     fi
-    if [[ $(netconfig search "$NAME"-fez --brief | wc -w) -gt 0 ]]; then
+    if host "$NAME"-fez $> /dev/null; then
         if ping -w 2 "$NAME"-fez >/dev/null 2>&1; then
            echo "$NAME-fez pings."
         else

--- a/scripts/serverStat
+++ b/scripts/serverStat
@@ -13,7 +13,7 @@ names_from_name(){
         INNAME=${INNAME//-ana/}
     fi
     CDSNAME=$INNAME
-    if ! host "$CSDNAME" &> /dev/null; then
+    if ! host "$CDSNAME" &> /dev/null; then
         echo "Host ($CDSNAME) not found in DNS, exiting..." >&2
         exit 1
     fi
@@ -77,7 +77,7 @@ for name in "tmo" "rix" "txi" "xpp" "xcs" "mfx" "cxi" "mec" "det"; do
     fi
 done
 
-if host "$HOSTNAME"-fez $> /dev/null; then
+if host "$HOSTNAME"-fez &> /dev/null; then
     HOST_HAS_FEZ=1
 else
     HOST_HAS_FEZ=0
@@ -115,8 +115,7 @@ if [[ $NAME == *'172.21'* ]]; then
     NAME=$(host "$NAME" | awk '{print $5}' | cut -d "." -f 1)
     echo "$DEV is an IP for $NAME"
 else
-    host "$NAME" $> /dev/null
-    ISSRV=$?
+    host "$NAME" &> /dev/null && ISSRV=1 || ISSRV=0
 fi
 
 if [[ $NAME == *'-ipmi'* ]]; then
@@ -185,17 +184,17 @@ if [[ $ISSRV -lt 1 ]] && [[ $HUTCH != 'unknown_hutch' ]]; then
         fi
     fi
     if [[ $NAME ]]; then
-        host "$NAME" $> /dev/null
+        host "$NAME" &> /dev/null
         ISSRV=$?
     fi
     if [[ $ISSRV -lt 1 ]]; then
         echo "Host ($NAME) not found in DNS, exiting..." >&2
         exit 1
     fi
-    SRVIP=host "$NAME" | awk '{print $4}'
+    SRVIP="$(host "$NAME" | awk '{print $4}')"
     echo "server for $DEV is: $NAME"
 else
-    SRVIP=host "$DEV" | awk '{print $4}'
+    SRVIP="$(host "$DEV" | awk '{print $4}')"
 fi
 
 
@@ -215,9 +214,7 @@ elif [[ $CMD == "reset" ]]; then
 elif [[ $CMD == "expert" ]]; then
     echo "Host sdfconfig entry:"
     echo -e "-------------------------------------------------"
-    # sdfconfig view currently broken, use search and hope for one entry only
-    # sdfconfig --domain pcdsn view "$NAME"
-    sdfconfig search "$NAME"
+    sdfconfig view "$NAME".pcdsn
     echo -e ""
     echo -e "Checking IPMI power status:"
     echo -e "-------------------------------------------------"
@@ -237,7 +234,7 @@ elif [[ $CMD == "expert" ]]; then
     else
        echo "$NAME-ipmi does not ping."
     fi
-    if host "$NAME"-fez $> /dev/null; then
+    if host "$NAME"-fez &> /dev/null; then
         if ping -w 2 "$NAME"-fez >/dev/null 2>&1; then
            echo "$NAME-fez pings."
         else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove all references to netconfig and include suitable replacement calls to sdfconfig or host

- `restartdaq`: Replace the `netconfig search *-fez` sort of call with the equivalent `sdfconfig` search for fez subnets (can't do the same search because the -fez etc. are part of the same entry as the main interface)
- `serverStat`: All calls that used `netconfig` to search for hostname existence have been replaced by the `host` utility, which is faster and wont disappear. (Incidentally: `serverStat status` is now much faster). The `netconfig` call that was used to view the netconfig output has been replaced by the equivalent `sdfconfig` call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-9486

Netconfig is going away
The replacement tool is sdfconfig
In some cases, we can get away with using neither, so that is preferred when possible for forward compatibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
- `restartdaq` I've forced the bash script into this error state and made sure it gave reasonable results
- `serverStat` was run through the paces with the `status` and `expert` commands on servers with/without fez to get some output variety

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
