### PR TITLE
MNT: XPP to LCLS2 DAQ

### DIFF
--- a/scripts/daq_utils.py
+++ b/scripts/daq_utils.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from subprocess import PIPE
 
-DAQMGR_HUTCHES = ["tmo", "rix", "txi", "ued", "mfx"]
+DAQMGR_HUTCHES = ["tmo", "rix", "txi", "xpp", "ued", "mfx"]
 LOCALHOST = socket.gethostname()
 SLURM_PARTITION = "drpq"
 SLURM_JOBNAME = "submit_daq"


### PR DESCRIPTION
Make scripts work for the LCLS2 DAQ at XPP:

- Add XPP to the `DAQMGR_HUTCHES` list