### PR TITLE
startami: strip trailing '})' from amicmd to avoid eval syntax error

### DIFF
--- a/scripts/startami
+++ b/scripts/startami
@@ -71,9 +71,7 @@ ami_path=$ami_base_path$(grep ami_GUI_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts
 
 proxy_cds=$(/reg/g/pcds/dist/pds/"$HUTCH"/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep ami_proxy | awk '{print $1}' | sed s/'-fez'/''/g)
 
-amicmd=$(grep ami_client /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep -v '#' |  awk 'BEGIN { FS = ":" }; { print $4}' | sed s/ami_GUI_path//g | sed s/\'+proxy_cds/"$proxy_cds"/g | sed  s:\'+expname:"$EXPNAME"/:g | sed s/+\'//g | sed s/\'\}\)//g)
-# Strip trailing cnf/python artifacts (e.g. "})") so eval doesn't choke
-amicmd=$(printf "%s" "$amicmd" | sed 's/[[:space:]]*[})][})]*$//')
+amicmd=$(grep ami_client /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep -v '#' |  awk 'BEGIN { FS = ":" }; { print $4}' | sed s/ami_GUI_path//g | sed s/\'+proxy_cds/"$proxy_cds"/g | sed  s:\'+expname:"$EXPNAME"/:g | sed s/+\'//g | sed s/\'\}\)//g | sed 's/[})][})]*$//')
 
 if [[ "$DAQHOST" == *"$HOSTNAME" ]]; then  # Check host and daq host line share host name...
     #running on the DAQ host, this will restart the ami_client!

--- a/scripts/startami
+++ b/scripts/startami
@@ -72,6 +72,8 @@ ami_path=$ami_base_path$(grep ami_GUI_path /reg/g/pcds/dist/pds/"$HUTCH"/scripts
 proxy_cds=$(/reg/g/pcds/dist/pds/"$HUTCH"/current/tools/procmgr/procmgr status /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep ami_proxy | awk '{print $1}' | sed s/'-fez'/''/g)
 
 amicmd=$(grep ami_client /reg/g/pcds/dist/pds/"$HUTCH"/scripts/"$CONFIG" | grep -v '#' |  awk 'BEGIN { FS = ":" }; { print $4}' | sed s/ami_GUI_path//g | sed s/\'+proxy_cds/"$proxy_cds"/g | sed  s:\'+expname:"$EXPNAME"/:g | sed s/+\'//g | sed s/\'\}\)//g)
+# Strip trailing cnf/python artifacts (e.g. "})") so eval doesn't choke
+amicmd=$(printf "%s" "$amicmd" | sed 's/[[:space:]]*[})][})]*$//')
 
 if [[ "$DAQHOST" == *"$HOSTNAME" ]]; then  # Check host and daq host line share host name...
     #running on the DAQ host, this will restart the ami_client!


### PR DESCRIPTION
## Description
Strip trailing config-artifact characters (e.g., `})`) from the `amicmd` string constructed in `scripts/startami` before it is executed.

## Motivation and Context
`startami -c cxi_0.cnf` could fail with:
`eval: syntax error near unexpected token ')'`

On CXI hosts, `amicmd` was being parsed from the `ami_client` line in `cxi_0.cnf` and could end up with a trailing `})`, causing bash `eval` to error. This change sanitizes the constructed command to avoid the syntax error.

## How Has This Been Tested?
- `cxi-monitor`: `/cds/home/i/iroque/programs/engineering_tools/scripts/startami -c cxi_0.cnf` (reaches expected restart prompt; no eval syntax error)
- `cxi-control`: `/cds/home/i/iroque/programs/engineering_tools/scripts/startami -c cxi_0.cnf` (successfully launches `online_ami`; no eval syntax error)
- `xcs-control`: `/cds/home/i/iroque/programs/engineering_tools/scripts/startami` (successfully launches online_ami; no eval syntax error)

## Where Has This Been Documented?
- Jira ticket: [ECS-9707](https://jira.slac.stanford.edu/browse/ECS-9707)