### PR TITLE
FIX: ctrlenv PYDM_DISPLAYS_PATH

### DIFF
--- a/scripts/ctrlenv_setup.sh
+++ b/scripts/ctrlenv_setup.sh
@@ -62,6 +62,7 @@ CTRLENV_BUNDLE_TOP="${CTRLENV_BUNDLE_TOP:-"${PYPS_SITE_TOP}"/bundles}"
 CTRLENV_ENVS="${PYPS_SITE_TOP}"/pixi
 CTRLENV_APPS="${PYPS_SITE_TOP}"/apps
 EPICS_SETUP=/cds/group/pcds/setup
+EPICS_PROD=/cds/group/pcds/epics
 EPICS_DEV=/cds/group/pcds/epics-dev
 
 # Pixi settings depending on whether you have a local mount to use
@@ -86,6 +87,7 @@ export PYDM_DESIGNER_ONLINE=1
 # TODO: remove hard-coded default stylesheet once pcdswidgets vacuum widgets no longer need it
 export PYDM_STYLESHEET="${EPICS_DEV}"/screens/pydm/vacuumscreens/styleSheet/masterStyleSheet.qss
 export PYDM_STYLESHEET_INCLUDE_DEFAULT=1
+export PYDM_DISPLAYS_PATH="${EPICS_PROD}"/screens/pydm:"${EPICS_DEV}"/screens/pydm
 
 # Default settings for our apps
 export HAPPI_CFG="${CTRLENV_APPS}/hutch-python/device_config/happi.cfg"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Set up the previously forgotten `PYDM_DISPLAYS_PATH` in `ctrlenv_setup.sh`
This will point first to our released screens area, and then second to the dev screens area.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We had some screens previously that relied on this environment variable being set in order to locate some displays to embed in the screen.

One example is the KFE vacuum screen: https://github.com/pcdshub/lcls-pydm-vacuum/blob/62ca8dfbe53e60467e46121ba589ff8ab3116a2a/screens/sxrVac.ui#L1168

For context, here's how it was set up previously for `dev_conda` and `pcds_conda`:
https://github.com/pcdshub/engineering_tools/blob/184a6faae8125a542fa5d411969c415c6006620b/scripts/shared_conda_setup.sh#L116

Compared to before, I have:
- Removed all dedicated dev typhos directories, because I don't want to deploy typhos screens like that any more
- Add in the prod/released ui directory, because I want people to be able to do e.g. `common/v1.0.0/screen_name.ui` as a versioned embedded display. (It also seemed strange to me that _only_ the dev directory had path support here).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made sure the KFE vacuum screen opened correctly with this environment variable set. (Previously, it opened up with errors)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
