### PR TITLE
ENH: add setup script for ctrlenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ usage:   source ctrlenv_setup.sh<br/>
     ctrlenv-pathmunge 2026/05/26_00</br>
     ctrlenv-pathmunge widgets/v0.1.1</br>
     ctrlenv-pathmunge pytmc</br>
-    ctrlenv-activate widgets</br>
     ctrlenv-versions pytmc</br>
     </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ usage:   source ctrlenv_setup.sh<br/>
     Some examples for subcommands:</br>
     ctrlenv-pathmunge latest-released</br>
     ctrlenv-pathmunge 2026/05/26_00</br>
-    ctrlenv-pathmunge widgets/v0.1.1</br>
+    ctrlenv-pathmunge ctrlenv-widgets/v0.1.1</br>
     ctrlenv-pathmunge pytmc</br>
     ctrlenv-versions pytmc</br>
     </td>

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ usage:   source ctrlenv_setup.sh<br/>
     ctrlenv-pathmunge widgets/v0.1.1</br>
     ctrlenv-pathmunge pytmc</br>
     ctrlenv-activate widgets</br>
+    ctrlenv-versions pytmc</br>
     </td>
 </tr>
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ Usage:   /reg/g/pcds/engineering_tools/latest/scripts/check_host HOSTNAME<br/>
 </tr>
 
 <tr>
+    <td>ctrlenv_setup.sh</td>
+    <td>
+usage:   source ctrlenv_setup.sh<br/>
+    <br/>
+    Set environment variables and add commands for using ctrlenv python tools.</br>
+    </br>
+    Some examples for subcommands:</br>
+    ctrlenv-pathmunge latest-released</br>
+    ctrlenv-pathmunge 2026/05/26_00</br>
+    ctrlenv-pathmunge widgets/v0.1.1</br>
+    ctrlenv-pathmunge pytmc</br>
+    ctrlenv-activate widgets</br>
+    </td>
+</tr>
+
+<tr>
     <td>configdb_readxtc</td>
     <td>
 usage: configdb_readxtc options<br/>

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -137,10 +137,14 @@ ctrlenv-pathmunge() {
             if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
                 pathmunge "${CTRLENV_ENVS}/${tg}/bin/${arch}"
                 return 0
-            else
-            # Wasn't a version- pick latest
+            elif [ -d "${CTRLENV_ENVS}/${tg}/latest-released/bin/${arch}" ]; then
+                # Wasn't a version- pick latest
                 pathmunge "${CTRLENV_ENVS}/${tg}/latest-released/bin/${arch}"
                 return 0
+            else
+                # Error state: let's try to be a little bit helpful
+                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing one of arch or version match or no latest-released" >&2
+                return 1
             fi
         fi
     done
@@ -149,10 +153,14 @@ ctrlenv-pathmunge() {
         if [ -d "${CTRLENV_APPS}/${target}/bin/${arch}" ]; then
             pathmunge "${CTRLENV_APPS}/${target}/bin/${arch}"
             return 0
-        else
-        # Wasn't a version- pick latest
+        elif [ -d "${CTRLENV_APPS}/${target}/latest-released/bin/${arch}" ]; then
+            # Wasn't a version- pick latest
             pathmunge "${CTRLENV_APPS}/${target}/latest-released/bin/${arch}"
             return 0
+        else
+            # Error state: let's try to be a little bit helpful
+            echo "Found matching apps series ${CTRLENV_APPS}/${target} but missing one of arch or version match or no latest-released" >&2
+            return 1
         fi
     fi
     echo "No matching bundle, env, or app found for ctrlenv-pathmunge $1" >&2
@@ -176,10 +184,14 @@ ctrlenv-activate() {
             if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
                 pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/src/${arch}"
                 return $?
-            else
-            # Wasn't a version- pick latest
+            elif [ -d "${CTRLENV_ENVS}/${tg}/latest-released/src/${arch}" ]; then
+                # Wasn't a version- pick latest
                 pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/latest-released/src/${arch}"
                 return $?
+            else
+                # Error state: let's try to be a little bit helpful
+                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing one of arch or version match or no latest-released" >&2
+                return 1
             fi
         fi
     done

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
-# Source this script to set shared environment variables and gain access to two shell functions:
+# Source this script to set shared environment variables and gain access to three shell functions:
 # 1. ctrlenv-pathmunge: adds the bin from a bundle, environment, or application to your path at a specific version
 # 2. ctrlenv-activate: puts you into a released pixi environment (pixi shell)
+# 3. ctrlenv-versions: shows you which versions exist for an environment or application
 #
 # Defaults are:
 # - Always the latest release
@@ -45,6 +46,10 @@
 #
 # Activate a specific version of a specific environment
 # ctrlenv-activate lucid/v0.1.2
+#
+# Show which versions exist for an environment or application
+# ctrlenv-versions widgets
+# ctrlenv-versions pytmc
 #
 
 # Local path settings
@@ -196,5 +201,30 @@ ctrlenv-activate() {
         fi
     done
     echo "No matching env found for ctrlenv-activate $1" >&2
+    return 1
+}
+
+
+# Show which versions exist
+ctrlenv-versions() {
+    local target
+    if [ -z "$1" ]; then
+        target=base
+    else
+        target="$1"
+    fi
+    # Check envs first: allow omit ctrlenv- prefix
+    for tg in "$target" "ctrlenv-${target}"; do
+        if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
+            ls "${CTRLENV_ENVS}/${tg}"
+            return 0
+        fi
+    done
+    # Check apps last
+    if [ -d "${CTRLENV_APPS}/${target}" ]; then
+        ls "${CTRLENV_APPS}/${target}"
+        return 0
+    fi
+    echo "No matching env or app found for ctrlenv-versions $1" >&2
     return 1
 }

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+#
+# Source this script to set shared environment variables and gain access to two shell functions:
+# 1. ctrlenv-pathmunge: adds the bin from a bundle, environment, or application to your path at a specific version
+# 2. ctrlenv-activate: puts you into a released pixi environment (pixi shell)
+#
+# Defaults are:
+# - Always the latest release
+# - If unspecified, the latest bundle release is assumed
+# - base is the default environment
+#
+# Example usage:
+# First, source this script
+# source ctrlenv_setup.sh
+#
+# Then, try one of:
+#
+# Put the latest released bundle bin on your path:
+# ctrlenv-pathmunge
+# or
+# ctrlenv-pathmunge latest-released
+#
+# Put a specific released bundle bin on your path:
+# ctrlenv-pathmunge 2026/05/26_00
+#
+# Put the default released environment bin on your path:
+# ctrlenv-pathmunge base
+#
+# Put a specific released environment bin at a specific version on your path
+# ctrlenv-pathmunge lucid/v0.1.2
+#
+# Put a latest version of an app on your path
+# ctrlenv-pathmunge pytmc
+#
+# Put a specific version of an app on your path
+# ctrlenv-pathmunge pytmc/v2.20.0
+#
+# Activate the default environment
+# ctrlenv-activate
+# or
+# ctrlenv-activate base
+#
+# Activate the latest version of a specific environment
+# ctrlenv-activate widgets
+#
+# Activate a specific version of a specific environment
+# ctrlenv-activate lucid/v0.1.2
+#
+
+# Local path settings
+PYPS_SITE_TOP="${PYPS_SITE_TOP:-/cds/group/pcds/pyps}"
+CTRLENV_BUNDLE_TOP="${CTRLENV_BUNDLE_TOP:-"${PYPS_SITE_TOP}"/bundles}"
+CTRLENV_ENVS="${PYPS_SITE_TOP}"/pixi
+CTRLENV_APPS="${PYPS_SITE_TOP}"/apps
+
+# Pixi settings depending on whether you have a local mount to use
+if [ -d /u1/"${USER}" ]; then
+  # local mount: use it for pixi cache
+  export PIXI_CACHE_DIR=/u1/"${USER}"/pixi_cache
+  export PIXI_CACHE_NETFS_REDIRECT="always"
+else
+  # no local mount, but weka is way faster than /tmp somehow
+  export PIXI_CACHE_NETFS_REDIRECT="never"
+fi
+
+# Default settings for qt
+# Avoid OpenGL-related crash for remote sessions
+# TODO: investigate whether this should be skipped for local desktop cpu
+export QT_XCB_GL_INTEGRATION=none
+
+# Default settings for pydm
+export PYDM_CONFIRM_QUIT=0
+export PYDM_DEFAULT_PROTOCOL=ca
+export PYDM_DESIGNER_ONLINE=1
+# TODO: remove this once pcdswidgets no longer needs it
+export PYDM_STYLESHEET=/cds/group/pcds/epics-dev/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
+export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
+
+# Default settings for our apps
+export HAPPI_CFG="${CTRLENV_APPS}/hutch-python/device_config/happi.cfg"
+
+
+_ctrlenv-arch() {
+    if [ -z "${EPICS_HOST_ARCH}" ]; then
+        local archstr
+        archstr="$(uname -r)"
+        if [[ "$archstr" == *"el9"* ]]; then
+            echo rhel9-x86_64
+        elif [[ "$archstr" == *"el7"* ]]; then
+            echo rhel7-x86_64
+        else
+            echo unknown
+        fi
+    else
+        echo "${EPICS_HOST_ARCH}"
+    fi
+}
+
+
+ctrlenv-pathmunge() {
+    local target
+    local arch
+    if [ -z "$1" ]; then
+        target=latest-released
+    else
+        target="$1"
+    fi
+    arch="$(_ctrlenv-arch)"
+    # Check bundle first: exact match only
+    if [ -d "${CTRLENV_BUNDLE_TOP}/${target}" ]; then
+        pathmunge "${CTRLENV_BUNDLE_TOP}/${target}/bin/${arch}"
+        return 0
+    fi
+    # Check envs second: allow omit ctrlenv- prefix
+    for tg in "$target" "ctrlenv-${target}"; do
+        if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
+            if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
+                pathmunge "${CTRLENV_ENVS}/${tg}/bin/${arch}"
+                return 0
+            else
+            # Wasn't a version- pick latest
+                pathmunge "${CTRLENV_ENVS}/${tg}/latest-released/bin/${arch}"
+                return 0
+            fi
+        fi
+    done
+    # Check apps last
+    if [ -d "${CTRLENV_APPS}/${target}" ]; then
+        if [ -d "${CTRLENV_APPS}/${target}/bin/${arch}" ]; then
+            pathmunge "${CTRLENV_APPS}/${target}/bin/${arch}"
+            return 0
+        else
+        # Wasn't a version- pick latest
+            pathmunge "${CTRLENV_APPS}/${target}/latest-released/bin/${arch}"
+            return 0
+        fi
+    fi
+    echo "No matching bundle, env, or app found for ctrlenv-pathmunge $1" >&2
+    return 1
+}
+
+
+ctrlenv-activate() {
+    local target
+    local arch
+    if [ -z "$1" ]; then
+        target=base
+    else
+        target="$1"
+    fi
+    arch="$(_ctrlenv-arch)"
+    # For envs allow omit ctrlenv- prefix
+    for tg in "$target" "ctrlenv-${target}"; do
+        if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
+            if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
+                pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/src/${arch}"
+                return $?
+            else
+            # Wasn't a version- pick latest
+                pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/latest-released/src/${arch}"
+                return $?
+            fi
+        fi
+    done
+    echo "No matching env found for ctrlenv-activate $1" >&2
+    return 1
+}

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -52,6 +52,8 @@ PYPS_SITE_TOP="${PYPS_SITE_TOP:-/cds/group/pcds/pyps}"
 CTRLENV_BUNDLE_TOP="${CTRLENV_BUNDLE_TOP:-"${PYPS_SITE_TOP}"/bundles}"
 CTRLENV_ENVS="${PYPS_SITE_TOP}"/pixi
 CTRLENV_APPS="${PYPS_SITE_TOP}"/apps
+EPICS_SETUP=/cds/group/pcds/setup
+EPICS_DEV=/cds/group/pcds/epics-dev
 
 # Pixi settings depending on whether you have a local mount to use
 if [ -d /u1/"${USER}" ]; then
@@ -73,12 +75,29 @@ export PYDM_CONFIRM_QUIT=0
 export PYDM_DEFAULT_PROTOCOL=ca
 export PYDM_DESIGNER_ONLINE=1
 # TODO: remove this once pcdswidgets no longer needs it
-export PYDM_STYLESHEET=/cds/group/pcds/epics-dev/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
+export PYDM_STYLESHEET="${EPICS_DEV}"/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
 export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
 
 # Default settings for our apps
 export HAPPI_CFG="${CTRLENV_APPS}/hutch-python/device_config/happi.cfg"
 
+# Make sure we have pathmunge command
+if ! command -v pathmunge >/dev/null 2>&1 ; then
+    # Use site-local version if available
+    if [ -f "${EPICS_SETUP}"/pathmunge.sh ]; then
+        source "${EPICS_SETUP}"/pathmunge.sh
+    else
+        # Provide simplest version as a backup
+        pathmunge () {
+            case ":${PATH}:" in
+                *:"$1":*)
+                    ;;
+                *)
+                    PATH=$1:$PATH
+            esac
+        }
+    fi
+fi
 
 _ctrlenv-arch() {
     if [ -z "${EPICS_HOST_ARCH}" ]; then
@@ -95,7 +114,6 @@ _ctrlenv-arch() {
         echo "${EPICS_HOST_ARCH}"
     fi
 }
-
 
 ctrlenv-pathmunge() {
     local target

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -143,7 +143,7 @@ ctrlenv-pathmunge() {
 ctrlenv-versions() {
     local target
     if [ -z "$1" ]; then
-        target=base
+        target=ctrlenv-base
     else
         target="$1"
     fi

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -24,10 +24,10 @@
 # ctrlenv-pathmunge 2026/05/26_00
 #
 # Put the default released environment bin on your path:
-# ctrlenv-pathmunge base
+# ctrlenv-pathmunge ctrlenv-base
 #
 # Put a specific released environment bin at a specific version on your path
-# ctrlenv-pathmunge lucid/v0.1.2
+# ctrlenv-pathmunge ctrlenv-lucid/v0.1.2
 #
 # Put a latest version of an app on your path
 # ctrlenv-pathmunge pytmc
@@ -36,7 +36,7 @@
 # ctrlenv-pathmunge pytmc/v2.20.0
 #
 # Show which versions exist for an environment or application
-# ctrlenv-versions widgets
+# ctrlenv-versions ctrlenv-widgets
 # ctrlenv-versions pytmc
 #
 
@@ -119,51 +119,26 @@ ctrlenv-pathmunge() {
         target="$1"
     fi
     arch="$(_ctrlenv-arch)"
-    # Check bundle first: exact match only
-    if [ -d "${CTRLENV_BUNDLE_TOP}/${target}" ]; then
-        pathmunge "${CTRLENV_BUNDLE_TOP}/${target}/bin/${arch}"
-        return 0
-    fi
-    # Check envs second: allow omit ctrlenv- prefix
-    for tg in "${target}" "ctrlenv-${target}"; do
-        if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
-            if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
-                pathmunge "${CTRLENV_ENVS}/${tg}/bin/${arch}"
+    for target_dir in "${CTRLENV_BUNDLE_TOP}" "${CTRLENV_ENVS}" "${CTRLENV_APPS}"; do
+        if [ -d "${target_dir}/${target}" ]; then
+            if [ -d "${target_dir}/${target}/bin/${arch}" ]; then
+                pathmunge "${target_dir}/${target}/bin/${arch}"
                 return 0
-            elif [ -d "${CTRLENV_ENVS}/${tg}/latest-released/bin/${arch}" ]; then
-                # Wasn't a version- pick latest
-                pathmunge "${CTRLENV_ENVS}/${tg}/latest-released/bin/${arch}"
+            elif [ -d "${target_dir}/${target}/latest-released/bin/${arch}" ]; then
+                pathmunge "${target_dir}/${target}/latest-released/bin/${arch}"
                 return 0
             else
                 # Error state: let's try to be a little bit helpful
-                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing arch, version, or latest-released" >&2
+                echo "Found matching area ${target_dir}/${target} but missing ${arch}, version, or latest-released" >&2
                 echo "Available versions are:" >&2
                 ctrlenv-versions "$1" >&2
                 return 1
             fi
         fi
     done
-    # Check apps last
-    if [ -d "${CTRLENV_APPS}/${target}" ]; then
-        if [ -d "${CTRLENV_APPS}/${target}/bin/${arch}" ]; then
-            pathmunge "${CTRLENV_APPS}/${target}/bin/${arch}"
-            return 0
-        elif [ -d "${CTRLENV_APPS}/${target}/latest-released/bin/${arch}" ]; then
-            # Wasn't a version- pick latest
-            pathmunge "${CTRLENV_APPS}/${target}/latest-released/bin/${arch}"
-            return 0
-        else
-            # Error state: let's try to be a little bit helpful
-            echo "Found matching apps series ${CTRLENV_APPS}/${target} but missing arch, version, or latest-released" >&2
-            echo "Available versions are:" >&2
-            ctrlenv-versions "$1" >&2
-            return 1
-        fi
-    fi
-    echo "No matching path or version found for ctrlenv-pathmunge $1" >&2
+    echo "No matching path or version found for ctrlenv-pathmunge $target" >&2
     return 1
 }
-
 
 # Show which versions exist
 ctrlenv-versions() {
@@ -173,18 +148,12 @@ ctrlenv-versions() {
     else
         target="$1"
     fi
-    # Check envs first: allow omit ctrlenv- prefix
-    for tg in "${target}" "ctrlenv-${target}"; do
-        if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
-            ls -1 "${CTRLENV_ENVS}/${tg}"
+    for target_dir in "${CTRLENV_ENVS}" "${CTRLENV_APPS}"; do
+        if [ -d "${target_dir}/${target}" ]; then
+            ls -1 "${target_dir}/${target}"
             return 0
         fi
     done
-    # Check apps last
-    if [ -d "${CTRLENV_APPS}/${target}" ]; then
-        ls -1 "${CTRLENV_APPS}/${target}"
-        return 0
-    fi
-    echo "No matching path or version found for ctrlenv-versions $1" >&2
+    echo "No matching env or app found for ctrlenv-versions ${target}" >&2
     return 1
 }

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -67,14 +67,14 @@ fi
 
 # Default settings for qt
 # Avoid OpenGL-related crash for remote sessions
-# TODO: investigate whether this should be skipped for local desktop cpu
+# TODO: investigate whether this should be skipped for local desktop cpu/gpu
 export QT_XCB_GL_INTEGRATION=none
 
 # Default settings for pydm
 export PYDM_CONFIRM_QUIT=0
 export PYDM_DEFAULT_PROTOCOL=ca
 export PYDM_DESIGNER_ONLINE=1
-# TODO: remove this once pcdswidgets no longer needs it
+# TODO: remove hard-coded default stylesheet once pcdswidgets vacuum widgets no longer need it
 export PYDM_STYLESHEET="${EPICS_DEV}"/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
 export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
 
@@ -99,6 +99,7 @@ if ! command -v pathmunge >/dev/null 2>&1 ; then
     fi
 fi
 
+# Pick a backup at command runtime if EPICS_HOST_ARCH is never set
 _ctrlenv-arch() {
     if [ -z "${EPICS_HOST_ARCH}" ]; then
         local archstr
@@ -115,6 +116,7 @@ _ctrlenv-arch() {
     fi
 }
 
+# Add a ctrlenv bin to your path
 ctrlenv-pathmunge() {
     local target
     local arch
@@ -158,6 +160,7 @@ ctrlenv-pathmunge() {
 }
 
 
+# Activate a ctrlenv environment
 ctrlenv-activate() {
     local target
     local arch

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -137,7 +137,7 @@ ctrlenv-pathmunge() {
         return 0
     fi
     # Check envs second: allow omit ctrlenv- prefix
-    for tg in "$target" "ctrlenv-${target}"; do
+    for tg in "${target}" "ctrlenv-${target}"; do
         if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
             if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
                 pathmunge "${CTRLENV_ENVS}/${tg}/bin/${arch}"
@@ -148,7 +148,9 @@ ctrlenv-pathmunge() {
                 return 0
             else
                 # Error state: let's try to be a little bit helpful
-                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing one of arch or version match or no latest-released" >&2
+                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing arch, version, or latest-released" >&2
+                echo "Available versions are:" >&2
+                ctrlenv-versions "$1" >&2
                 return 1
             fi
         fi
@@ -164,11 +166,13 @@ ctrlenv-pathmunge() {
             return 0
         else
             # Error state: let's try to be a little bit helpful
-            echo "Found matching apps series ${CTRLENV_APPS}/${target} but missing one of arch or version match or no latest-released" >&2
+            echo "Found matching apps series ${CTRLENV_APPS}/${target} but missing arch, version, or latest-released" >&2
+            echo "Available versions are:" >&2
+            ctrlenv-versions "$1" >&2
             return 1
         fi
     fi
-    echo "No matching bundle, env, or app found for ctrlenv-pathmunge $1" >&2
+    echo "No matching path or version found for ctrlenv-pathmunge $1" >&2
     return 1
 }
 
@@ -184,7 +188,7 @@ ctrlenv-activate() {
     fi
     arch="$(_ctrlenv-arch)"
     # For envs allow omit ctrlenv- prefix
-    for tg in "$target" "ctrlenv-${target}"; do
+    for tg in "${target}" "ctrlenv-${target}"; do
         if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
             if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
                 pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/src/${arch}"
@@ -195,12 +199,14 @@ ctrlenv-activate() {
                 return $?
             else
                 # Error state: let's try to be a little bit helpful
-                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing one of arch or version match or no latest-released" >&2
+                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing arch, version, or latest-released" >&2
+                echo "Available versions are:" >&2
+                ctrlenv-versions "$1" >&2
                 return 1
             fi
         fi
     done
-    echo "No matching env found for ctrlenv-activate $1" >&2
+    echo "No matching path or version found for ctrlenv-activate $1" >&2
     return 1
 }
 
@@ -214,17 +220,17 @@ ctrlenv-versions() {
         target="$1"
     fi
     # Check envs first: allow omit ctrlenv- prefix
-    for tg in "$target" "ctrlenv-${target}"; do
+    for tg in "${target}" "ctrlenv-${target}"; do
         if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
-            ls "${CTRLENV_ENVS}/${tg}"
+            ls -1 "${CTRLENV_ENVS}/${tg}"
             return 0
         fi
     done
     # Check apps last
     if [ -d "${CTRLENV_APPS}/${target}" ]; then
-        ls "${CTRLENV_APPS}/${target}"
+        ls -1 "${CTRLENV_APPS}/${target}"
         return 0
     fi
-    echo "No matching env or app found for ctrlenv-versions $1" >&2
+    echo "No matching path or version found for ctrlenv-versions $1" >&2
     return 1
 }

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# Source this script to set shared environment variables and gain access to three shell functions:
+# Source this script to set shared environment variables and gain access to two shell functions:
 # 1. ctrlenv-pathmunge: adds the bin from a bundle, environment, or application to your path at a specific version
-# 2. ctrlenv-activate: puts you into a released pixi environment (pixi shell)
-# 3. ctrlenv-versions: shows you which versions exist for an environment or application
+# 2. ctrlenv-versions: shows you which versions exist for an environment or application
 #
 # Defaults are:
 # - Always the latest release
@@ -35,17 +34,6 @@
 #
 # Put a specific version of an app on your path
 # ctrlenv-pathmunge pytmc/v2.20.0
-#
-# Activate the default environment
-# ctrlenv-activate
-# or
-# ctrlenv-activate base
-#
-# Activate the latest version of a specific environment
-# ctrlenv-activate widgets
-#
-# Activate a specific version of a specific environment
-# ctrlenv-activate lucid/v0.1.2
 #
 # Show which versions exist for an environment or application
 # ctrlenv-versions widgets
@@ -173,40 +161,6 @@ ctrlenv-pathmunge() {
         fi
     fi
     echo "No matching path or version found for ctrlenv-pathmunge $1" >&2
-    return 1
-}
-
-
-# Activate a ctrlenv environment
-ctrlenv-activate() {
-    local target
-    local arch
-    if [ -z "$1" ]; then
-        target=base
-    else
-        target="$1"
-    fi
-    arch="$(_ctrlenv-arch)"
-    # For envs allow omit ctrlenv- prefix
-    for tg in "${target}" "ctrlenv-${target}"; do
-        if [ -d "${CTRLENV_ENVS}/${tg}" ]; then
-            if [ -d "${CTRLENV_ENVS}/${tg}/bin/${arch}" ]; then
-                pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/src/${arch}"
-                return $?
-            elif [ -d "${CTRLENV_ENVS}/${tg}/latest-released/src/${arch}" ]; then
-                # Wasn't a version- pick latest
-                pixi shell --manifest-path "${CTRLENV_ENVS}/${tg}/latest-released/src/${arch}"
-                return $?
-            else
-                # Error state: let's try to be a little bit helpful
-                echo "Found matching env series ${CTRLENV_ENVS}/${tg} but missing arch, version, or latest-released" >&2
-                echo "Available versions are:" >&2
-                ctrlenv-versions "$1" >&2
-                return 1
-            fi
-        fi
-    done
-    echo "No matching path or version found for ctrlenv-activate $1" >&2
     return 1
 }
 

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -7,7 +7,6 @@
 # Defaults are:
 # - Always the latest release
 # - If unspecified, the latest bundle release is assumed
-# - base is the default environment
 #
 # Example usage:
 # First, source this script
@@ -24,7 +23,7 @@
 # ctrlenv-pathmunge 2026/05/26_00
 #
 # Put the default released environment bin on your path:
-# ctrlenv-pathmunge ctrlenv-base
+# ctrlenv-pathmunge ctrlenv-widgets
 #
 # Put a specific released environment bin at a specific version on your path
 # ctrlenv-pathmunge ctrlenv-lucid/v0.1.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This is a script for opting into the new pixi/uv environments.
Sourcing the script sets some shared environment variables and adds the `ctrlenv-pathmunge`, ~`ctrlenv-activate`~ (delayed to a later PR), and `ctrlenv-versions` bash functions to your shell.

To use these environments:
```
source ctrlenv_setup.sh
ctrlenv-pathmunge
```
Would be the most basic invocation. This adds the `latest-released` set of applications to your path. There are also options for adding a specific release or a specific environment version to your path, or adding a specific single application- just specify what you want e.g.
```
ctrlenv-pathmunge pytmc/v2.20.0
```

I expect most people to just the most basic setup and never think about it again, but these options need to be provided.

To check what versions are available, you can use `ctrlenv-versions`:

```
ctrlenv-versions pytmc
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'd like have a way for people to use the production-level deployments of external tools like pixi and uv and internal tools like pytmc without needing to activate pcds_conda/dev_conda, and I'd like it to be usable this week. Long-term I want this to be the way we distribute python environments.

Since `pcds_conda` and `dev_conda` are both in this repo, this repo seems like the right place to include this too.

See https://jira.slac.stanford.edu/browse/ECS-10013 for more.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively- all the commands I've tried have worked as I intended.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added a lengthy docstring to the script here.
I will add an entry to the repo README 
<!--
## Screenshots (if appropriate):
-->
