### PR TITLE
ENH: add ctrlenv activation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,49 @@ Usage:   /reg/g/pcds/engineering_tools/latest/scripts/check_host HOSTNAME<br/>
 usage:   source ctrlenv_setup.sh<br/>
     <br/>
     Set environment variables and add commands for using ctrlenv python tools.</br>
+    There are three subcommands that become available after sourcing:</br>
+    <ul>
+    <li>ctrlenv-pathmunge: adds a bundle, environment export bin, or application to your path.</li>
+    <li>ctrlenv-activate: activates a python environment.</li>
+    <li>ctrlenv-versions: shows which versions exist for an app or environment.</li>
+    </ul>
     </br>
-    Some examples for subcommands:</br>
-    ctrlenv-pathmunge latest-released</br>
-    ctrlenv-pathmunge 2026/05/26_00</br>
-    ctrlenv-pathmunge ctrlenv-widgets/v0.1.1</br>
-    ctrlenv-pathmunge pytmc</br>
-    ctrlenv-activate ctrlenv-lucid</br>
-    ctrlenv-versions pytmc</br>
+    Some definitions:</br>
+    <ul>
+    <li>A bundle is a grouping of tools from many environments</li>
+    <li>
+    An environment is a specific python interpretter with specific libraries installed.
+    In our system, these also include exported executables that are included in bundles.
+    </li>
+    <li>
+    An application is any tool that can be executed from the path.
+    These are also exported to be included in bundles.
+    </li>
+    </ul>
+    </br>
+    Suggested .bashrc setup for general use:</br>
+    <pre><code>source /cds/group/pcds/engineering_tools/latest-released/scripts/ctrlenv_setup.sh</br>ctrlenv-pathmunge</code></pre>
+    Suggested usage inside a script for running an application:</br>
+    <pre><code>source /cds/group/pcds/engineering_tools/pick_version/scripts/ctrlenv_setup.sh</br>ctrlenv-pathmunge app_or_env_name/version</br>some_app some_args</code></pre>
+    Suggested usage inside a script to invoke python:</br>
+    <pre><code>source /cds/group/pcds/engineering_tools/pick_version/scripts/ctrlenv_setup.sh</br>ctrlenv-activate env_name/version</br>python something.py</code></pre>
+    Examples for the subcommands:</br>
+    <ul>
+    <li>ctrlenv-pathmunge</li>
+    <ul><li>Note: with no args, ctrlenv-pathmunge targets the latest bundle</li></ul>
+    <li>ctrlenv-pathmunge latest-released</li>
+    <li>ctrlenv-pathmunge 2026/05/26_00</li>
+    <li>ctrlenv-pathmunge ctrlenv-widgets/v0.1.1</li>
+    <li>ctrlenv-pathmunge pytmc</li>
+    <li>ctrlenv-activate</li>
+    <ul><li>Note: with no args, ctrlenv-activate targets the latest ctrlenv-base</li></ul>
+    <li>ctrlenv-activate ctrlenv-lucid</li>
+    <li>ctrlenv-activate ctrlenv-widgets/v0.2.0</li>
+    <li>ctrlenv-version</li>
+    <ul><li>Note: with no args, ctrlenv-activate targets the ctrlenv-base</li></ul>
+    <li>ctrlenv-versions pytmc</li>
+    <li>ctrlenv-versions ctrlenv-widgets</li>
+    </ul>
     </td>
 </tr>
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ usage:   source ctrlenv_setup.sh<br/>
     ctrlenv-pathmunge 2026/05/26_00</br>
     ctrlenv-pathmunge ctrlenv-widgets/v0.1.1</br>
     ctrlenv-pathmunge pytmc</br>
+    ctrlenv-activate ctrlenv-lucid</br>
     ctrlenv-versions pytmc</br>
     </td>
 </tr>

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -187,10 +187,10 @@ ctrlenv-activate() {
     fi
     did_source=0
     if [ -d "${CTRLENV_ENVS}/${target}" ]; then
-        if [ -d "${CTRLENV_ENVS}/${target}/src/${arch}" ]; then
+        if [ -f "${CTRLENV_ENVS}/${target}/src/${arch}/.pixi/ctrlenv_activate" ]; then
             source "${CTRLENV_ENVS}/${target}/src/${arch}/.pixi/ctrlenv_activate"
             did_source=1
-        elif [ -d "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}" ]; then
+        elif [ -f "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}/.pixi/ctrlenv_activate" ]; then
             source "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}/.pixi/ctrlenv_activate"
             did_source=1
         else

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -121,6 +121,23 @@ _ctrlenv-arch() {
     fi
 }
 
+# Workaround for epics-base installs in pixi env breaking central install
+# We did something similar in pcds_conda, but put it in each env instead of centrally
+# Without this, basic epics utilities break and EPICS_HOST_ARCH is set to
+# standard values like linux-x86_64 instead of SLAC disambiguations like rhel9-x86_64,
+# which interferes with _ctrlenv-arch and other things
+_reset_to_central_epics() {
+    local setup_script
+    setup_script="${SETUP_SITE_TOP:=/cds/group/pcds/setup}"/epicsenv-cur.sh
+    if [ -f "${setup_script}" ]; then
+        source "${setup_script}"
+        return 0
+    else
+        echo "Failed to reactivate central EPICS: cannot find ${setup_script}" >&2
+        return 1
+    fi
+}
+
 # Add a ctrlenv bin to your path
 ctrlenv-pathmunge() {
     local target
@@ -142,7 +159,6 @@ ctrlenv-pathmunge() {
             else
                 # Error state: let's try to be a little bit helpful
                 echo "Found matching area ${target_dir}/${target} but missing ${arch}, version, or latest-released" >&2
-                echo "Available versions are:" >&2
                 ctrlenv-versions "$1" >&2
                 return 1
             fi
@@ -156,28 +172,42 @@ ctrlenv-pathmunge() {
 ctrlenv-activate() {
     local target
     local arch
+    local has_central_epics
+    local did_source
     if [ -z "$1" ]; then
         target=ctrlenv-base
     else
         target="$1"
     fi
     arch="$(_ctrlenv-arch)"
+    if command -v caget >/dev/null 2>&1; then
+        has_central_epics=1
+    else
+        has_central_epics=0
+    fi
+    did_source=0
     if [ -d "${CTRLENV_ENVS}/${target}" ]; then
         if [ -d "${CTRLENV_ENVS}/${target}/src/${arch}" ]; then
             source "${CTRLENV_ENVS}/${target}/src/${arch}/.pixi/ctrlenv_activate"
-            return $?
+            did_source=1
         elif [ -d "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}" ]; then
             source "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}/.pixi/ctrlenv_activate"
-            return $?
+            did_source=1
         else
             # Error state: let's try to be a little bit helpful
-            echo "Found matching env ${CTRLENV_ENVS}/${target} but missing arch, version, or latest-released" >&2
-            echo "Available versions are:" >&2
+            echo "Found matching env ${CTRLENV_ENVS}/${target} but missing ${arch}, version, or latest-released" >&2
             ctrlenv-versions "$1" >&2
             return 1
         fi
     fi
-    echo "No matching path or version found for ctrlenv-activate $target" >&2
+    if [ "${did_source}" -eq 1 ]; then
+        if [ "${has_central_epics}" -eq 1 ]; then
+            _reset_to_central_epics
+            return $?
+        fi
+        return 0
+    fi
+    echo "No matching env found for ctrlenv-activate $target" >&2
     return 1
 }
 
@@ -191,6 +221,7 @@ ctrlenv-versions() {
     fi
     for target_dir in "${CTRLENV_ENVS}" "${CTRLENV_APPS}"; do
         if [ -d "${target_dir}/${target}" ]; then
+            echo "Showing versions for ${target}, deployed at ${target_dir}/${target}" >&2
             ls -1 "${target_dir}/${target}"
             return 0
         fi

--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 #
-# Source this script to set shared environment variables and gain access to two shell functions:
+# Source this script to set shared environment variables and gain access to three shell functions:
 # 1. ctrlenv-pathmunge: adds the bin from a bundle, environment, or application to your path at a specific version
-# 2. ctrlenv-versions: shows you which versions exist for an environment or application
+# 2. ctrlenv-activate: puts you into a released pixi environment (pixi shell-hook)
+# 3. ctrlenv-versions: shows you which versions exist for an environment or application
 #
 # Defaults are:
 # - Always the latest release
 # - If unspecified, the latest bundle release is assumed
+# - ctrlenv-base is the default environment
 #
 # Example usage:
 # First, source this script
@@ -33,6 +35,17 @@
 #
 # Put a specific version of an app on your path
 # ctrlenv-pathmunge pytmc/v2.20.0
+#
+# Activate the default environment
+# ctrlenv-activate
+# or
+# ctrlenv-activate base
+#
+# Activate the latest version of a specific environment
+# ctrlenv-activate widgets
+#
+# Activate a specific version of a specific environment
+# ctrlenv-activate lucid/v0.1.2
 #
 # Show which versions exist for an environment or application
 # ctrlenv-versions ctrlenv-widgets
@@ -136,6 +149,35 @@ ctrlenv-pathmunge() {
         fi
     done
     echo "No matching path or version found for ctrlenv-pathmunge $target" >&2
+    return 1
+}
+
+# Activate a ctrlenv environment
+ctrlenv-activate() {
+    local target
+    local arch
+    if [ -z "$1" ]; then
+        target=ctrlenv-base
+    else
+        target="$1"
+    fi
+    arch="$(_ctrlenv-arch)"
+    if [ -d "${CTRLENV_ENVS}/${target}" ]; then
+        if [ -d "${CTRLENV_ENVS}/${target}/src/${arch}" ]; then
+            source "${CTRLENV_ENVS}/${target}/src/${arch}/.pixi/ctrlenv_activate"
+            return $?
+        elif [ -d "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}" ]; then
+            source "${CTRLENV_ENVS}/${target}/latest-released/src/${arch}/.pixi/ctrlenv_activate"
+            return $?
+        else
+            # Error state: let's try to be a little bit helpful
+            echo "Found matching env ${CTRLENV_ENVS}/${target} but missing arch, version, or latest-released" >&2
+            echo "Available versions are:" >&2
+            ctrlenv-versions "$1" >&2
+            return 1
+        fi
+    fi
+    echo "No matching path or version found for ctrlenv-activate $target" >&2
     return 1
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `ctrlenv-activate` to `ctrlenv_setup.sh` that can be used to activate the new environments in the current shell.

This requires a special activate script to be placed in each environment, which I will do as part of the deployment scripts. The upside of doing it this way is that there aren't any external dependencies for activation, and activation is extremely quick because only environment variables are being set.

Note that, unlike `conda` environments, these cannot be deactivated. You might have some limited success with changing from env to env, but you cannot trivially go back to "before" the activation. If there's some desire for deactivation we can try to re-integrate `pixi shell` for interactive use.

This was previously part of #335 but had some issues:
- Required `pixi` on the path
- Entered a new subshell, preventing its use in scripts
- Didn't work at all

Before merging, I need to:

- [x] Re-run build script on environments released so far to add the activation script
- [x] Release and deploy ctrlenv-base so there's some useful default environment to try this on
- [x] Test thoroughly

I'll ask for reviews after testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
People want to be able to activate environments sometimes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only, in all currently deployed environments:
```
ctrlenv-activate ctrlenv-base
ipython
which python
```
```
ctrlenv-activate ctrlenv-widgets
designer
pydm --help
which python
```
```
ctrlenv-activate ctrlenv-lucid
typhos --help
which python
```
```
ctrlenv-activate ctrlenv-external
uv --help
which gh
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings, readme

<!--
## Screenshots (if appropriate):
-->
