### PR TITLE
ENH: add xrt to camviewer script, don't ssh if you don't need to

### DIFF
--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -386,15 +386,15 @@ else
     echo 'cannot check Acquiring PV, try to open camera viewer anyways....'
 fi
 
-current_host="$(hostname)"
 if [[ -z "$IS_REMOTE_SSH" ]]; then
-    if [ "$hutch" == "kfe" ] && [ "$current_host" != "kfe-console" ]; then
+    current_host="$(hostname)"
+    if [[ "$hutch" == "kfe" && "$current_host" != "kfe-console" && "$current_host" != "xbdo-control" ]]; then
         echo "Not in SSH, connecting to kfe-console..." >&2
         ssh -t kfe-console "IS_REMOTE_SSH=1 $EXE --camerapv '$CAMPVFULL' --instrument '$hutch' --pvlist '$PVLIST' --rate '$RATE' ; bash"
         exit_status=$?
         echo "SSH exit status: $exit_status" >&2
         exit $exit_status
-    elif [ "$hutch" == "lfe" ] || [ "$hutch" == "xrt" ] && [ "$current_host" != "lfe-console" ]; then
+    elif [[ ("$hutch" == "lfe" || "$hutch" == "xrt") && "$current_host" != "lfe-console" && "$current_host" != "xbdo-control" ]]; then
         echo "Not in SSH, connecting to lfe-console..." >&2
         ssh -t lfe-console "IS_REMOTE_SSH=1 $EXE --camerapv '$CAMPVFULL' --instrument '$hutch' --pvlist '$PVLIST' --rate '$RATE' ; bash"
         exit_status=$?

--- a/scripts/camViewer
+++ b/scripts/camViewer
@@ -302,6 +302,8 @@ if [ "$CAMNUM" -eq 0 ]; then
         CAMNAME=GigE_Questar1
     elif [ "$hutch" = "lfe" ]; then
         CAMNAME=xrt_spec
+    elif [ "$hutch" = "xrt" ]; then
+        CAMNAME=xrt_spec
     elif [ "$hutch" = "ued" ]; then
         CAMNAME=ued-gige-01
     else
@@ -384,14 +386,15 @@ else
     echo 'cannot check Acquiring PV, try to open camera viewer anyways....'
 fi
 
+current_host="$(hostname)"
 if [[ -z "$IS_REMOTE_SSH" ]]; then
-    if [ "$hutch" == "kfe" ]; then
+    if [ "$hutch" == "kfe" ] && [ "$current_host" != "kfe-console" ]; then
         echo "Not in SSH, connecting to kfe-console..." >&2
         ssh -t kfe-console "IS_REMOTE_SSH=1 $EXE --camerapv '$CAMPVFULL' --instrument '$hutch' --pvlist '$PVLIST' --rate '$RATE' ; bash"
         exit_status=$?
         echo "SSH exit status: $exit_status" >&2
         exit $exit_status
-    elif [ "$hutch" == "lfe" ]; then
+    elif [ "$hutch" == "lfe" ] || [ "$hutch" == "xrt" ] && [ "$current_host" != "lfe-console" ]; then
         echo "Not in SSH, connecting to lfe-console..." >&2
         ssh -t lfe-console "IS_REMOTE_SSH=1 $EXE --camerapv '$CAMPVFULL' --instrument '$hutch' --pvlist '$PVLIST' --rate '$RATE' ; bash"
         exit_status=$?

--- a/scripts/verify-hutch
+++ b/scripts/verify-hutch
@@ -20,7 +20,7 @@ if [[ ($1 == "--help") || ($1 == "-h") ]]; then
 fi
 
 hutch=${1,,}
-for i in "tmo" "txi" "rix" "xpp" "xcs" "mfx" "cxi" "mec" "ued" "ued" "det" "lfe" "kfe" "tst" "las" "hpl"; do
+for i in "tmo" "txi" "rix" "xpp" "xcs" "mfx" "cxi" "mec" "ued" "ued" "det" "lfe" "kfe" "xrt" "tst" "las" "hpl"; do
     if [[ $hutch == "$i" ]]; then
         exit 0
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `xrt` as a valid option for `camViewer`
- Add `xrt` as a valid hutch for `verify-hutch`
- Make `xrt` ssh you to `lfe-console` to open the gui
- If you're already on the hutch we need to ssh to, don't ssh

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@patoppermann asked me about ssh-ing to avoid bad gateway performance for camViewer, this is his code from last year but extended to allow xrt
Small cleanup while here

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
