### PR TITLE
CI/AUTO: SHA Pinning and Dependabot

### DIFF
--- a/.github/dependabot_template.yml
+++ b/.github/dependabot_template.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      exclude:
+      - pcdshub/pcds-ci-helpers/*

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       PROJECT_FILES: ${{ steps.changed_files.outputs.PROJECT_FILES }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -48,6 +48,6 @@ jobs:
     needs:
       - get_changed_files
     name: 'pre-commit checks'
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@2e7e5ec8fb8afca5fa0cdb60b82b0f1b99cd2647
     with:
       args: "--files ${{ needs.get_changed_files.outputs.PROJECT_FILES }}"


### PR DESCRIPTION

# SHA Pinning

We are now required to pin GitHub Actions to specific SHAs.
This PR automatically updates all actions to a somewhat recent SHA.
It also configures dependabot to update the SHAs for us on a monthly basis.

If this PR is not merged, all GitHub Actions Workflows in this repository
will stop working at the end of June 2026.

See https://jira.slac.stanford.edu/browse/ECS-10557

## Code Review

For reviewers: our task is to pick one of:

- Merge as-is, then fix the CI if needed
- Fix the CI, and then merge
- Close this PR and archive the repo
- Merge this PR and archive the repo
- Remove the GitHub Actions configuration from the repo,
  then close this PR.
- Ignore this PR until we use the repo again
